### PR TITLE
Dual license under MIT/Apache 2

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,203 @@
+Copyright (c) 2020 Georgios Konstantopoulos
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2020 Georgios Konstantopoulos
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE O THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.R

--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "ethers-contract"
+license = "MIT OR Apache-2.0"
 version = "0.1.0"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "ethers-core"
+license = "MIT OR Apache-2.0"
 version = "0.1.0"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "ethers-providers"
+license = "MIT OR Apache-2.0"
 version = "0.1.0"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"

--- a/ethers-providers/src/ws.rs
+++ b/ethers-providers/src/ws.rs
@@ -1,0 +1,204 @@
+use crate::{provider::ProviderError, JsonRpcClient};
+
+use async_trait::async_trait;
+use reqwest::{Client, Error as ReqwestError};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::{
+    fmt,
+    str::FromStr,
+    sync::atomic::{AtomicU64, Ordering},
+};
+use thiserror::Error;
+use url::Url;
+
+/// A low-level JSON-RPC Client over HTTP.
+///
+/// # Example
+///
+/// ```no_run
+/// use ethers::{types::U64, providers::{JsonRpcClient, Http}};
+/// use std::str::FromStr;
+///
+/// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
+/// let provider = Http::from_str("http://localhost:8545")?;
+/// let block_number: U64 = provider.request("eth_blockNumber", None::<()>).await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct Provider {
+    id: AtomicU64,
+    client: Client,
+    url: Url,
+}
+
+#[derive(Error, Debug)]
+/// Error thrown when sending an HTTP request
+pub enum WsError {
+    /// Thrown if the request failed
+    #[error(transparent)]
+    ReqwestError(#[from] ReqwestError),
+    #[error(transparent)]
+    /// Thrown if the response could not be parsed
+    JsonRpcError(#[from] errors::JsonRpcError),
+}
+
+impl From<ClientError> for ProviderError {
+    fn from(src: ClientError) -> Self {
+        ProviderError::JsonRpcClientError(Box::new(src))
+    }
+}
+
+#[async_trait]
+impl JsonRpcClient for Provider {
+    type Error = ClientError;
+
+    /// Sends a POST request with the provided method and the params serialized as JSON
+    /// over HTTP
+    async fn request<T: Serialize + Send + Sync, R: for<'a> Deserialize<'a>>(
+        &self,
+        method: &str,
+        params: T,
+    ) -> Result<R, ClientError> {
+        let next_id = self.id.load(Ordering::SeqCst) + 1;
+        self.id.store(next_id, Ordering::SeqCst);
+
+        let payload = Request::new(next_id, method, params);
+
+        let res = self
+            .client
+            .post(self.url.as_ref())
+            .json(&payload)
+            .send()
+            .await?;
+        let res = res.json::<Response<R>>().await?;
+
+        Ok(res.data.into_result()?)
+    }
+}
+
+impl Provider {
+    /// Initializes a new HTTP Client
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ethers::providers::Http;
+    /// use url::Url;
+    ///
+    /// let url = Url::parse("http://localhost:8545").unwrap();
+    /// let provider = Http::new(url);
+    /// ```
+    pub fn new(url: impl Into<Url>) -> Self {
+        Self {
+            id: AtomicU64::new(0),
+            client: Client::new(),
+            url: url.into(),
+        }
+    }
+}
+
+impl FromStr for Provider {
+    type Err = url::ParseError;
+
+    fn from_str(src: &str) -> Result<Self, Self::Err> {
+        let url = Url::parse(src)?;
+        Ok(Provider::new(url))
+    }
+}
+
+impl Clone for Provider {
+    fn clone(&self) -> Self {
+        Self {
+            id: AtomicU64::new(0),
+            client: self.client.clone(),
+            url: self.url.clone(),
+        }
+    }
+}
+
+// leak private type w/o exposing it
+mod errors {
+    use super::*;
+
+    #[derive(Serialize, Deserialize, Debug, Clone, Error)]
+    /// A JSON-RPC 2.0 error
+    pub struct JsonRpcError {
+        /// The error code
+        pub code: i64,
+        /// The error message
+        pub message: String,
+        /// Additional data
+        pub data: Option<Value>,
+    }
+
+    impl fmt::Display for JsonRpcError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                f,
+                "(code: {}, message: {}, data: {:?})",
+                self.code, self.message, self.data
+            )
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+/// A JSON-RPC request
+struct Request<'a, T> {
+    id: u64,
+    jsonrpc: &'a str,
+    method: &'a str,
+    params: T,
+}
+
+impl<'a, T> Request<'a, T> {
+    /// Creates a new JSON RPC request
+    fn new(id: u64, method: &'a str, params: T) -> Self {
+        Self {
+            id,
+            jsonrpc: "2.0",
+            method,
+            params,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Response<T> {
+    id: u64,
+    jsonrpc: String,
+    #[serde(flatten)]
+    data: ResponseData<T>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+enum ResponseData<R> {
+    Error { error: errors::JsonRpcError },
+    Success { result: R },
+}
+
+impl<R> ResponseData<R> {
+    /// Consume response and return value
+    fn into_result(self) -> Result<R, errors::JsonRpcError> {
+        match self {
+            ResponseData::Success { result } => Ok(result),
+            ResponseData::Error { error } => Err(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response() {
+        let response: Response<u64> =
+            serde_json::from_str(r#"{"jsonrpc": "2.0", "result": 19, "id": 1}"#).unwrap();
+        assert_eq!(response.id, 1);
+        assert_eq!(response.data.into_result().unwrap(), 19);
+    }
+}

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "ethers-signers"
+license = "MIT OR Apache-2.0"
 version = "0.1.0"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"

--- a/ethers/Cargo.toml
+++ b/ethers/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ethers"
 version = "0.1.0"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
+license = "MIT OR Apache-2.0"
 edition = "2018"
 readme = "README.md"
 documentation = "https://docs.rs/ethers"


### PR DESCRIPTION
Adds an MIT/Apache 2 dual license since that's most adoption friendly and is generally in the spirit of most Rust repositories - h/t @zmanian 

Fixes #26 
Supersedes https://github.com/gakonst/ethers-rs/pull/27