### PR TITLE
feature: ethers-core wasm32 arch compatibility

### DIFF
--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -21,7 +21,7 @@ use crate::types::{Address, Bytes, U256};
 use std::convert::TryInto;
 
 /// 1 Ether = 1e18 Wei == 0x0de0b6b3a7640000 Wei
-pub const WEI_IN_ETHER: U256 = U256([0x0, 0x0, 0x0, 0x0de0b6b3a7640000]);
+pub const WEI_IN_ETHER: U256 = U256([0x0de0b6b3a7640000, 0x0, 0x0, 0x0]);
 
 /// Format the output for the user which prefer to see values
 /// in ether (instead of wei)
@@ -104,6 +104,11 @@ pub fn get_create2_address(
 mod tests {
     use super::*;
     use rustc_hex::FromHex;
+
+    #[test]
+    fn wei_in_ether() {
+        assert_eq!(WEI_IN_ETHER.as_u64(), 1e18 as u64);
+    }
 
     #[test]
     fn contract_address() {

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -1,9 +1,14 @@
 /// Utilities for launching a ganache-cli testnet instance
+#[cfg(not(target_arch = "wasm32"))]
 mod ganache;
+#[cfg(not(target_arch = "wasm32"))]
 pub use ganache::{Ganache, GanacheInstance};
 
 /// Solidity compiler bindings
+#[cfg(not(target_arch = "wasm32"))]
 mod solc;
+
+#[cfg(not(target_arch = "wasm32"))]
 pub use solc::{CompiledContract, Solc};
 
 mod hash;
@@ -15,8 +20,8 @@ pub use rlp;
 use crate::types::{Address, Bytes, U256};
 use std::convert::TryInto;
 
-/// 1 Ether = 1e18 Wei
-pub const WEI_IN_ETHER: usize = 1000000000000000000;
+/// 1 Ether = 1e18 Wei == 0x0de0b6b3a7640000 Wei
+pub const WEI_IN_ETHER: U256 = U256([0x0, 0x0, 0x0, 0x0de0b6b3a7640000]);
 
 /// Format the output for the user which prefer to see values
 /// in ether (instead of wei)


### PR DESCRIPTION
Adds wasm compatibility for the `ethers-core` crate.

## Motivation

Core functionality (abi encoding etc) should be usable in more environments (e.g a browser).

## Solution
1. Update the following constant in `crate::utils`:
    - `pub const WEI_IN_ETHER: U256 = U256([0x0, 0x0, 0x0, 0x0de0b6b3a7640000]);`
2. Remove `ganache` and `solc` utils when compiling for wasm32

building this way should work now: 
`$ cargo build --target wasm32-unknown-unknown`
