### PR TITLE
Update docs path

### DIFF
--- a/ethers/src/lib.rs
+++ b/ethers/src/lib.rs
@@ -247,7 +247,8 @@ pub mod signers {
 /// # ABI Encoding and Decoding
 ///
 /// This crate re-exports the [`ethabi`](http://docs.rs/ethabi) crate's functions
-/// under the `abi` module, as well as the [`secp256k1`](https://docs.rs/libsecp256k1) and [`rand`](https://docs.rs/rand) crates for convenience.
+/// under the `abi` module, as well as the [`secp256k1`](https://docs.rs/libsecp256k1)
+/// and [`rand`](https://docs.rs/rand) crates for convenience.
 pub mod core {
     pub use ethers_core::*;
 }


### PR DESCRIPTION
When I ran `cargo doc --open` I would get this error:

```
 Documenting ethers v0.1.0 (/home/sebas/repos/eth2.0/ethers-rs/ethers)
error: `[secp256k1]` cannot be resolved, ignoring it.
       --> ethers/src/lib.rs:250:58
       |
250 | /// under the `abi` module, as well as the [`secp256k1`](secp256k1) and [`rand`](rand)
       |                                                                                          ^^^^^^^^^ cannot be resolved, ignoring
       |
...
error: `[rand]` cannot be resolved, ignoring it.
      --> ethers/src/lib.rs:250:82
       |
250 | /// under the `abi` module, as well as the [`secp256k1`](secp256k1) and [`rand`](rand)
       |                                                                                                                                ^^^^ cannot be resolved, ignoring
       |
      = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`

error: aborting due to 2 previous errors

error: Could not document `ethers`.
```

This PR changes the docs url paths for both `secp256k1` and `rand`. It is using the docs.rs docs but notice that the version of `rand` is not matching with `Cargo.toml`. `0.7.3` in the docs.rs url vs `0.7.2` used in Cargo).  I used the docs.rs url so that it is consistent with the `ethabi` link in the same comment location.