### PR TITLE
feat(signers): make Signer on Client optional

### DIFF
--- a/ethers-contract/src/factory.rs
+++ b/ethers-contract/src/factory.rs
@@ -148,6 +148,7 @@ where
 
         // create the tx object. Since we're deploying a contract, `to` is `None`
         let tx = TransactionRequest {
+            from: Some(self.client.address()),
             to: None,
             data: Some(data),
             ..Default::default()

--- a/ethers-signers/src/wallet.rs
+++ b/ethers-signers/src/wallet.rs
@@ -119,7 +119,7 @@ impl Wallet {
         let address = self.address();
         Client {
             address,
-            signer: self,
+            signer: Some(self),
             provider,
         }
     }


### PR DESCRIPTION
This allows using Contract either in read-only mode (e.g. for fetching data/events) or for using the accounts on the node as senders
