### PR TITLE
fix: make multicall work by reference

### DIFF
--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -203,7 +203,7 @@ where
     ///
     /// If more than the maximum number of supported calls are added. The maximum
     /// limits is constrained due to tokenization/detokenization support for tuples
-    pub fn add_call<D: Detokenize>(mut self, call: ContractCall<P, S, D>) -> Self {
+    pub fn add_call<D: Detokenize>(&mut self, call: ContractCall<P, S, D>) -> &mut Self {
         if self.calls.len() >= 16 {
             panic!("Cannot support more than {} calls", 16);
         }
@@ -229,7 +229,7 @@ where
     ///
     /// If more than the maximum number of supported calls are added. The maximum
     /// limits is constrained due to tokenization/detokenization support for tuples
-    pub fn eth_balance_of(self, addr: Address) -> Self {
+    pub fn eth_balance_of(&mut self, addr: Address) -> &mut Self {
         let call = self.contract.get_eth_balance(addr);
         self.add_call(call)
     }
@@ -271,7 +271,7 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    pub fn clear_calls(mut self) -> Self {
+    pub fn clear_calls(&mut self) -> &mut Self {
         self.calls.clear();
         self
     }

--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -264,9 +264,11 @@ mod eth_tests {
             .unwrap();
 
         // initiate the Multicall instance and add calls one by one in builder style
-        let multicall = Multicall::new(client4.clone(), Some(addr))
+        let mut multicall = Multicall::new(client4.clone(), Some(addr))
             .await
-            .unwrap()
+            .unwrap();
+
+        multicall
             .add_call(value)
             .add_call(value2)
             .add_call(last_sender)
@@ -295,8 +297,8 @@ mod eth_tests {
         // new calls. Previously we used the `.call()` functionality to do a batch of calls in one
         // go. Now we will use the `.send()` functionality to broadcast a batch of transactions
         // in one go
-        let multicall_send = multicall
-            .clone()
+        let mut multicall_send = multicall.clone();
+        multicall_send
             .clear_calls()
             .add_call(broadcast)
             .add_call(broadcast2);
@@ -321,8 +323,7 @@ mod eth_tests {
         // query ETH balances of multiple addresses
         // these keys haven't been used to do any tx
         // so should have 100 ETH
-        let multicall = multicall
-            .clear_calls()
+        multicall.clear_calls()
             .eth_balance_of(Address::from(&ganache.keys()[4]))
             .eth_balance_of(Address::from(&ganache.keys()[5]))
             .eth_balance_of(Address::from(&ganache.keys()[6]));


### PR DESCRIPTION
If we use Multicall with a Websocket provider, we're unable to clone it (due to `Ws` not being `Clone` fundamentally), so it's preferable to make the functions work by reference instead.