### PR TITLE
fix(provider): Add Send trait bound to PendingTx state future

### DIFF
--- a/ethers-providers/src/pending_transaction.rs
+++ b/ethers-providers/src/pending_transaction.rs
@@ -159,7 +159,7 @@ impl<'a, P> Deref for PendingTransaction<'a, P> {
 }
 
 // Helper type alias
-type PinBoxFut<'a, T> = Pin<Box<dyn Future<Output = Result<T, ProviderError>> + 'a>>;
+type PinBoxFut<'a, T> = Pin<Box<dyn Future<Output = Result<T, ProviderError>> + 'a + Send>>;
 
 // We box the TransactionReceipts to keep the enum small.
 enum PendingTxState<'a> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

As @roynalnaruto pointed out, the PendingTransaction struct was not Send. Reproduced with https://gist.github.com/roynalnaruto/e9424d8917eaf330d8317d19328586b5#file-sample-rs-L34. This happens because the `BinPoxFut` trait object was not limited to be `Send` (which it should be ).

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add a `Send` trait bound.