### PR TITLE
(feat) gas oracle support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "chrono"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "time",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +508,7 @@ dependencies = [
  "reqwest",
  "rustc-hex",
  "serde",
+ "serde-aux",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1059,6 +1071,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1476,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-aux"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae50f53d4b01e854319c1f5b854cd59471f054ea7e554988850d3f36ca1dc852"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -81,7 +81,8 @@ pub static ADDRESS_BOOK: Lazy<HashMap<U256, Address>> = Lazy::new(|| {
 ///     .parse::<Wallet>()?.connect(provider);
 ///
 /// // create the contract object. This will be used to construct the calls for multicall
-/// let contract = Contract::new(address, abi, client.clone());
+/// let client = Arc::new(client);
+/// let contract = Contract::new(address, abi, Arc::clone(&client));
 ///
 /// // note that these [`ContractCall`]s are futures, and need to be `.await`ed to resolve.
 /// // But we will let `Multicall` to take care of that for us
@@ -92,7 +93,7 @@ pub static ADDRESS_BOOK: Lazy<HashMap<U256, Address>> = Lazy::new(|| {
 /// // the Multicall contract and we set that to `None`. If you wish to provide the address
 /// // for the Multicall contract, you can pass the `Some(multicall_addr)` argument.
 /// // Construction of the `Multicall` instance follows the builder pattern
-/// let multicall = Multicall::new(client.clone(), None)
+/// let multicall = Multicall::new(Arc::clone(&client), None)
 ///     .await?
 ///     .add_call(first_call)
 ///     .add_call(second_call);

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -38,6 +38,9 @@ tokio = { version = "0.2.21", default-features = false, optional = true }
 real-tokio-native-tls = { package = "tokio-native-tls", version = "0.1.0", optional = true }
 async-tls = { version = "0.7.0", optional = true }
 
+# needed for parsing while deserialization in gas oracles
+serde-aux = "0.6.1"
+
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }
 

--- a/ethers-providers/src/gas_oracle/eth_gas_station.rs
+++ b/ethers-providers/src/gas_oracle/eth_gas_station.rs
@@ -8,6 +8,8 @@ use crate::gas_oracle::{GasOracleError, GasOracleFetch, GasOracleResponse};
 
 const ETH_GAS_STATION_URL_PREFIX: &str = "https://ethgasstation.info/api/ethgasAPI.json";
 
+/// A client over HTTP for the [EthGasStation](https://ethgasstation.info/api/ethgasAPI.json) gas tracker API
+/// that implements the `GasOracleFetch` trait
 pub struct EthGasStation {
     client: Client,
     url: Url,

--- a/ethers-providers/src/gas_oracle/eth_gas_station.rs
+++ b/ethers-providers/src/gas_oracle/eth_gas_station.rs
@@ -5,7 +5,7 @@ use reqwest::Client;
 use serde::Deserialize;
 use url::Url;
 
-use crate::gas_oracle::{GasCategory, GasOracle, GasOracleError};
+use crate::gas_oracle::{GasCategory, GasOracle, GasOracleError, GWEI_TO_WEI};
 
 const ETH_GAS_STATION_URL_PREFIX: &str = "https://ethgasstation.info/api/ethgasAPI.json";
 
@@ -61,10 +61,10 @@ impl GasOracle for EthGasStation {
             .await?;
 
         let gas_price = match self.gas_category {
-            GasCategory::SafeLow => U256::from(res.safe_low / 10),
-            GasCategory::Standard => U256::from(res.average / 10),
-            GasCategory::Fast => U256::from(res.fast / 10),
-            GasCategory::Fastest => U256::from(res.fastest / 10),
+            GasCategory::SafeLow => U256::from((res.safe_low * GWEI_TO_WEI) / 10),
+            GasCategory::Standard => U256::from((res.average * GWEI_TO_WEI) / 10),
+            GasCategory::Fast => U256::from((res.fast * GWEI_TO_WEI) / 10),
+            GasCategory::Fastest => U256::from((res.fastest * GWEI_TO_WEI) / 10),
         };
 
         Ok(gas_price)

--- a/ethers-providers/src/gas_oracle/eth_gas_station.rs
+++ b/ethers-providers/src/gas_oracle/eth_gas_station.rs
@@ -1,0 +1,82 @@
+use async_trait::async_trait;
+use reqwest::{Client, Error as ReqwestError};
+use serde::Deserialize;
+use thiserror::Error;
+use url::Url;
+
+use crate::gas_oracle::{GasOracleError, GasOracleFetch, GasOracleResponse};
+
+const ETH_GAS_STATION_URL_PREFIX: &str = "https://ethgasstation.info/api/ethgasAPI.json";
+
+pub struct EthGasStation {
+    client: Client,
+    url: Url,
+}
+
+#[derive(Deserialize)]
+struct EthGasStationResponse {
+    #[serde(rename = "blockNum")]
+    block_num: u64,
+    #[serde(rename = "safeLow")]
+    safe_low: u64,
+    average: u64,
+    fast: u64,
+    fastest: u64,
+}
+
+impl From<EthGasStationResponse> for GasOracleResponse {
+    fn from(src: EthGasStationResponse) -> Self {
+        Self {
+            block: Some(src.block_num),
+            safe_low: Some(src.safe_low / 10),
+            standard: Some(src.average / 10),
+            fast: Some(src.fast / 10),
+            fastest: Some(src.fastest / 10),
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ClientError {
+    #[error(transparent)]
+    ReqwestError(#[from] ReqwestError),
+}
+
+impl From<ClientError> for GasOracleError {
+    fn from(src: ClientError) -> GasOracleError {
+        GasOracleError::HttpClientError(Box::new(src))
+    }
+}
+
+impl EthGasStation {
+    pub fn new(api_key: Option<&'static str>) -> Self {
+        let url = match api_key {
+            Some(key) => format!("{}?api-key={}", ETH_GAS_STATION_URL_PREFIX, key),
+            None => ETH_GAS_STATION_URL_PREFIX.to_string(),
+        };
+
+        let url = Url::parse(&url).expect("invalid url");
+
+        EthGasStation {
+            client: Client::new(),
+            url,
+        }
+    }
+}
+
+#[async_trait]
+impl GasOracleFetch for EthGasStation {
+    type Error = ClientError;
+
+    async fn fetch(&self) -> Result<GasOracleResponse, ClientError> {
+        let res = self
+            .client
+            .get(self.url.as_ref())
+            .send()
+            .await?
+            .json::<EthGasStationResponse>()
+            .await?;
+
+        Ok(res.into())
+    }
+}

--- a/ethers-providers/src/gas_oracle/etherchain.rs
+++ b/ethers-providers/src/gas_oracle/etherchain.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use serde_aux::prelude::*;
 use url::Url;
 
-use crate::gas_oracle::{GasCategory, GasOracle, GasOracleError};
+use crate::gas_oracle::{GasCategory, GasOracle, GasOracleError, GWEI_TO_WEI};
 
 const ETHERCHAIN_URL: &str = "https://www.etherchain.org/api/gasPriceOracle";
 
@@ -67,10 +67,10 @@ impl GasOracle for Etherchain {
             .await?;
 
         let gas_price = match self.gas_category {
-            GasCategory::SafeLow => U256::from(res.safe_low as u64),
-            GasCategory::Standard => U256::from(res.standard as u64),
-            GasCategory::Fast => U256::from(res.fast as u64),
-            GasCategory::Fastest => U256::from(res.fastest as u64),
+            GasCategory::SafeLow => U256::from((res.safe_low as u64) * GWEI_TO_WEI),
+            GasCategory::Standard => U256::from((res.standard as u64) * GWEI_TO_WEI),
+            GasCategory::Fast => U256::from((res.fast as u64) * GWEI_TO_WEI),
+            GasCategory::Fastest => U256::from((res.fastest as u64) * GWEI_TO_WEI),
         };
 
         Ok(gas_price)

--- a/ethers-providers/src/gas_oracle/etherchain.rs
+++ b/ethers-providers/src/gas_oracle/etherchain.rs
@@ -9,9 +9,17 @@ use crate::gas_oracle::{GasOracleError, GasOracleFetch, GasOracleResponse};
 
 const ETHERCHAIN_URL: &str = "https://www.etherchain.org/api/gasPriceOracle";
 
+/// A client over HTTP for the [Etherchain](https://www.etherchain.org/api/gasPriceOracle) gas tracker API
+/// that implements the `GasOracleFetch` trait
 pub struct Etherchain {
     client: Client,
     url: Url,
+}
+
+impl Default for Etherchain {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[derive(Deserialize)]

--- a/ethers-providers/src/gas_oracle/etherchain.rs
+++ b/ethers-providers/src/gas_oracle/etherchain.rs
@@ -1,0 +1,80 @@
+use async_trait::async_trait;
+use reqwest::{Client, Error as ReqwestError};
+use serde::Deserialize;
+use serde_aux::prelude::*;
+use thiserror::Error;
+use url::Url;
+
+use crate::gas_oracle::{GasOracleError, GasOracleFetch, GasOracleResponse};
+
+const ETHERCHAIN_URL: &str = "https://www.etherchain.org/api/gasPriceOracle";
+
+pub struct Etherchain {
+    client: Client,
+    url: Url,
+}
+
+#[derive(Deserialize)]
+struct EtherchainResponse {
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    #[serde(rename = "safeLow")]
+    safe_low: f32,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    standard: f32,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    fast: f32,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    fastest: f32,
+}
+
+impl From<EtherchainResponse> for GasOracleResponse {
+    fn from(src: EtherchainResponse) -> Self {
+        Self {
+            block: None,
+            safe_low: Some(src.safe_low as u64),
+            standard: Some(src.standard as u64),
+            fast: Some(src.fast as u64),
+            fastest: Some(src.fastest as u64),
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ClientError {
+    #[error(transparent)]
+    ReqwestError(#[from] ReqwestError),
+}
+
+impl From<ClientError> for GasOracleError {
+    fn from(src: ClientError) -> GasOracleError {
+        GasOracleError::HttpClientError(Box::new(src))
+    }
+}
+
+impl Etherchain {
+    pub fn new() -> Self {
+        let url = Url::parse(ETHERCHAIN_URL).expect("invalid url");
+
+        Etherchain {
+            client: Client::new(),
+            url,
+        }
+    }
+}
+
+#[async_trait]
+impl GasOracleFetch for Etherchain {
+    type Error = ClientError;
+
+    async fn fetch(&self) -> Result<GasOracleResponse, ClientError> {
+        let res = self
+            .client
+            .get(self.url.as_ref())
+            .send()
+            .await?
+            .json::<EtherchainResponse>()
+            .await?;
+
+        Ok(res.into())
+    }
+}

--- a/ethers-providers/src/gas_oracle/etherscan.rs
+++ b/ethers-providers/src/gas_oracle/etherscan.rs
@@ -10,6 +10,8 @@ use crate::gas_oracle::{GasOracleError, GasOracleFetch, GasOracleResponse};
 const ETHERSCAN_URL_PREFIX: &str =
     "https://api.etherscan.io/api?module=gastracker&action=gasoracle";
 
+/// A client over HTTP for the [Etherscan](https://api.etherscan.io/api?module=gastracker&action=gasoracle) gas tracker API
+/// that implements the `GasOracleFetch` trait
 pub struct Etherscan {
     client: Client,
     url: Url,

--- a/ethers-providers/src/gas_oracle/etherscan.rs
+++ b/ethers-providers/src/gas_oracle/etherscan.rs
@@ -1,0 +1,91 @@
+use async_trait::async_trait;
+use reqwest::{Client, Error as ReqwestError};
+use serde::Deserialize;
+use serde_aux::prelude::*;
+use thiserror::Error;
+use url::Url;
+
+use crate::gas_oracle::{GasOracleError, GasOracleFetch, GasOracleResponse};
+
+const ETHERSCAN_URL_PREFIX: &str =
+    "https://api.etherscan.io/api?module=gastracker&action=gasoracle";
+
+pub struct Etherscan {
+    client: Client,
+    url: Url,
+}
+
+#[derive(Deserialize)]
+struct EtherscanResponse {
+    result: EtherscanResponseInner,
+}
+
+#[derive(Deserialize)]
+struct EtherscanResponseInner {
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    #[serde(rename = "LastBlock")]
+    last_block: u64,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    #[serde(rename = "SafeGasPrice")]
+    safe_gas_price: u64,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    #[serde(rename = "ProposeGasPrice")]
+    propose_gas_price: u64,
+}
+
+impl From<EtherscanResponse> for GasOracleResponse {
+    fn from(src: EtherscanResponse) -> Self {
+        Self {
+            block: Some(src.result.last_block),
+            safe_low: Some(src.result.safe_gas_price),
+            standard: Some(src.result.propose_gas_price),
+            fast: None,
+            fastest: None,
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ClientError {
+    #[error(transparent)]
+    ReqwestError(#[from] ReqwestError),
+}
+
+impl From<ClientError> for GasOracleError {
+    fn from(src: ClientError) -> GasOracleError {
+        GasOracleError::HttpClientError(Box::new(src))
+    }
+}
+
+impl Etherscan {
+    pub fn new(api_key: Option<&'static str>) -> Self {
+        let url = match api_key {
+            Some(key) => format!("{}&apikey={}", ETHERSCAN_URL_PREFIX, key),
+            None => ETHERSCAN_URL_PREFIX.to_string(),
+        };
+
+        let url = Url::parse(&url).expect("invalid url");
+
+        Etherscan {
+            client: Client::new(),
+            url,
+        }
+    }
+}
+
+#[async_trait]
+impl GasOracleFetch for Etherscan {
+    type Error = ClientError;
+
+    async fn fetch(&self) -> Result<GasOracleResponse, ClientError> {
+        let res = self
+            .client
+            .get(self.url.as_ref())
+            .send()
+            .await?
+            .json::<EtherscanResponse>()
+            .await?;
+
+        Ok(res.into())
+    }
+}

--- a/ethers-providers/src/gas_oracle/etherscan.rs
+++ b/ethers-providers/src/gas_oracle/etherscan.rs
@@ -60,11 +60,9 @@ impl Etherscan {
 #[async_trait]
 impl GasOracle for Etherscan {
     async fn fetch(&self) -> Result<U256, GasOracleError> {
-        match self.gas_category {
-            GasCategory::Fast => return Err(GasOracleError::GasCategoryNotSupported),
-            GasCategory::Fastest => return Err(GasOracleError::GasCategoryNotSupported),
-            _ => {}
-        };
+        if matches!(self.gas_category, GasCategory::Fast | GasCategory::Fastest) {
+            return Err(GasOracleError::GasCategoryNotSupported);
+        }
 
         let res = self
             .client

--- a/ethers-providers/src/gas_oracle/etherscan.rs
+++ b/ethers-providers/src/gas_oracle/etherscan.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use serde_aux::prelude::*;
 use url::Url;
 
-use crate::gas_oracle::{GasCategory, GasOracle, GasOracleError};
+use crate::gas_oracle::{GasCategory, GasOracle, GasOracleError, GWEI_TO_WEI};
 
 const ETHERSCAN_URL_PREFIX: &str =
     "https://api.etherscan.io/api?module=gastracker&action=gasoracle";
@@ -73,8 +73,8 @@ impl GasOracle for Etherscan {
             .await?;
 
         match self.gas_category {
-            GasCategory::SafeLow => Ok(U256::from(res.result.safe_gas_price)),
-            GasCategory::Standard => Ok(U256::from(res.result.propose_gas_price)),
+            GasCategory::SafeLow => Ok(U256::from(res.result.safe_gas_price * GWEI_TO_WEI)),
+            GasCategory::Standard => Ok(U256::from(res.result.propose_gas_price * GWEI_TO_WEI)),
             _ => Err(GasOracleError::GasCategoryNotSupported),
         }
     }

--- a/ethers-providers/src/gas_oracle/etherscan.rs
+++ b/ethers-providers/src/gas_oracle/etherscan.rs
@@ -60,6 +60,12 @@ impl Etherscan {
 #[async_trait]
 impl GasOracle for Etherscan {
     async fn fetch(&self) -> Result<U256, GasOracleError> {
+        match self.gas_category {
+            GasCategory::Fast => return Err(GasOracleError::GasCategoryNotSupported),
+            GasCategory::Fastest => return Err(GasOracleError::GasCategoryNotSupported),
+            _ => {}
+        };
+
         let res = self
             .client
             .get(self.url.as_ref())
@@ -71,8 +77,7 @@ impl GasOracle for Etherscan {
         match self.gas_category {
             GasCategory::SafeLow => Ok(U256::from(res.result.safe_gas_price)),
             GasCategory::Standard => Ok(U256::from(res.result.propose_gas_price)),
-            GasCategory::Fast => Err(GasOracleError::GasCategoryNotSupported),
-            GasCategory::Fastest => Err(GasOracleError::GasCategoryNotSupported),
+            _ => Err(GasOracleError::GasCategoryNotSupported),
         }
     }
 }

--- a/ethers-providers/src/gas_oracle/gas_now.rs
+++ b/ethers-providers/src/gas_oracle/gas_now.rs
@@ -1,0 +1,78 @@
+use ethers_core::types::U256;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use url::Url;
+
+use crate::gas_oracle::{GasCategory, GasOracle, GasOracleError};
+
+const GAS_NOW_URL: &str = "https://www.gasnow.org/api/v1/gas/price";
+
+/// A client over HTTP for the [GasNow](https://www.gasnow.org/api/v1/gas/price) gas tracker API
+/// that implements the `GasOracle` trait
+#[derive(Debug)]
+pub struct GasNow {
+    client: Client,
+    url: Url,
+    gas_category: GasCategory,
+}
+
+impl Default for GasNow {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Deserialize)]
+struct GasNowResponse {
+    data: GasNowResponseInner,
+}
+
+#[derive(Deserialize)]
+struct GasNowResponseInner {
+    #[serde(rename = "top50")]
+    top_50: u64,
+    #[serde(rename = "top200")]
+    top_200: u64,
+    #[serde(rename = "top400")]
+    top_400: u64,
+}
+
+impl GasNow {
+    pub fn new() -> Self {
+        let url = Url::parse(GAS_NOW_URL).expect("invalid url");
+
+        Self {
+            client: Client::new(),
+            url,
+            gas_category: GasCategory::Standard,
+        }
+    }
+
+    pub fn category(mut self, gas_category: GasCategory) -> Self {
+        self.gas_category = gas_category;
+        self
+    }
+}
+
+#[async_trait]
+impl GasOracle for GasNow {
+    async fn fetch(&self) -> Result<U256, GasOracleError> {
+        let res = self
+            .client
+            .get(self.url.as_ref())
+            .send()
+            .await?
+            .json::<GasNowResponse>()
+            .await?;
+
+        let gas_price = match self.gas_category {
+            GasCategory::SafeLow => U256::from(res.data.top_400),
+            GasCategory::Standard => U256::from(res.data.top_200),
+            _ => U256::from(res.data.top_50),
+        };
+
+        Ok(gas_price)
+    }
+}

--- a/ethers-providers/src/gas_oracle/mod.rs
+++ b/ethers-providers/src/gas_oracle/mod.rs
@@ -15,7 +15,9 @@ use thiserror::Error;
 /// # Example
 ///
 /// ```no_run
-/// use ethers::providers::{EthGasStation, Etherscan, GasOracle};
+/// use ethers::providers::{
+///     gas_oracle::{EthGasStation, Etherscan, GasOracle},
+/// };
 ///
 /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
 /// let eth_gas_station_oracle = EthGasStation::new(Some("my-api-key"));
@@ -56,7 +58,9 @@ impl<G: GasOracleFetch> GasOracle<G> {
     /// # Example
     ///
     /// ```
-    /// use ethers::providers::{Etherchain, GasOracle};
+    /// use ethers::providers::{
+    ///     gas_oracle::{Etherchain, GasOracle},
+    /// };
     ///
     /// let etherchain_oracle = GasOracle::new(Etherchain::new());
     /// ```
@@ -69,7 +73,9 @@ impl<G: GasOracleFetch> GasOracle<G> {
     /// # Example
     ///
     /// ```
-    /// use ethers::providers::{Etherchain, GasOracle};
+    /// use ethers::providers::{
+    ///     gas_oracle::{Etherchain, GasOracle},
+    /// };
     ///
     /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
     /// let etherchain_oracle = GasOracle::new(Etherchain::new());

--- a/ethers-providers/src/gas_oracle/mod.rs
+++ b/ethers-providers/src/gas_oracle/mod.rs
@@ -7,11 +7,16 @@ pub use etherchain::Etherchain;
 mod etherscan;
 pub use etherscan::Etherscan;
 
+mod gas_now;
+pub use gas_now::GasNow;
+
 use ethers_core::types::U256;
 
 use async_trait::async_trait;
 use reqwest::Error as ReqwestError;
 use thiserror::Error;
+
+const GWEI_TO_WEI: u64 = 1000000000;
 
 /// Various gas price categories. Choose one of the available
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -55,7 +60,7 @@ pub enum GasOracleError {
 /// # }
 /// ```
 #[async_trait]
-pub trait GasOracle: Send + Sync + 'static + std::any::Any + std::fmt::Debug {
+pub trait GasOracle: Send + Sync + std::fmt::Debug {
     /// Makes an asynchronous HTTP query to the underlying `GasOracle`
     ///
     /// # Example

--- a/ethers-providers/src/gas_oracle/mod.rs
+++ b/ethers-providers/src/gas_oracle/mod.rs
@@ -1,0 +1,91 @@
+mod eth_gas_station;
+pub use eth_gas_station::EthGasStation;
+
+mod etherchain;
+pub use etherchain::Etherchain;
+
+mod etherscan;
+pub use etherscan::Etherscan;
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+/// `GasOracle` encapsulates a generic type that implements the `GasOracleFetch` trait.
+///
+/// # Example
+///
+/// ```no_run
+/// use ethers::providers::{EthGasStation, Etherscan, GasOracle};
+///
+/// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
+/// let eth_gas_station_oracle = EthGasStation::new(Some("my-api-key"));
+/// let gas_oracle_1 = GasOracle::new(eth_gas_station_oracle);
+///
+/// let etherscan_oracle = EthGasStation::new(None);
+/// let gas_oracle_2 = GasOracle::new(etherscan_oracle);
+///
+/// let data_1 = gas_oracle_1.fetch().await?;
+/// let data_2 = gas_oracle_2.fetch().await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct GasOracle<G: GasOracleFetch>(G);
+
+/// The response from a successful fetch from the `GasOracle`
+#[derive(Debug)]
+pub struct GasOracleResponse {
+    pub block: Option<u64>,
+    pub safe_low: Option<u64>,
+    pub standard: Option<u64>,
+    pub fast: Option<u64>,
+    pub fastest: Option<u64>,
+}
+
+#[derive(Error, Debug)]
+/// Error thrown when fetching data from the `GasOracle`
+pub enum GasOracleError {
+    /// An internal error in the HTTP request made from the underlying
+    /// gas oracle
+    #[error(transparent)]
+    HttpClientError(#[from] Box<dyn std::error::Error>),
+}
+
+impl<G: GasOracleFetch> GasOracle<G> {
+    /// Initializes a new `GasOracle`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ethers::providers::{Etherchain, GasOracle};
+    ///
+    /// let etherchain_oracle = GasOracle::new(Etherchain::new());
+    /// ```
+    pub fn new(oracle: G) -> Self {
+        Self(oracle)
+    }
+
+    /// Makes an asynchronous HTTP query to the underlying `GasOracle`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ethers::providers::{Etherchain, GasOracle};
+    ///
+    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
+    /// let etherchain_oracle = GasOracle::new(Etherchain::new());
+    /// let data = etherchain_oracle.fetch().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn fetch(&self) -> Result<GasOracleResponse, GasOracleError> {
+        Ok(self.0.fetch().await.map_err(Into::into)?)
+    }
+}
+
+/// A common trait that an underlying gas oracle needs to implement.
+#[async_trait]
+pub trait GasOracleFetch {
+    type Error: std::error::Error + Into<GasOracleError>;
+
+    async fn fetch(&self) -> Result<GasOracleResponse, Self::Error>;
+}

--- a/ethers-providers/src/gas_oracle/mod.rs
+++ b/ethers-providers/src/gas_oracle/mod.rs
@@ -14,7 +14,7 @@ use reqwest::Error as ReqwestError;
 use thiserror::Error;
 
 /// Various gas price categories. Choose one of the available
-#[derive(Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum GasCategory {
     SafeLow,
     Standard,
@@ -55,7 +55,7 @@ pub enum GasOracleError {
 /// # }
 /// ```
 #[async_trait]
-pub trait GasOracle: std::fmt::Debug {
+pub trait GasOracle: Send + Sync + 'static + std::any::Any + std::fmt::Debug {
     /// Makes an asynchronous HTTP query to the underlying `GasOracle`
     ///
     /// # Example

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -107,8 +107,7 @@ mod provider;
 // ENS support
 mod ens;
 
-mod gas_oracle;
-pub use gas_oracle::{EthGasStation, Etherchain, Etherscan, GasOracle, GasOracleResponse};
+pub mod gas_oracle;
 
 mod pending_transaction;
 pub use pending_transaction::PendingTransaction;

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -107,6 +107,9 @@ mod provider;
 // ENS support
 mod ens;
 
+mod gas_oracle;
+pub use gas_oracle::{EthGasStation, Etherchain, Etherscan, GasOracle, GasOracleResponse};
+
 mod pending_transaction;
 pub use pending_transaction::PendingTransaction;
 

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -1,5 +1,8 @@
 #![allow(unused_braces)]
-use ethers::providers::{EthGasStation, Etherchain, Etherscan, GasOracle, Http, Provider};
+use ethers::providers::{
+    gas_oracle::{EthGasStation, Etherchain, Etherscan, GasOracle},
+    Http, Provider,
+};
 use std::{convert::TryFrom, time::Duration};
 
 #[cfg(not(feature = "celo"))]

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -1,5 +1,5 @@
 #![allow(unused_braces)]
-use ethers::providers::{Http, Provider};
+use ethers::providers::{EthGasStation, Etherchain, Etherscan, GasOracle, Http, Provider};
 use std::{convert::TryFrom, time::Duration};
 
 #[cfg(not(feature = "celo"))]
@@ -71,6 +71,39 @@ mod eth_tests {
         let ws = Ws::connect(ganache.ws_endpoint()).await.unwrap();
         let provider = Provider::new(ws);
         generic_pending_txs_test(provider).await;
+    }
+
+    #[tokio::test]
+    async fn gas_oracle() {
+        // initialize and fetch gas estimates from EthGasStation
+        let eth_gas_station_oracle = EthGasStation::new(None);
+        let gas_oracle_1 = GasOracle::new(eth_gas_station_oracle);
+        let data_1 = gas_oracle_1.fetch().await.unwrap();
+        assert!(data_1.block.is_some());
+        assert!(data_1.safe_low.is_some());
+        assert!(data_1.standard.is_some());
+        assert!(data_1.fast.is_some());
+        assert!(data_1.fastest.is_some());
+
+        // initialize and fetch gas estimates from Etherscan
+        let etherscan_oracle = Etherscan::new(None);
+        let gas_oracle_2 = GasOracle::new(etherscan_oracle);
+        let data_2 = gas_oracle_2.fetch().await.unwrap();
+        assert!(data_2.block.is_some());
+        assert!(data_2.safe_low.is_some());
+        assert!(data_2.standard.is_some());
+        assert!(data_2.fast.is_none());
+        assert!(data_2.fastest.is_none());
+
+        // initialize and fetch gas estimates from Etherchain
+        let etherchain_oracle = Etherchain::new();
+        let gas_oracle_3 = GasOracle::new(etherchain_oracle);
+        let data_3 = gas_oracle_3.fetch().await.unwrap();
+        assert!(data_3.block.is_none());
+        assert!(data_3.safe_low.is_some());
+        assert!(data_3.standard.is_some());
+        assert!(data_3.fast.is_some());
+        assert!(data_3.fastest.is_some());
     }
 
     async fn generic_pending_txs_test<P: JsonRpcClient>(provider: Provider<P>) {

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -1,6 +1,6 @@
 #![allow(unused_braces)]
 use ethers::providers::{
-    gas_oracle::{EthGasStation, Etherchain, Etherscan, GasCategory, GasOracle},
+    gas_oracle::{EthGasStation, Etherchain, Etherscan, GasCategory, GasNow, GasOracle},
     Http, Provider,
 };
 use std::{convert::TryFrom, time::Duration};
@@ -99,6 +99,11 @@ mod eth_tests {
         let etherchain_oracle = Etherchain::new().category(GasCategory::Fast);
         let data_4 = etherchain_oracle.fetch().await;
         assert!(data_4.is_ok());
+
+        // initialize and fetch gas estimates from Etherchain
+        let gas_now_oracle = GasNow::new().category(GasCategory::Fastest);
+        let data_5 = gas_now_oracle.fetch().await;
+        assert!(data_5.is_ok());
     }
 
     async fn generic_pending_txs_test<P: JsonRpcClient>(provider: Provider<P>) {

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -80,8 +80,7 @@ mod eth_tests {
     async fn gas_oracle() {
         // initialize and fetch gas estimates from EthGasStation
         let eth_gas_station_oracle = EthGasStation::new(None);
-        let gas_oracle_1 = GasOracle::new(eth_gas_station_oracle);
-        let data_1 = gas_oracle_1.fetch().await.unwrap();
+        let data_1 = eth_gas_station_oracle.fetch().await.unwrap();
         assert!(data_1.block.is_some());
         assert!(data_1.safe_low.is_some());
         assert!(data_1.standard.is_some());
@@ -90,8 +89,7 @@ mod eth_tests {
 
         // initialize and fetch gas estimates from Etherscan
         let etherscan_oracle = Etherscan::new(None);
-        let gas_oracle_2 = GasOracle::new(etherscan_oracle);
-        let data_2 = gas_oracle_2.fetch().await.unwrap();
+        let data_2 = etherscan_oracle.fetch().await.unwrap();
         assert!(data_2.block.is_some());
         assert!(data_2.safe_low.is_some());
         assert!(data_2.standard.is_some());
@@ -100,8 +98,7 @@ mod eth_tests {
 
         // initialize and fetch gas estimates from Etherchain
         let etherchain_oracle = Etherchain::new();
-        let gas_oracle_3 = GasOracle::new(etherchain_oracle);
-        let data_3 = gas_oracle_3.fetch().await.unwrap();
+        let data_3 = etherchain_oracle.fetch().await.unwrap();
         assert!(data_3.block.is_none());
         assert!(data_3.safe_low.is_some());
         assert!(data_3.standard.is_some());

--- a/ethers-signers/src/client.rs
+++ b/ethers-signers/src/client.rs
@@ -3,13 +3,13 @@ use crate::Signer;
 use ethers_core::types::{
     Address, BlockNumber, Bytes, NameOrAddress, Signature, TransactionRequest, TxHash,
 };
-use ethers_providers::{JsonRpcClient, Provider, ProviderError};
+use ethers_providers::{gas_oracle::GasOracle, JsonRpcClient, Provider, ProviderError};
 
 use futures_util::{future::ok, join};
 use std::{future::Future, ops::Deref, time::Duration};
 use thiserror::Error;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 /// A client provides an interface for signing and broadcasting locally signed transactions
 /// It Derefs to [`Provider`], which allows interacting with the Ethereum JSON-RPC provider
 /// via the same API. Sending transactions also supports using [ENS](https://ens.domains/) as a receiver. If you will
@@ -70,6 +70,7 @@ pub struct Client<P, S> {
     pub(crate) provider: Provider<P>,
     pub(crate) signer: Option<S>,
     pub(crate) address: Address,
+    pub(crate) gas_oracle: Option<Box<dyn GasOracle>>,
 }
 
 #[derive(Debug, Error)]
@@ -91,8 +92,8 @@ pub enum ClientError {
 // Helper functions for locally signing transactions
 impl<P, S> Client<P, S>
 where
-    S: Signer,
     P: JsonRpcClient,
+    S: Signer,
 {
     /// Creates a new client from the provider and signer.
     pub fn new(provider: Provider<P>, signer: S) -> Self {
@@ -101,6 +102,7 @@ where
             provider,
             signer: Some(signer),
             address,
+            gas_oracle: None,
         }
     }
 
@@ -186,27 +188,19 @@ where
     /// calls.
     ///
     /// Clones internally.
-    pub fn with_signer(&self, signer: S) -> Self
-    where
-        P: Clone,
-    {
-        let mut this = self.clone();
-        this.address = signer.address();
-        this.signer = Some(signer);
-        this
+    pub fn with_signer(&mut self, signer: S) -> &Self {
+        self.address = signer.address();
+        self.signer = Some(signer);
+        self
     }
 
     /// Sets the provider and returns a mutable reference to self so that it can be used in chained
     /// calls.
     ///
     /// Clones internally.
-    pub fn with_provider(&self, provider: Provider<P>) -> Self
-    where
-        P: Clone,
-    {
-        let mut this = self.clone();
-        this.provider = provider;
-        this
+    pub fn with_provider(&mut self, provider: Provider<P>) -> &Self {
+        self.provider = provider;
+        self
     }
 
     /// Sets the address which will be used for interacting with the blockchain.
@@ -234,6 +228,12 @@ where
     pub fn interval<T: Into<Duration>>(mut self, interval: T) -> Self {
         let provider = self.provider.interval(interval.into());
         self.provider = provider;
+        self
+    }
+
+    /// Sets the gas oracle to query for gas estimates while broadcasting transactions
+    pub fn gas_oracle(mut self, gas_oracle: Box<dyn GasOracle>) -> Self {
+        self.gas_oracle = Some(gas_oracle);
         self
     }
 }
@@ -267,6 +267,7 @@ impl<P: JsonRpcClient, S> From<Provider<P>> for Client<P, S> {
             provider,
             signer: None,
             address: Address::zero(),
+            gas_oracle: None,
         }
     }
 }

--- a/ethers-signers/src/wallet.rs
+++ b/ethers-signers/src/wallet.rs
@@ -121,6 +121,7 @@ impl Wallet {
             address,
             signer: Some(self),
             provider,
+            gas_oracle: None,
         }
     }
 

--- a/ethers-signers/tests/signer.rs
+++ b/ethers-signers/tests/signer.rs
@@ -1,5 +1,8 @@
 use ethers::{
-    providers::{Http, Provider},
+    providers::{
+        gas_oracle::{Etherchain, GasOracle},
+        Http, Provider,
+    },
     signers::Wallet,
     types::TransactionRequest,
 };
@@ -70,6 +73,36 @@ mod eth_tests {
         let balance_after = client.get_balance(client.address(), None).await.unwrap();
 
         assert!(balance_before > balance_after);
+    }
+
+    #[tokio::test]
+    async fn using_gas_oracle() {
+        let ganache = Ganache::new().spawn();
+
+        // this private key belongs to the above mnemonic
+        let wallet: Wallet = ganache.keys()[0].clone().into();
+        let wallet2: Wallet = ganache.keys()[1].clone().into();
+
+        // connect to the network
+        let provider = Provider::<Http>::try_from(ganache.endpoint())
+            .unwrap()
+            .interval(Duration::from_millis(10u64));
+
+        // connect the wallet to the provider
+        let client = wallet.connect(provider);
+
+        // assign a gas oracle to use
+        let gas_oracle = Etherchain::new();
+        let _expected_gas_price = gas_oracle.fetch().await.unwrap();
+
+        let client = client.gas_oracle(Box::new(gas_oracle));
+
+        // broadcast a transaction
+        let tx = TransactionRequest::new().to(wallet2.address()).value(10000);
+        let tx_hash = client.send_transaction(tx, None).await.unwrap();
+
+        // TODO: compare to see if the expected gas matches the gas used
+        let _tx_receipt = client.get_transaction_receipt(tx_hash).await.unwrap();
     }
 }
 

--- a/ethers-signers/tests/signer.rs
+++ b/ethers-signers/tests/signer.rs
@@ -1,6 +1,6 @@
 use ethers::{
     providers::{
-        gas_oracle::{Etherchain, GasOracle},
+        gas_oracle::{Etherchain, GasCategory, GasOracle},
         Http, Provider,
     },
     signers::Wallet,
@@ -92,8 +92,8 @@ mod eth_tests {
         let client = wallet.connect(provider);
 
         // assign a gas oracle to use
-        let gas_oracle = Etherchain::new();
-        let _expected_gas_price = gas_oracle.fetch().await.unwrap();
+        let gas_oracle = Etherchain::new().category(GasCategory::Fastest);
+        let expected_gas_price = gas_oracle.fetch().await.unwrap();
 
         let client = client.gas_oracle(Box::new(gas_oracle));
 
@@ -101,8 +101,8 @@ mod eth_tests {
         let tx = TransactionRequest::new().to(wallet2.address()).value(10000);
         let tx_hash = client.send_transaction(tx, None).await.unwrap();
 
-        // TODO: compare to see if the expected gas matches the gas used
-        let _tx_receipt = client.get_transaction_receipt(tx_hash).await.unwrap();
+        let tx = client.get_transaction(tx_hash).await.unwrap();
+        assert_eq!(tx.gas_price, expected_gas_price);
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Resolves #54 

## Solution
A gas oracle is a generic struct that implements the `GasOracle` trait. The method `async fetch` in `GasOracle` allows fetching the gas price data from the underlying oracle as a `Result<U256, GasOracleError>` response.

#### API
```rust
use ethers::providers::{
   gas_oracle::{EthGasStation, Etherchain, Etherscan, GasOracle},
};

async fn foo() -> Result<(), Box<dyn std::error::Error>> {
    let gas_oracle_1 = EthGasStation::new(Some("my-api-key"));
  
    let gas_oracle_2 = EthGasStation::new(None);

    let gas_oracle_3 = Etherchain::new();
  
    let data_1 = gas_oracle_1.fetch().await?;
    let data_2 = gas_oracle_2.fetch().await?;
    let data_3 = gas_oracle_3.fetch().await?;
    Ok(())
}
```

#### Dependencies
* Needed for parsing between types (`String` to `u64`/`f32`) while deserialising
```
serde-aux = "0.6.1"
```