### PR TITLE
Provider Fixes on filters and gas estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 **Complete Ethereum and Celo wallet implementation and utilities in Rust**
 
-[![CircleCI](https://circleci.com/gh/circleci/circleci-docs.svg?style=svg)](https://circleci.com/gh/circleci/circleci-docs)
+![Github Actions](https://github.com/gakonst/ethers-rs/workflows/Tests/badge.svg)
 
 ## Documentation
 
-Extensive documentation and examples are available [here](docs.rs/ethers).
+Extensive documentation and examples are available [here](https://docs.rs/ethers).
 
 Alternatively, you may clone the repository and run `cd ethers/ && cargo doc --open`
 
@@ -55,7 +55,7 @@ in the transactions which are fetched over JSON-RPC.
 
 ## Getting Help
 
-First, see if the answer to your question can be found in the [API documentation](docs.rs/ethers). If the answer
+First, see if the answer to your question can be found in the [API documentation](https://docs.rs/ethers). If the answer
 is not there, try opening an [issue](https://github.com/gakonst/ethers-rs/issues/new) with the question.
 
 ## Contributing

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -254,18 +254,12 @@ impl<P: JsonRpcClient> Provider<P> {
     pub async fn estimate_gas(
         &self,
         tx: &TransactionRequest,
-        block: Option<BlockNumber>,
     ) -> Result<U256, ProviderError> {
         let tx = utils::serialize(tx);
 
-        let args = match block {
-            Some(block) => vec![tx, utils::serialize(&block)],
-            None => vec![tx],
-        };
-
         Ok(self
             .0
-            .request("eth_estimateGas", args)
+            .request("eth_estimateGas", [tx])
             .await
             .map_err(Into::into)?)
     }

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -251,10 +251,7 @@ impl<P: JsonRpcClient> Provider<P> {
     /// Sends a transaction to a single Ethereum node and return the estimated amount of gas required (as a U256) to send it
     /// This is free, but only an estimate. Providing too little gas will result in a transaction being rejected
     /// (while still consuming all provided gas).
-    pub async fn estimate_gas(
-        &self,
-        tx: &TransactionRequest,
-    ) -> Result<U256, ProviderError> {
+    pub async fn estimate_gas(&self, tx: &TransactionRequest) -> Result<U256, ProviderError> {
         let tx = utils::serialize(tx);
 
         Ok(self
@@ -359,14 +356,12 @@ impl<P: JsonRpcClient> Provider<P> {
     /// To check if the state has changed, call `get_filter_changes` with the filter id.
     pub async fn new_filter(&self, filter: FilterKind<'_>) -> Result<U256, ProviderError> {
         let (method, args) = match filter {
-            FilterKind::NewBlocks => ("eth_newBlockFilter", utils::serialize(&())),
-            FilterKind::PendingTransactions => {
-                ("eth_newPendingTransactionFilter", utils::serialize(&()))
-            }
-            FilterKind::Logs(filter) => ("eth_newFilter", utils::serialize(&filter)),
+            FilterKind::NewBlocks => ("eth_newBlockFilter", vec![]),
+            FilterKind::PendingTransactions => ("eth_newPendingTransactionFilter", vec![]),
+            FilterKind::Logs(filter) => ("eth_newFilter", vec![utils::serialize(&filter)]),
         };
 
-        Ok(self.0.request(method, [args]).await.map_err(Into::into)?)
+        Ok(self.0.request(method, args).await.map_err(Into::into)?)
     }
 
     /// Uninstalls a filter

--- a/ethers-signers/src/client.rs
+++ b/ethers-signers/src/client.rs
@@ -151,7 +151,7 @@ where
         // will poll and await the futures concurrently
         let (gas_price, gas, nonce) = join!(
             maybe(tx.gas_price, self.provider.get_gas_price()),
-            maybe(tx.gas, self.provider.estimate_gas(&tx, block)),
+            maybe(tx.gas, self.provider.estimate_gas(&tx)),
             maybe(
                 tx.nonce,
                 self.provider.get_transaction_count(self.address(), block)

--- a/ethers-signers/tests/signer.rs
+++ b/ethers-signers/tests/signer.rs
@@ -8,7 +8,7 @@ use std::convert::TryFrom;
 #[cfg(not(feature = "celo"))]
 mod eth_tests {
     use super::*;
-    use ethers::utils::{parse_ether, Ganache};
+    use ethers::{types::BlockNumber, utils::{parse_ether, Ganache}};
 
     #[tokio::test]
     async fn pending_txs_with_confirmations_rinkeby_infura() {
@@ -25,9 +25,8 @@ mod eth_tests {
             .connect(provider);
 
         let tx = TransactionRequest::pay(client.address(), parse_ether(1u64).unwrap());
-        let pending_tx = client.send_transaction(tx, None).await.unwrap();
+        let pending_tx = client.send_transaction(tx, Some(BlockNumber::Pending)).await.unwrap();
         let hash = *pending_tx;
-        dbg!(hash);
         let receipt = pending_tx.confirmations(3).await.unwrap();
 
         // got the correct receipt


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes 2 bugs:
1. Previously we'd allow passing a block parameter in `estimate_gas`, which is wrong. The JSON-RPC spec is very misleading here because in the parameters docs it says "look above. The calls which support the default block param are only noted [here](https://eth.wiki/json-rpc/API#the-default-block-parameter)

1. Previously we'd pass additional arguments when watching events (serialization of `()`), which is obviously wrong
 
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

1. Remove the block parameter
2. Serialize only 1 param