### PR TITLE
Replace contract client references with Arc

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -44,7 +44,7 @@ impl Context {
         let abi_name = super::util::safe_ident(&format!("{}_ABI", name.to_string().to_uppercase()));
 
         // 0. Imports
-        let imports = common::imports();
+        let imports = common::imports(&name.to_string());
 
         // 1. Declare Contract struct
         let struct_decl = common::struct_declaration(&cx, &abi_name);
@@ -67,12 +67,12 @@ impl Context {
 
                 #struct_decl
 
-                impl<'a, P: JsonRpcClient, S: Signer> #name<'a, P, S> {
+                impl<'a, P: JsonRpcClient, S: Signer> #name<P, S> {
                     /// Creates a new contract instance with the specified `ethers`
                     /// client at the given `Address`. The contract derefs to a `ethers::Contract`
                     /// object
-                    pub fn new<T: Into<Address>>(address: T, client: &'a Client<P, S>) -> Self {
-                        let contract = Contract::new(address.into(), #abi_name.clone(), client);
+                    pub fn new<T: Into<Address>, C: Into<Arc<Client<P, S>>>>(address: T, client: C) -> Self {
+                        let contract = Contract::new(address.into(), #abi_name.clone(), client.into());
                         Self(contract)
                     }
 

--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -45,9 +45,9 @@ fn expand_function(function: &Function, alias: Option<Ident>) -> Result<TokenStr
         StateMutability::Nonpayable | StateMutability::Payable
     );
     let result = if !is_mutable {
-        quote! { ContractCall<'a, P, S, #outputs> }
+        quote! { ContractCall<P, S, #outputs> }
     } else {
-        quote! { ContractCall<'a, P, S, H256> }
+        quote! { ContractCall<P, S, H256> }
     };
 
     let arg = expand_inputs_call_arg(&function.inputs);

--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -1,8 +1,8 @@
 use ethers_core::{
     abi::{Detokenize, Error as AbiError, Function, InvalidOutputType},
-    types::{Address, BlockNumber, TransactionRequest, U256},
+    types::{Address, BlockNumber, TransactionRequest, TxHash, U256},
 };
-use ethers_providers::{JsonRpcClient, PendingTransaction, ProviderError};
+use ethers_providers::{JsonRpcClient, ProviderError};
 use ethers_signers::{Client, ClientError, Signer};
 
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
@@ -111,12 +111,7 @@ where
     }
 
     /// Signs and broadcasts the provided transaction
-    pub async fn send(&self) -> Result<PendingTransaction<'_, P>, ContractError> {
-        // TODO: Can we avoid the tx clone? Copying large bytes of data is not really
-        // good for performance.
-        Ok(self
-            .client
-            .send_transaction(self.tx.clone(), self.block)
-            .await?)
+    pub async fn send(self) -> Result<TxHash, ContractError> {
+        Ok(self.client.send_transaction(self.tx, self.block).await?)
     }
 }

--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -5,7 +5,7 @@ use ethers_core::{
 use ethers_providers::{JsonRpcClient, PendingTransaction, ProviderError};
 use ethers_signers::{Client, ClientError, Signer};
 
-use std::{fmt::Debug, marker::PhantomData};
+use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
 use thiserror::Error as ThisError;
 
@@ -42,18 +42,18 @@ pub enum ContractError {
 #[derive(Debug, Clone)]
 #[must_use = "contract calls do nothing unless you `send` or `call` them"]
 /// Helper for managing a transaction before submitting it to a node
-pub struct ContractCall<'a, P, S, D> {
+pub struct ContractCall<P, S, D> {
     /// The raw transaction object
     pub tx: TransactionRequest,
     /// The ABI of the function being called
     pub function: Function,
     /// Optional block number to be used when calculating the transaction's gas and nonce
     pub block: Option<BlockNumber>,
-    pub(crate) client: &'a Client<P, S>,
+    pub(crate) client: Arc<Client<P, S>>,
     pub(crate) datatype: PhantomData<D>,
 }
 
-impl<'a, P, S, D: Detokenize> ContractCall<'a, P, S, D> {
+impl<P, S, D: Detokenize> ContractCall<P, S, D> {
     /// Sets the `from` field in the transaction to the provided value
     pub fn from<T: Into<Address>>(mut self, from: T) -> Self {
         self.tx.from = Some(from.into());
@@ -85,7 +85,7 @@ impl<'a, P, S, D: Detokenize> ContractCall<'a, P, S, D> {
     }
 }
 
-impl<'a, P, S, D> ContractCall<'a, P, S, D>
+impl<P, S, D> ContractCall<P, S, D>
 where
     S: Signer,
     P: JsonRpcClient,
@@ -111,7 +111,12 @@ where
     }
 
     /// Signs and broadcasts the provided transaction
-    pub async fn send(self) -> Result<PendingTransaction<'a, P>, ContractError> {
-        Ok(self.client.send_transaction(self.tx, self.block).await?)
+    pub async fn send(&self) -> Result<PendingTransaction<'_, P>, ContractError> {
+        // TODO: Can we avoid the tx clone? Copying large bytes of data is not really
+        // good for performance.
+        Ok(self
+            .client
+            .send_transaction(self.tx.clone(), self.block)
+            .await?)
     }
 }

--- a/ethers-contract/src/factory.rs
+++ b/ethers-contract/src/factory.rs
@@ -7,18 +7,21 @@ use ethers_core::{
 use ethers_providers::JsonRpcClient;
 use ethers_signers::{Client, Signer};
 
+use std::{sync::Arc, time::Duration};
+
 #[derive(Debug, Clone)]
 /// Helper which manages the deployment transaction of a smart contract
-pub struct Deployer<'a, P, S> {
+pub struct Deployer<P, S> {
     /// The deployer's transaction, exposed for overriding the defaults
     pub tx: TransactionRequest,
     abi: Abi,
-    client: &'a Client<P, S>,
+    client: Arc<Client<P, S>>,
     confs: usize,
     block: BlockNumber,
+    interval: Duration,
 }
 
-impl<'a, P, S> Deployer<'a, P, S>
+impl<P, S> Deployer<P, S>
 where
     S: Signer,
     P: JsonRpcClient,
@@ -26,6 +29,12 @@ where
     /// Sets the number of confirmations to wait for the contract deployment transaction
     pub fn confirmations<T: Into<usize>>(mut self, confirmations: T) -> Self {
         self.confs = confirmations.into();
+        self
+    }
+
+    /// Sets the poll interval for the pending deployment transaction's inclusion
+    pub fn interval<T: Into<Duration>>(mut self, interval: T) -> Self {
+        self.interval = interval.into();
         self
     }
 
@@ -37,13 +46,15 @@ where
     /// Broadcasts the contract deployment transaction and after waiting for it to
     /// be sufficiently confirmed (default: 1), it returns a [`Contract`](crate::Contract)
     /// struct at the deployed contract's address.
-    pub async fn send(self) -> Result<Contract<'a, P, S>, ContractError> {
+    pub async fn send(self) -> Result<Contract<P, S>, ContractError> {
         let pending_tx = self
             .client
             .send_transaction(self.tx, Some(self.block))
             .await?;
-
-        let receipt = pending_tx.confirmations(self.confs).await?;
+        let receipt = pending_tx
+            .interval(self.interval)
+            .confirmations(self.confs)
+            .await?;
 
         let address = receipt
             .contract_address
@@ -97,7 +108,7 @@ where
 ///     .parse::<Wallet>()?.connect(provider);
 ///
 /// // create a factory which will be used to deploy instances of the contract
-/// let factory = ContractFactory::new(contract.abi.clone(), contract.bytecode.clone(), &client);
+/// let factory = ContractFactory::new(contract.abi.clone(), contract.bytecode.clone(), client);
 ///
 /// // The deployer created by the `deploy` call exposes a builder which gets consumed
 /// // by the async `send` call
@@ -109,13 +120,13 @@ where
 /// println!("{}", contract.address());
 /// # Ok(())
 /// # }
-pub struct ContractFactory<'a, P, S> {
-    client: &'a Client<P, S>,
+pub struct ContractFactory<P, S> {
+    client: Arc<Client<P, S>>,
     abi: Abi,
     bytecode: Bytes,
 }
 
-impl<'a, P, S> ContractFactory<'a, P, S>
+impl<P, S> ContractFactory<P, S>
 where
     S: Signer,
     P: JsonRpcClient,
@@ -123,9 +134,9 @@ where
     /// Creates a factory for deployment of the Contract with bytecode, and the
     /// constructor defined in the abi. The client will be used to send any deployment
     /// transaction.
-    pub fn new(abi: Abi, bytecode: Bytes, client: &'a Client<P, S>) -> Self {
+    pub fn new(abi: Abi, bytecode: Bytes, client: impl Into<Arc<Client<P, S>>>) -> Self {
         Self {
-            client,
+            client: client.into(),
             abi,
             bytecode,
         }
@@ -139,10 +150,7 @@ where
     /// 1. If there are no constructor arguments, you should pass `()` as the argument.
     /// 1. The default poll duration is 7 seconds.
     /// 1. The default number of confirmations is 1 block.
-    pub fn deploy<T: Tokenize>(
-        self,
-        constructor_args: T,
-    ) -> Result<Deployer<'a, P, S>, ContractError> {
+    pub fn deploy<T: Tokenize>(self, constructor_args: T) -> Result<Deployer<P, S>, ContractError> {
         // Encode the constructor args & concatenate with the bytecode if necessary
         let params = constructor_args.into_tokens();
         let data: Bytes = match (self.abi.constructor(), params.is_empty()) {
@@ -164,11 +172,12 @@ where
         };
 
         Ok(Deployer {
-            client: self.client,
+            client: self.client.clone(), // cheap clone behind the arc
             abi: self.abi,
             tx,
             confs: 1,
             block: BlockNumber::Latest,
+            interval: self.client.get_interval(),
         })
     }
 }

--- a/ethers-contract/src/factory.rs
+++ b/ethers-contract/src/factory.rs
@@ -47,11 +47,13 @@ where
     /// be sufficiently confirmed (default: 1), it returns a [`Contract`](crate::Contract)
     /// struct at the deployed contract's address.
     pub async fn send(self) -> Result<Contract<P, S>, ContractError> {
-        let pending_tx = self
+        let tx_hash = self
             .client
             .send_transaction(self.tx, Some(self.block))
             .await?;
-        let receipt = pending_tx
+        let receipt = self
+            .client
+            .pending_transaction(tx_hash)
             .interval(self.interval)
             .confirmations(self.confs)
             .await?;
@@ -172,7 +174,7 @@ where
         };
 
         Ok(Deployer {
-            client: self.client.clone(), // cheap clone behind the arc
+            client: Arc::clone(&self.client), // cheap clone behind the arc
             abi: self.abi,
             tx,
             confs: 1,

--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -13,7 +13,7 @@ mod eth_tests {
         utils::Ganache,
     };
     use serial_test::serial;
-    use std::convert::TryFrom;
+    use std::{convert::TryFrom, sync::Arc, time::Duration};
 
     #[tokio::test]
     #[serial]
@@ -31,7 +31,7 @@ mod eth_tests {
         let client2 = connect("cc96601bc52293b53c4736a12af9130abf347669b3813f9ec4cafdf6991b087e");
 
         // create a factory which will be used to deploy instances of the contract
-        let factory = ContractFactory::new(abi, bytecode, &client);
+        let factory = ContractFactory::new(abi, bytecode, client.clone());
 
         // `send` consumes the deployer so it must be cloned for later re-use
         // (practically it's not expected that you'll need to deploy multiple instances of
@@ -46,20 +46,20 @@ mod eth_tests {
         let value = get_value.clone().call().await.unwrap();
         assert_eq!(value, "initial value");
 
-        // make a call with `client2`
-        let _tx_hash = contract
-            .connect(&client2)
+        // need to declare the method first, and only then send it
+        // this is because it internally clones an Arc which would otherwise
+        // get immediately dropped
+        let method = contract
+            .connect(client2.clone())
             .method::<_, H256>("setValue", "hi".to_owned())
-            .unwrap()
-            .send()
-            .await
             .unwrap();
+        let _tx_hash = method.send().await.unwrap();
         assert_eq!(last_sender.clone().call().await.unwrap(), client2.address());
         assert_eq!(get_value.clone().call().await.unwrap(), "hi");
 
         // we can also call contract methods at other addresses with the `at` call
         // (useful when interacting with multiple ERC20s for example)
-        let contract2_addr = deployer.clone().send().await.unwrap().address();
+        let contract2_addr = deployer.send().await.unwrap().address();
         let contract2 = contract.at(contract2_addr);
         let init_value: String = contract2
             .method::<_, String>("getValue", ())
@@ -82,15 +82,13 @@ mod eth_tests {
     async fn get_past_events() {
         let (abi, bytecode) = compile();
         let client = connect("380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc");
-        let (_ganache, contract) = deploy(&client, abi, bytecode).await;
+        let (_ganache, contract) = deploy(client.clone(), abi, bytecode).await;
 
         // make a call with `client2`
-        let _tx_hash = contract
+        let method = contract
             .method::<_, H256>("setValue", "hi".to_owned())
-            .unwrap()
-            .send()
-            .await
             .unwrap();
+        let _tx_hash = method.send().await.unwrap();
 
         // and we can fetch the events
         let logs: Vec<ValueChanged> = contract
@@ -111,7 +109,7 @@ mod eth_tests {
     async fn watch_events() {
         let (abi, bytecode) = compile();
         let client = connect("380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc");
-        let (_ganache, contract) = deploy(&client, abi, bytecode).await;
+        let (_ganache, contract) = deploy(client, abi, bytecode).await;
 
         // We spawn the event listener:
         let mut stream = contract
@@ -125,12 +123,10 @@ mod eth_tests {
 
         // and we make a few calls
         for i in 0..num_calls {
-            let _tx_hash = contract
+            let method = contract
                 .method::<_, H256>("setValue", i.to_string())
-                .unwrap()
-                .send()
-                .await
                 .unwrap();
+            method.send().await.unwrap();
         }
 
         for i in 0..num_calls {
@@ -144,12 +140,14 @@ mod eth_tests {
     #[serial]
     async fn signer_on_node() {
         let (abi, bytecode) = compile();
-        let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
+        let provider = Provider::<Http>::try_from("http://localhost:8545")
+            .unwrap()
+            .interval(Duration::from_millis(10u64));
         let deployer = "3cDB3d9e1B74692Bb1E3bb5fc81938151cA64b02"
             .parse::<Address>()
             .unwrap();
-        let client = Client::from(provider).with_sender(deployer);
-        let (_ganache, contract) = deploy(&client, abi, bytecode).await;
+        let client = Arc::new(Client::from(provider).with_sender(deployer));
+        let (_ganache, contract) = deploy(client, abi, bytecode).await;
 
         // make a call without the signer
         let _tx = contract
@@ -178,7 +176,7 @@ mod celo_tests {
         signers::Wallet,
         types::BlockNumber,
     };
-    use std::convert::TryFrom;
+    use std::{convert::TryFrom, sync::Arc, time::Duration};
 
     #[tokio::test]
     async fn deploy_and_call_contract() {
@@ -192,9 +190,11 @@ mod celo_tests {
         let client = "d652abb81e8c686edba621a895531b1f291289b63b5ef09a94f686a5ecdd5db1"
             .parse::<Wallet>()
             .unwrap()
-            .connect(provider);
+            .connect(provider)
+            .interval(Duration::from_millis(6000));
+        let client = Arc::new(client);
 
-        let factory = ContractFactory::new(abi, bytecode, &client);
+        let factory = ContractFactory::new(abi, bytecode, client);
         let deployer = factory.deploy("initial value".to_string()).unwrap();
         let contract = deployer.block(BlockNumber::Pending).send().await.unwrap();
 
@@ -207,12 +207,10 @@ mod celo_tests {
         assert_eq!(value, "initial value");
 
         // make a state mutating transaction
-        let pending_tx = contract
+        let method = contract
             .method::<_, H256>("setValue", "hi".to_owned())
-            .unwrap()
-            .send()
-            .await
             .unwrap();
+        let pending_tx = method.send().await.unwrap();
         let _receipt = pending_tx.await.unwrap();
 
         let value: String = contract

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -111,7 +111,7 @@ mod pending_transaction;
 pub use pending_transaction::PendingTransaction;
 
 mod stream;
-pub use stream::FilterStream;
+pub use stream::{FilterStream, DEFAULT_POLL_INTERVAL};
 // re-export `StreamExt` so that consumers can call `next()` on the `FilterStream`
 // without having to import futures themselves
 pub use futures_util::StreamExt;

--- a/ethers-providers/src/pending_transaction.rs
+++ b/ethers-providers/src/pending_transaction.rs
@@ -1,5 +1,5 @@
 use crate::{
-    stream::{interval, DEFAULT_POLL_DURATION},
+    stream::{interval, DEFAULT_POLL_INTERVAL},
     JsonRpcClient, Provider, ProviderError,
 };
 use ethers_core::types::{TransactionReceipt, TxHash, U64};
@@ -38,7 +38,7 @@ impl<'a, P: JsonRpcClient> PendingTransaction<'a, P> {
             confirmations: 1,
             provider,
             state: PendingTxState::GettingReceipt(fut),
-            interval: Box::new(interval(DEFAULT_POLL_DURATION)),
+            interval: Box::new(interval(DEFAULT_POLL_INTERVAL)),
         }
     }
 
@@ -50,8 +50,8 @@ impl<'a, P: JsonRpcClient> PendingTransaction<'a, P> {
     }
 
     /// Sets the polling interval
-    pub fn interval<T: Into<u64>>(mut self, duration: T) -> Self {
-        self.interval = Box::new(interval(Duration::from_millis(duration.into())));
+    pub fn interval<T: Into<Duration>>(mut self, duration: T) -> Self {
+        self.interval = Box::new(interval(duration.into()));
         self
     }
 }

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -265,7 +265,7 @@ impl<P: JsonRpcClient> Provider<P> {
     pub async fn send_transaction(
         &self,
         mut tx: TransactionRequest,
-    ) -> Result<PendingTransaction<'_, P>, ProviderError> {
+    ) -> Result<TxHash, ProviderError> {
         if let Some(ref to) = tx.to {
             if let NameOrAddress::Name(ens_name) = to {
                 // resolve to an address
@@ -276,33 +276,22 @@ impl<P: JsonRpcClient> Provider<P> {
             }
         }
 
-        let tx_hash = self
+        Ok(self
             .0
             .request("eth_sendTransaction", [tx])
             .await
-            .map_err(Into::into)?;
-
-        let pending_tx = PendingTransaction::new(tx_hash, self).interval(self.get_interval());
-
-        Ok(pending_tx)
+            .map_err(Into::into)?)
     }
 
     /// Send the raw RLP encoded transaction to the entire Ethereum network and returns the transaction's hash
     /// This will consume gas from the account that signed the transaction.
-    pub async fn send_raw_transaction(
-        &self,
-        tx: &Transaction,
-    ) -> Result<PendingTransaction<'_, P>, ProviderError> {
+    pub async fn send_raw_transaction(&self, tx: &Transaction) -> Result<TxHash, ProviderError> {
         let rlp = utils::serialize(&tx.rlp());
-        let tx_hash = self
+        Ok(self
             .0
             .request("eth_sendRawTransaction", [rlp])
             .await
-            .map_err(Into::into)?;
-
-        let pending_tx = PendingTransaction::new(tx_hash, self).interval(self.get_interval());
-
-        Ok(pending_tx)
+            .map_err(Into::into)?)
     }
 
     /// Signs data using a specific account. This account needs to be unlocked.
@@ -517,6 +506,12 @@ impl<P: JsonRpcClient> Provider<P> {
     /// and pending transactions (default: 7 seconds)
     pub fn get_interval(&self) -> Duration {
         self.2.unwrap_or(DEFAULT_POLL_INTERVAL)
+    }
+
+    /// Helper which creates a pending transaction object from a transaction hash
+    /// using the provider's polling interval
+    pub fn pending_transaction(&self, tx_hash: TxHash) -> PendingTransaction<'_, P> {
+        PendingTransaction::new(tx_hash, self).interval(self.get_interval())
     }
 }
 

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1,6 +1,6 @@
 use crate::{
     ens,
-    stream::{FilterStream, FilterWatcher},
+    stream::{FilterStream, FilterWatcher, DEFAULT_POLL_INTERVAL},
     Http as HttpProvider, JsonRpcClient, PendingTransaction,
 };
 
@@ -17,7 +17,7 @@ use serde::Deserialize;
 use thiserror::Error;
 use url::{ParseError, Url};
 
-use std::{convert::TryFrom, fmt::Debug};
+use std::{convert::TryFrom, fmt::Debug, time::Duration};
 
 /// An abstract provider for interacting with the [Ethereum JSON RPC
 /// API](https://github.com/ethereum/wiki/wiki/JSON-RPC). Must be instantiated
@@ -41,7 +41,7 @@ use std::{convert::TryFrom, fmt::Debug};
 /// # }
 /// ```
 #[derive(Clone, Debug)]
-pub struct Provider<P>(P, Option<Address>);
+pub struct Provider<P>(P, Option<Address>, Option<Duration>);
 
 #[derive(Debug, Error)]
 /// An error thrown when making a call to the provider
@@ -72,7 +72,7 @@ pub enum FilterKind<'a> {
 impl<P: JsonRpcClient> Provider<P> {
     /// Instantiate a new provider with a backend.
     pub fn new(provider: P) -> Self {
-        Self(provider, None)
+        Self(provider, None, None)
     }
 
     ////// Blockchain Status
@@ -281,7 +281,11 @@ impl<P: JsonRpcClient> Provider<P> {
             .request("eth_sendTransaction", [tx])
             .await
             .map_err(Into::into)?;
-        Ok(PendingTransaction::new(tx_hash, self))
+
+        let pending_tx = PendingTransaction::new(tx_hash, self)
+            .interval(self.2.unwrap_or(DEFAULT_POLL_INTERVAL));
+
+        Ok(pending_tx)
     }
 
     /// Send the raw RLP encoded transaction to the entire Ethereum network and returns the transaction's hash
@@ -296,7 +300,11 @@ impl<P: JsonRpcClient> Provider<P> {
             .request("eth_sendRawTransaction", [rlp])
             .await
             .map_err(Into::into)?;
-        Ok(PendingTransaction::new(tx_hash, self))
+
+        let pending_tx = PendingTransaction::new(tx_hash, self)
+            .interval(self.2.unwrap_or(DEFAULT_POLL_INTERVAL));
+
+        Ok(pending_tx)
     }
 
     /// Signs data using a specific account. This account needs to be unlocked.
@@ -332,14 +340,17 @@ impl<P: JsonRpcClient> Provider<P> {
     ) -> Result<impl FilterStream<Log> + '_, ProviderError> {
         let id = self.new_filter(FilterKind::Logs(filter)).await?;
         let fut = move || Box::pin(self.get_filter_changes(id));
-        Ok(FilterWatcher::new(id, fut))
+        let filter = FilterWatcher::new(id, fut).interval(self.2.unwrap_or(DEFAULT_POLL_INTERVAL));
+
+        Ok(filter)
     }
 
     /// Streams new block hashes
     pub async fn watch_blocks(&self) -> Result<impl FilterStream<H256> + '_, ProviderError> {
         let id = self.new_filter(FilterKind::NewBlocks).await?;
         let fut = move || Box::pin(self.get_filter_changes(id));
-        Ok(FilterWatcher::new(id, fut))
+        let filter = FilterWatcher::new(id, fut).interval(self.2.unwrap_or(DEFAULT_POLL_INTERVAL));
+        Ok(filter)
     }
 
     /// Streams pending transactions
@@ -348,7 +359,8 @@ impl<P: JsonRpcClient> Provider<P> {
     ) -> Result<impl FilterStream<H256> + '_, ProviderError> {
         let id = self.new_filter(FilterKind::PendingTransactions).await?;
         let fut = move || Box::pin(self.get_filter_changes(id));
-        Ok(FilterWatcher::new(id, fut))
+        let filter = FilterWatcher::new(id, fut).interval(self.2.unwrap_or(DEFAULT_POLL_INTERVAL));
+        Ok(filter)
     }
 
     /// Creates a filter object, based on filter options, to notify when the state changes (logs).
@@ -495,6 +507,12 @@ impl<P: JsonRpcClient> Provider<P> {
         self.1 = Some(ens.into());
         self
     }
+
+    /// Sets the default polling interval for event filters and pending transactions
+    pub fn interval<T: Into<Duration>>(mut self, interval: T) -> Self {
+        self.2 = Some(interval.into());
+        self
+    }
 }
 
 /// infallbile conversion of Bytes to Address/String
@@ -512,7 +530,7 @@ impl TryFrom<&str> for Provider<HttpProvider> {
     type Error = ParseError;
 
     fn try_from(src: &str) -> Result<Self, Self::Error> {
-        Ok(Provider(HttpProvider::new(Url::parse(src)?), None))
+        Ok(Provider(HttpProvider::new(Url::parse(src)?), None, None))
     }
 }
 
@@ -578,15 +596,12 @@ mod tests {
     async fn test_new_block_filter() {
         let num_blocks = 3;
 
-        let provider = Provider::<HttpProvider>::try_from("http://localhost:8545").unwrap();
+        let provider = Provider::<HttpProvider>::try_from("http://localhost:8545")
+            .unwrap()
+            .interval(Duration::from_millis(1000));
         let start_block = provider.get_block_number().await.unwrap();
 
-        let stream = provider
-            .watch_blocks()
-            .await
-            .unwrap()
-            .interval(1000u64)
-            .stream();
+        let stream = provider.watch_blocks().await.unwrap().stream();
 
         let hashes: Vec<H256> = stream.take(num_blocks).collect::<Vec<H256>>().await;
         for (i, hash) in hashes.iter().enumerate() {
@@ -606,14 +621,15 @@ mod tests {
     async fn test_new_pending_txs_filter() {
         let num_txs = 5;
 
-        let provider = Provider::<HttpProvider>::try_from("http://localhost:8545").unwrap();
+        let provider = Provider::<HttpProvider>::try_from("http://localhost:8545")
+            .unwrap()
+            .interval(Duration::from_millis(1000));
         let accounts = provider.get_accounts().await.unwrap();
 
         let stream = provider
             .watch_pending_transactions()
             .await
             .unwrap()
-            .interval(1000u64)
             .stream();
 
         let mut tx_hashes = Vec::new();

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -11,6 +11,7 @@ mod eth_tests {
         utils::{parse_ether, Ganache},
     };
     use serial_test::serial;
+    use std::time::Duration;
 
     // Without TLS this would error with "TLS Support not compiled in"
     #[test]
@@ -65,7 +66,9 @@ mod eth_tests {
     #[serial]
     async fn pending_txs_with_confirmations_ganache() {
         let _ganache = Ganache::new().block_time(2u64).spawn();
-        let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
+        let provider = Provider::<Http>::try_from("http://localhost:8545")
+            .unwrap()
+            .interval(Duration::from_millis(500u64));
         generic_pending_txs_test(provider).await;
     }
 
@@ -86,7 +89,7 @@ mod eth_tests {
         let tx = TransactionRequest::pay(accounts[0], parse_ether(1u64).unwrap()).from(accounts[0]);
         let pending_tx = provider.send_transaction(tx).await.unwrap();
         let hash = *pending_tx;
-        let receipt = pending_tx.interval(500u64).confirmations(5).await.unwrap();
+        let receipt = pending_tx.confirmations(5).await.unwrap();
 
         // got the correct receipt
         assert_eq!(receipt.transaction_hash, hash);

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -1,6 +1,6 @@
 #![allow(unused_braces)]
 use ethers::providers::{Http, Provider};
-use std::{time::Duration, convert::TryFrom};
+use std::{convert::TryFrom, time::Duration};
 
 #[cfg(not(feature = "celo"))]
 mod eth_tests {
@@ -81,12 +81,12 @@ mod eth_tests {
         let accounts = provider.get_accounts().await.unwrap();
 
         let tx = TransactionRequest::pay(accounts[0], parse_ether(1u64).unwrap()).from(accounts[0]);
-        let pending_tx = provider.send_transaction(tx).await.unwrap();
-        let hash = *pending_tx;
+        let tx_hash = provider.send_transaction(tx).await.unwrap();
+        let pending_tx = provider.pending_transaction(tx_hash);
         let receipt = pending_tx.confirmations(5).await.unwrap();
 
         // got the correct receipt
-        assert_eq!(receipt.transaction_hash, hash);
+        assert_eq!(receipt.transaction_hash, tx_hash);
     }
 }
 
@@ -114,14 +114,11 @@ mod celo_tests {
 
     #[tokio::test]
     async fn watch_blocks() {
-        let provider =
-            Provider::<Http>::try_from("https://alfajores-forno.celo-testnet.org").unwrap().interval(Duration::from_millis(2000u64));
-
-        let stream = provider
-            .watch_blocks()
-            .await
+        let provider = Provider::<Http>::try_from("https://alfajores-forno.celo-testnet.org")
             .unwrap()
-            .stream();
+            .interval(Duration::from_millis(2000u64));
+
+        let stream = provider.watch_blocks().await.unwrap().stream();
 
         let _blocks = stream.take(3usize).collect::<Vec<H256>>().await;
     }

--- a/ethers-signers/src/lib.rs
+++ b/ethers-signers/src/lib.rs
@@ -24,10 +24,10 @@
 //!     .value(10000);
 //!
 //! // send it! (this will resolve the ENS name to an address under the hood)
-//! let pending_tx = client.send_transaction(tx, None).await?;
+//! let tx_hash = client.send_transaction(tx, None).await?;
 //!
 //! // get the receipt
-//! let receipt = pending_tx.await?;
+//! let receipt = client.pending_transaction(tx_hash).await?;
 //!
 //! // get the mined tx
 //! let tx = client.get_transaction(receipt.transaction_hash).await?;

--- a/ethers/examples/contract.rs
+++ b/ethers/examples/contract.rs
@@ -52,13 +52,11 @@ async fn main() -> Result<()> {
     let addr = contract.address();
 
     // 9. instantiate the contract
-    let contract = SimpleContract::new(addr, client);
+    let contract = SimpleContract::new(addr, client.clone());
 
     // 10. call the `setValue` method
-    let call = contract.set_value("hi".to_owned());
-    let pending_tx = call.send().await?;
-    // wait for the tx to get mined
-    let _receipt = pending_tx.await?;
+    let tx_hash = contract.set_value("hi".to_owned()).send().await?;
+    let _receipt = client.pending_transaction(tx_hash).await?;
 
     // 11. get all events
     let logs = contract

--- a/ethers/examples/contract.rs
+++ b/ethers/examples/contract.rs
@@ -3,7 +3,7 @@ use ethers::{
     prelude::*,
     utils::{Ganache, Solc},
 };
-use std::convert::TryFrom;
+use std::{convert::TryFrom, sync::Arc, time::Duration};
 
 // Generate the type-safe contract bindings by providing the ABI
 abigen!(
@@ -32,13 +32,18 @@ async fn main() -> Result<()> {
         "380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc".parse::<Wallet>()?;
 
     // 4. connect to the network
-    let provider = Provider::<Http>::try_from(url.as_str())?;
+    let provider = Provider::<Http>::try_from(url.as_str())?.interval(Duration::from_millis(10u64));
 
     // 5. instantiate the client with the wallet
     let client = wallet.connect(provider);
+    let client = Arc::new(client);
 
     // 6. create a factory which will be used to deploy instances of the contract
-    let factory = ContractFactory::new(contract.abi.clone(), contract.bytecode.clone(), &client);
+    let factory = ContractFactory::new(
+        contract.abi.clone(),
+        contract.bytecode.clone(),
+        client.clone(),
+    );
 
     // 7. deploy it with the constructor arguments
     let contract = factory.deploy("initial value".to_string())?.send().await?;
@@ -47,10 +52,13 @@ async fn main() -> Result<()> {
     let addr = contract.address();
 
     // 9. instantiate the contract
-    let contract = SimpleContract::new(addr, &client);
+    let contract = SimpleContract::new(addr, client);
 
     // 10. call the `setValue` method
-    let _tx_hash = contract.set_value("hi".to_owned()).send().await?;
+    let call = contract.set_value("hi".to_owned());
+    let pending_tx = call.send().await?;
+    // wait for the tx to get mined
+    let _receipt = pending_tx.await?;
 
     // 11. get all events
     let logs = contract

--- a/ethers/examples/ens.rs
+++ b/ethers/examples/ens.rs
@@ -18,9 +18,9 @@ async fn main() -> Result<()> {
     let tx = TransactionRequest::new().to("vitalik.eth").value(100_000);
 
     // send it!
-    let pending_tx = client.send_transaction(tx, None).await?;
+    let tx_hash = client.send_transaction(tx, None).await?;
 
-    let receipt = pending_tx.await?;
+    let receipt = client.pending_transaction(tx_hash).await?;
     let tx = client.get_transaction(receipt.transaction_hash).await?;
 
     println!("{}", serde_json::to_string(&tx)?);

--- a/ethers/examples/local_signer.rs
+++ b/ethers/examples/local_signer.rs
@@ -27,10 +27,10 @@ async fn main() -> Result<()> {
         .value(10000);
 
     // send it!
-    let pending_tx = client.send_transaction(tx, None).await?;
+    let tx_hash = client.send_transaction(tx, None).await?;
 
     // get the mined tx
-    let receipt = pending_tx.await?;
+    let receipt = client.pending_transaction(tx_hash).await?;
     let tx = client.get_transaction(receipt.transaction_hash).await?;
 
     println!("Sent tx: {}\n", serde_json::to_string(&tx)?);

--- a/ethers/examples/transfer_eth.rs
+++ b/ethers/examples/transfer_eth.rs
@@ -22,9 +22,9 @@ async fn main() -> Result<()> {
     let balance_before = provider.get_balance(from, None).await?;
 
     // broadcast it via the eth_sendTransaction API
-    let pending_tx = provider.send_transaction(tx).await?;
+    let tx_hash = provider.send_transaction(tx).await?;
 
-    let tx = pending_tx.await?;
+    let tx = provider.pending_transaction(tx_hash).await?;
 
     println!("{}", serde_json::to_string(&tx)?);
 

--- a/ethers/examples/watch_blocks.rs
+++ b/ethers/examples/watch_blocks.rs
@@ -1,10 +1,11 @@
 use ethers::prelude::*;
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let ws = Ws::connect("ws://localhost:8546").await?;
-    let provider = Provider::new(ws);
-    let mut stream = provider.watch_blocks().await?.interval(2000u64).stream();
+    let provider = Provider::new(ws).interval(Duration::from_millis(2000));
+    let mut stream = provider.watch_blocks().await?.stream();
     while let Some(block) = stream.next().await {
         dbg!(block);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Currently, the Contract struct takes a reference to the Client (https://github.com/gakonst/ethers-rs/blob/master/ethers-contract/src/contract.rs#L166). 

This is done in order to avoid cloning/moving the client everywhere which would be: 
1. inefficient: you should have 1 client which is responsible for creating your requests used by all contract instances!
2. risky: Cloning the client might mean cloning the private key all over your memory. Bad. 

This introduced a lifetime in the Contract struct which can be a huge pain, in particular if you want to put the contract struct inside another struct which you want to do a spawn call for (which requires static bounds).

## Solution

Replacing the reference with `Arc` does the trick. We get some runtime overheads, but that's acceptable.

## Drive-by changes

Add a default `interval` parameter to the client/provider/contract/factory, so that we can specify the polling interval for all calls once (previously we'd need to specify it on a per-call basis, which is annoying if you're on different networks with faster block times and want to do multiple calls)


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

**This is a breaking change since it changes the interface of `send_transaction`, `send_raw_transaction`, and `call`**