### PR TITLE
Add polling interval to pending transactions

### DIFF
--- a/ethers-providers/src/stream.rs
+++ b/ethers-providers/src/stream.rs
@@ -16,11 +16,11 @@ use std::{
 };
 
 // https://github.com/tomusdrw/rust-web3/blob/befcb2fb8f3ca0a43e3081f68886fa327e64c8e6/src/api/eth_filter.rs#L20
-fn interval(duration: Duration) -> impl Stream<Item = ()> + Send + Unpin {
+pub fn interval(duration: Duration) -> impl Stream<Item = ()> + Send + Unpin {
     stream::unfold((), move |_| Delay::new(duration).map(|_| Some(((), ())))).map(drop)
 }
 
-const DEFAULT_POLL_DURATION: Duration = Duration::from_millis(7000);
+pub const DEFAULT_POLL_DURATION: Duration = Duration::from_millis(7000);
 
 /// Trait for streaming filters.
 pub trait FilterStream<R>: StreamExt + Stream<Item = R>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Previously, the `PendingTransaction` struct would spam the chain with calls to get the transaction receipt and the block number, as instructed by the runtime. Similarly to how Filter streams are implemented, the async runtime should not poll more frequently than the block time.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

We add an `interval` parameter which makes the future sleep until the interval has passed.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
