### PR TITLE
feat(contract): add helper to query events w/ metadata (block num + tx hash)

### DIFF
--- a/ethers-contract/src/factory.rs
+++ b/ethers-contract/src/factory.rs
@@ -2,7 +2,7 @@ use crate::{Contract, ContractError};
 
 use ethers_core::{
     abi::{Abi, Tokenize},
-    types::{Bytes, TransactionRequest},
+    types::{BlockNumber, Bytes, TransactionRequest},
 };
 use ethers_providers::JsonRpcClient;
 use ethers_signers::{Client, Signer};
@@ -15,6 +15,7 @@ pub struct Deployer<'a, P, S> {
     abi: Abi,
     client: &'a Client<P, S>,
     confs: usize,
+    block: BlockNumber,
 }
 
 impl<'a, P, S> Deployer<'a, P, S>
@@ -28,11 +29,19 @@ where
         self
     }
 
+    pub fn block<T: Into<BlockNumber>>(mut self, block: T) -> Self {
+        self.block = block.into();
+        self
+    }
+
     /// Broadcasts the contract deployment transaction and after waiting for it to
     /// be sufficiently confirmed (default: 1), it returns a [`Contract`](crate::Contract)
     /// struct at the deployed contract's address.
     pub async fn send(self) -> Result<Contract<'a, P, S>, ContractError> {
-        let pending_tx = self.client.send_transaction(self.tx, None).await?;
+        let pending_tx = self
+            .client
+            .send_transaction(self.tx, Some(self.block))
+            .await?;
 
         let receipt = pending_tx.confirmations(self.confs).await?;
 
@@ -158,6 +167,7 @@ where
             abi: self.abi,
             tx,
             confs: 1,
+            block: BlockNumber::Latest,
         })
     }
 }

--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -140,6 +140,7 @@ mod celo_tests {
     use super::*;
     use ethers::{
         providers::{Http, Provider},
+        types::BlockNumber,
         signers::Wallet,
     };
     use std::convert::TryFrom;
@@ -160,7 +161,7 @@ mod celo_tests {
 
         let factory = ContractFactory::new(abi, bytecode, &client);
         let deployer = factory.deploy("initial value".to_string()).unwrap();
-        let contract = deployer.send().await.unwrap();
+        let contract = deployer.block(BlockNumber::Pending).send().await.unwrap();
 
         let value: String = contract
             .method("getValue", ())

--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -140,8 +140,8 @@ mod celo_tests {
     use super::*;
     use ethers::{
         providers::{Http, Provider},
-        types::BlockNumber,
         signers::Wallet,
+        types::BlockNumber,
     };
     use std::convert::TryFrom;
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Oftentimes, clients will want to get the logs but also check their block number / transaction hash to index them in some way. This information was not exposed before.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add a `query_with_meta` function which returns a `Vec<(D, LogMeta)>` instead of just `Vec<D>`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
