### PR TITLE
add json rpc bindings for eth_getCode

### DIFF
--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -409,7 +409,27 @@ impl<P: JsonRpcClient> Provider<P> {
             .map_err(Into::into)?)
     }
 
-    // TODO: get_code, get_storage_at
+    // TODO: get_storage_at
+
+    /// Returns the deployed code at a given address
+    pub async fn get_code(
+        &self,
+        at: impl Into<NameOrAddress>,
+        block: Option<BlockNumber>,
+    ) -> Result<Bytes, ProviderError> {
+        let at = match at.into() {
+            NameOrAddress::Name(ens_name) => self.resolve_name(&ens_name).await?,
+            NameOrAddress::Address(addr) => addr,
+        };
+
+        let at = utils::serialize(&at);
+        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest));
+        Ok(self
+            .0
+            .request("eth_getCode", [at, block])
+            .await
+            .map_err(Into::into)?)
+    }
 
     ////// Ethereum Naming Service
     // The Ethereum Naming Service (ENS) allows easy to remember and use names to

--- a/ethers/src/lib.rs
+++ b/ethers/src/lib.rs
@@ -132,6 +132,9 @@ pub mod contract {
 ///
 /// let block = provider.get_block(100u64).await?;
 /// println!("Got block: {}", serde_json::to_string(&block)?);
+///
+/// let code = provider.get_code("0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359", None).await?;
+/// println!("Got code: {}", serde_json::to_string(&code)?);
 /// # Ok(())
 /// # }
 /// ```


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Hello @gakonst. I have just started browsing through this repository, trying to understand the implementation structure.

While doing this and getting my local machine setup, I found a `TODO` in the provider's JSON RPC bindings, and it was a quick way to get up and running.

I am exploring the issues you've added, and hopefully I can take up some of them.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The addition is quite similar to `get_balance` or `get_transaction_count`. I am not sure if the lines I added in `ethers/src/lib.rs` add any value, because the existing docs for `get_block` already solve that purpose.
