### PR TITLE
Monomorphic provider

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -67,11 +67,11 @@ impl Context {
 
                 #struct_decl
 
-                impl<'a, P: JsonRpcClient, S: Signer> #name<P, S> {
+                impl<'a, S: Signer> #name<S> {
                     /// Creates a new contract instance with the specified `ethers`
                     /// client at the given `Address`. The contract derefs to a `ethers::Contract`
                     /// object
-                    pub fn new<T: Into<Address>, C: Into<Arc<Client<P, S>>>>(address: T, client: C) -> Self {
+                    pub fn new<T: Into<Address>, C: Into<Arc<Client<S>>>>(address: T, client: C) -> Self {
                         let contract = Contract::new(address.into(), #abi_name.clone(), client.into());
                         Self(contract)
                     }

--- a/ethers-contract/ethers-contract-abigen/src/contract/common.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/common.rs
@@ -36,17 +36,17 @@ pub(crate) fn struct_declaration(cx: &Context, abi_name: &proc_macro2::Ident) ->
 
         // Struct declaration
         #[derive(Clone)]
-        pub struct #name<P, S>(Contract<P, S>);
+        pub struct #name<S>(Contract<S>);
 
 
         // Deref to the inner contract in order to access more specific functions functions
-        impl<P, S> std::ops::Deref for #name<P, S> {
-            type Target = Contract<P, S>;
+        impl<S> std::ops::Deref for #name<S> {
+            type Target = Contract<S>;
 
             fn deref(&self) -> &Self::Target { &self.0 }
         }
 
-        impl<P: JsonRpcClient, S: Signer> std::fmt::Debug for #name<P, S> {
+        impl<S: Signer> std::fmt::Debug for #name<S> {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
                 f.debug_tuple(stringify!(#name))
                     .field(&self.address())

--- a/ethers-contract/ethers-contract-abigen/src/contract/events.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/events.rs
@@ -319,7 +319,7 @@ mod tests {
 
         assert_quote!(expand_filter(&event).unwrap(), {
             #[doc = "Gets the contract's `Transfer` event"]
-            pub fn transfer_filter(&self) -> Event<P, TransferFilter> {
+            pub fn transfer_filter(&self) -> Event<TransferFilter> {
                 self.0
                     .event("Transfer")
                     .expect("event not found (this should never happen)")

--- a/ethers-contract/ethers-contract-abigen/src/contract/events.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/events.rs
@@ -56,7 +56,7 @@ fn expand_filter(event: &Event) -> Result<TokenStream> {
     Ok(quote! {
 
         #doc
-        pub fn #name(&self) -> Event<P, #result> {
+        pub fn #name(&self) -> Event<#result> {
             self.0.event(#ev_name).expect("event not found (this should never happen)")
         }
     })

--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -40,7 +40,7 @@ fn expand_function(function: &Function, alias: Option<Ident>) -> Result<TokenStr
 
     let outputs = expand_fn_outputs(&function.outputs)?;
 
-    let result = quote! { ContractCall<P, S, #outputs> };
+    let result = quote! { ContractCall<S, #outputs> };
 
     let arg = expand_inputs_call_arg(&function.inputs);
     let doc = util::expand_doc(&format!(

--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -2,7 +2,7 @@ use ethers_core::{
     abi::{Detokenize, Error as AbiError, Function, InvalidOutputType},
     types::{Address, BlockNumber, Bytes, TransactionRequest, TxHash, U256},
 };
-use ethers_providers::{JsonRpcClient, ProviderError};
+use ethers_providers::ProviderError;
 use ethers_signers::{Client, ClientError, Signer};
 
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
@@ -42,18 +42,18 @@ pub enum ContractError {
 #[derive(Debug, Clone)]
 #[must_use = "contract calls do nothing unless you `send` or `call` them"]
 /// Helper for managing a transaction before submitting it to a node
-pub struct ContractCall<P, S, D> {
+pub struct ContractCall<S, D> {
     /// The raw transaction object
     pub tx: TransactionRequest,
     /// The ABI of the function being called
     pub function: Function,
     /// Optional block number to be used when calculating the transaction's gas and nonce
     pub block: Option<BlockNumber>,
-    pub(crate) client: Arc<Client<P, S>>,
+    pub(crate) client: Arc<Client<S>>,
     pub(crate) datatype: PhantomData<D>,
 }
 
-impl<P, S, D: Detokenize> ContractCall<P, S, D> {
+impl<S, D: Detokenize> ContractCall<S, D> {
     /// Sets the `from` field in the transaction to the provided value
     pub fn from<T: Into<Address>>(mut self, from: T) -> Self {
         self.tx.from = Some(from.into());
@@ -85,10 +85,9 @@ impl<P, S, D: Detokenize> ContractCall<P, S, D> {
     }
 }
 
-impl<P, S, D> ContractCall<P, S, D>
+impl<S, D> ContractCall<S, D>
 where
     S: Signer,
-    P: JsonRpcClient,
     D: Detokenize,
 {
     /// Returns the underlying transaction's ABI encoded data

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -4,7 +4,7 @@ use ethers_core::{
     abi::{Abi, Detokenize, Error, EventExt, Function, FunctionExt, Tokenize},
     types::{Address, Filter, NameOrAddress, Selector, TransactionRequest, TxHash},
 };
-use ethers_providers::{JsonRpcClient, PendingTransaction};
+use ethers_providers::PendingTransaction;
 use ethers_signers::{Client, Signer};
 
 use rustc_hex::ToHex;

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -74,7 +74,7 @@ use std::{collections::HashMap, fmt::Debug, hash::Hash, marker::PhantomData, syn
 /// let abi: Abi = serde_json::from_str(r#"[{"inputs":[{"internalType":"string","name":"value","type":"string"}],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"author","type":"address"},{"indexed":true,"internalType":"address","name":"oldAuthor","type":"address"},{"indexed":false,"internalType":"string","name":"oldValue","type":"string"},{"indexed":false,"internalType":"string","name":"newValue","type":"string"}],"name":"ValueChanged","type":"event"},{"inputs":[],"name":"getValue","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"lastSender","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"string","name":"value","type":"string"}],"name":"setValue","outputs":[],"stateMutability":"nonpayable","type":"function"}]"#)?;
 ///
 /// // connect to the network
-/// let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
+/// let provider = Provider::try_from("http://localhost:8545").unwrap();
 /// let client = "380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc"
 ///     .parse::<Wallet>()?.connect(provider);
 ///
@@ -115,7 +115,7 @@ use std::{collections::HashMap, fmt::Debug, hash::Hash, marker::PhantomData, syn
 /// # // this is a fake address used just for this example
 /// # let address = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".parse::<Address>()?;
 /// # let abi: Abi = serde_json::from_str(r#"[]"#)?;
-/// # let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
+/// # let provider = Provider::try_from("http://localhost:8545").unwrap();
 /// # let client = "380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc".parse::<Wallet>()?.connect(provider);
 /// # let contract = Contract::new(address, abi, client);
 ///

--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -1,6 +1,6 @@
 use crate::ContractError;
 
-use ethers_providers::{FilterStream, JsonRpcClient, Provider};
+use ethers_providers::{FilterStream, Provider};
 
 use ethers_core::{
     abi::{Detokenize, Event as AbiEvent, RawLog},
@@ -13,17 +13,17 @@ use std::marker::PhantomData;
 /// Helper for managing the event filter before querying or streaming its logs
 #[derive(Debug)]
 #[must_use = "event filters do nothing unless you `query` or `stream` them"]
-pub struct Event<'a: 'b, 'b, P, D> {
+pub struct Event<'a: 'b, 'b, D> {
     /// The event filter's state
     pub filter: Filter,
     /// The ABI of the event which is being filtered
     pub event: &'b AbiEvent,
-    pub(crate) provider: &'a Provider<P>,
+    pub(crate) provider: &'a Provider,
     pub(crate) datatype: PhantomData<D>,
 }
 
 // TODO: Improve these functions
-impl<P, D: Detokenize> Event<'_, '_, P, D> {
+impl<D: Detokenize> Event<'_, '_, D> {
     /// Sets the filter's `from` block
     #[allow(clippy::wrong_self_convention)]
     pub fn from_block<T: Into<BlockNumber>>(mut self, block: T) -> Self {
@@ -63,9 +63,8 @@ impl<P, D: Detokenize> Event<'_, '_, P, D> {
     }
 }
 
-impl<'a, 'b, P, D> Event<'a, 'b, P, D>
+impl<'a, 'b, D> Event<'a, 'b, D>
 where
-    P: JsonRpcClient,
     D: 'b + Detokenize + Clone,
     'a: 'b,
 {
@@ -78,9 +77,8 @@ where
     }
 }
 
-impl<P, D> Event<'_, '_, P, D>
+impl<D> Event<'_, '_, D>
 where
-    P: JsonRpcClient,
     D: Detokenize + Clone,
 {
     /// Queries the blockchain for the selected filter and returns a vector of matching

--- a/ethers-contract/src/factory.rs
+++ b/ethers-contract/src/factory.rs
@@ -103,7 +103,7 @@ where
 ///     .expect("could not find contract");
 ///
 /// // connect to the network
-/// let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
+/// let provider = Provider::try_from("http://localhost:8545").unwrap();
 /// let client = "380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc"
 ///     .parse::<Wallet>()?.connect(provider);
 ///

--- a/ethers-contract/src/factory.rs
+++ b/ethers-contract/src/factory.rs
@@ -4,7 +4,6 @@ use ethers_core::{
     abi::{Abi, Tokenize},
     types::{BlockNumber, Bytes, TransactionRequest},
 };
-use ethers_providers::JsonRpcClient;
 use ethers_signers::{Client, Signer};
 
 use std::{sync::Arc, time::Duration};

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -2,7 +2,6 @@ use ethers_core::{
     abi::{Detokenize, Function, Token},
     types::{Address, BlockNumber, NameOrAddress, TxHash, U256},
 };
-use ethers_providers::JsonRpcClient;
 use ethers_signers::{Client, Signer};
 
 use std::{collections::HashMap, str::FromStr, sync::Arc};

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -75,7 +75,7 @@ pub static ADDRESS_BOOK: Lazy<HashMap<U256, Address>> = Lazy::new(|| {
 /// let abi: Abi = serde_json::from_str(r#"[{"inputs":[{"internalType":"string","name":"value","type":"string"}],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"author","type":"address"},{"indexed":true,"internalType":"address","name":"oldAuthor","type":"address"},{"indexed":false,"internalType":"string","name":"oldValue","type":"string"},{"indexed":false,"internalType":"string","name":"newValue","type":"string"}],"name":"ValueChanged","type":"event"},{"inputs":[],"name":"getValue","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"lastSender","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"string","name":"value","type":"string"}],"name":"setValue","outputs":[],"stateMutability":"nonpayable","type":"function"}]"#)?;
 ///
 /// // connect to the network
-/// let provider = Provider::<Http>::try_from("https://kovan.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27")?;
+/// let provider = Provider::try_from("https://kovan.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27")?;
 /// let client = "380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc"
 ///     .parse::<Wallet>()?.connect(provider);
 ///
@@ -237,7 +237,7 @@ impl<S: Signer> Multicall<S> {
     /// # use ethers::prelude::*;
     /// # use std::{sync::Arc, convert::TryFrom};
     /// #
-    /// # let provider = Provider::<Http>::try_from("http://localhost:8545")?;
+    /// # let provider = Provider::try_from("http://localhost:8545")?;
     /// # let client = "380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc"
     /// #     .parse::<Wallet>()?.connect(provider);
     /// # let client = Arc::new(client);
@@ -282,7 +282,7 @@ impl<S: Signer> Multicall<S> {
     /// # use ethers::prelude::*;
     /// # use std::convert::TryFrom;
     /// #
-    /// # let provider = Provider::<Http>::try_from("http://localhost:8545")?;
+    /// # let provider = Provider::try_from("http://localhost:8545")?;
     /// # let client = "380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc"
     /// #     .parse::<Wallet>()?.connect(provider);
     /// #
@@ -336,7 +336,7 @@ impl<S: Signer> Multicall<S> {
     /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
     /// # use ethers::prelude::*;
     /// # use std::convert::TryFrom;
-    /// # let provider = Provider::<Http>::try_from("http://localhost:8545")?;
+    /// # let provider = Provider::try_from("http://localhost:8545")?;
     /// # let client = "380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc"
     /// #     .parse::<Wallet>()?.connect(provider);
     /// # let multicall = Multicall::new(client, None).await?;

--- a/ethers-contract/src/multicall/multicall_contract.rs
+++ b/ethers-contract/src/multicall/multicall_contract.rs
@@ -18,25 +18,25 @@ mod multicallcontract_mod {
         serde_json :: from_str ( "[{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"callData\",\"type\":\"bytes\"}],\"internalType\":\"struct MulticallContract.Call[]\",\"name\":\"calls\",\"type\":\"tuple[]\"}],\"name\":\"aggregate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"},{\"internalType\":\"bytes[]\",\"name\":\"returnData\",\"type\":\"bytes[]\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"name\":\"getBlockHash\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"blockHash\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getCurrentBlockCoinbase\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"coinbase\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getCurrentBlockDifficulty\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"difficulty\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getCurrentBlockGasLimit\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"gaslimit\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getCurrentBlockTimestamp\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"getEthBalance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getLastBlockHash\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"blockHash\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]" ) . expect ( "invalid abi" )
     });
     #[derive(Clone)]
-    pub struct MulticallContract<P, S>(Contract<P, S>);
-    impl<P, S> std::ops::Deref for MulticallContract<P, S> {
-        type Target = Contract<P, S>;
+    pub struct MulticallContract<S>(Contract<S>);
+    impl<S> std::ops::Deref for MulticallContract<S> {
+        type Target = Contract<S>;
         fn deref(&self) -> &Self::Target {
             &self.0
         }
     }
-    impl<P: JsonRpcClient, S: Signer> std::fmt::Debug for MulticallContract<P, S> {
+    impl<S: Signer> std::fmt::Debug for MulticallContract<S> {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
             f.debug_tuple(stringify!(MulticallContract))
                 .field(&self.address())
                 .finish()
         }
     }
-    impl<'a, P: JsonRpcClient, S: Signer> MulticallContract<P, S> {
+    impl<'a, S: Signer> MulticallContract<S> {
         #[doc = r" Creates a new contract instance with the specified `ethers`"]
         #[doc = r" client at the given `Address`. The contract derefs to a `ethers::Contract`"]
         #[doc = r" object"]
-        pub fn new<T: Into<Address>, C: Into<Arc<Client<P, S>>>>(address: T, client: C) -> Self {
+        pub fn new<T: Into<Address>, C: Into<Arc<Client<S>>>>(address: T, client: C) -> Self {
             let contract =
                 Contract::new(address.into(), MULTICALLCONTRACT_ABI.clone(), client.into());
             Self(contract)
@@ -45,49 +45,49 @@ mod multicallcontract_mod {
         pub fn aggregate(
             &self,
             calls: Vec<(Address, Vec<u8>)>,
-        ) -> ContractCall<P, S, (U256, Vec<Vec<u8>>)> {
+        ) -> ContractCall<S, (U256, Vec<Vec<u8>>)> {
             self.0
                 .method_hash([37, 45, 186, 66], calls)
                 .expect("method not found (this should never happen)")
         }
         #[doc = "Calls the contract's `getCurrentBlockDifficulty` (0x72425d9d) function"]
-        pub fn get_current_block_difficulty(&self) -> ContractCall<P, S, U256> {
+        pub fn get_current_block_difficulty(&self) -> ContractCall<S, U256> {
             self.0
                 .method_hash([114, 66, 93, 157], ())
                 .expect("method not found (this should never happen)")
         }
         #[doc = "Calls the contract's `getCurrentBlockGasLimit` (0x86d516e8) function"]
-        pub fn get_current_block_gas_limit(&self) -> ContractCall<P, S, U256> {
+        pub fn get_current_block_gas_limit(&self) -> ContractCall<S, U256> {
             self.0
                 .method_hash([134, 213, 22, 232], ())
                 .expect("method not found (this should never happen)")
         }
         #[doc = "Calls the contract's `getCurrentBlockTimestamp` (0x0f28c97d) function"]
-        pub fn get_current_block_timestamp(&self) -> ContractCall<P, S, U256> {
+        pub fn get_current_block_timestamp(&self) -> ContractCall<S, U256> {
             self.0
                 .method_hash([15, 40, 201, 125], ())
                 .expect("method not found (this should never happen)")
         }
         #[doc = "Calls the contract's `getCurrentBlockCoinbase` (0xa8b0574e) function"]
-        pub fn get_current_block_coinbase(&self) -> ContractCall<P, S, Address> {
+        pub fn get_current_block_coinbase(&self) -> ContractCall<S, Address> {
             self.0
                 .method_hash([168, 176, 87, 78], ())
                 .expect("method not found (this should never happen)")
         }
         #[doc = "Calls the contract's `getBlockHash` (0xee82ac5e) function"]
-        pub fn get_block_hash(&self, block_number: U256) -> ContractCall<P, S, [u8; 32]> {
+        pub fn get_block_hash(&self, block_number: U256) -> ContractCall<S, [u8; 32]> {
             self.0
                 .method_hash([238, 130, 172, 94], block_number)
                 .expect("method not found (this should never happen)")
         }
         #[doc = "Calls the contract's `getEthBalance` (0x4d2301cc) function"]
-        pub fn get_eth_balance(&self, addr: Address) -> ContractCall<P, S, U256> {
+        pub fn get_eth_balance(&self, addr: Address) -> ContractCall<S, U256> {
             self.0
                 .method_hash([77, 35, 1, 204], addr)
                 .expect("method not found (this should never happen)")
         }
         #[doc = "Calls the contract's `getLastBlockHash` (0x27e86d6e) function"]
-        pub fn get_last_block_hash(&self) -> ContractCall<P, S, [u8; 32]> {
+        pub fn get_last_block_hash(&self) -> ContractCall<S, [u8; 32]> {
             self.0
                 .method_hash([39, 232, 109, 110], ())
                 .expect("method not found (this should never happen)")

--- a/ethers-contract/tests/common/mod.rs
+++ b/ethers-contract/tests/common/mod.rs
@@ -5,7 +5,7 @@ use ethers_core::{
 
 use ethers_contract::{Contract, ContractFactory};
 use ethers_core::utils::{GanacheInstance, Solc};
-use ethers_providers::{Http, Provider};
+use ethers_providers::Provider;
 use ethers_signers::{Client, Wallet};
 use std::{convert::TryFrom, sync::Arc, time::Duration};
 
@@ -44,8 +44,8 @@ pub fn compile_contract(name: &str, filename: &str) -> (Abi, Bytes) {
 }
 
 /// connects the private key to http://localhost:8545
-pub fn connect(ganache: &GanacheInstance, idx: usize) -> Arc<Client<Http, Wallet>> {
-    let provider = Provider::<Http>::try_from(ganache.endpoint()).unwrap();
+pub fn connect(ganache: &GanacheInstance, idx: usize) -> Arc<Client<Wallet>> {
+    let provider = Provider::try_from(ganache.endpoint()).unwrap();
     let wallet: Wallet = ganache.keys()[idx].clone().into();
     Arc::new(
         wallet
@@ -55,11 +55,7 @@ pub fn connect(ganache: &GanacheInstance, idx: usize) -> Arc<Client<Http, Wallet
 }
 
 /// Launches a ganache instance and deploys the SimpleStorage contract
-pub async fn deploy(
-    client: Arc<Client<Http, Wallet>>,
-    abi: Abi,
-    bytecode: Bytes,
-) -> Contract<Http, Wallet> {
+pub async fn deploy(client: Arc<Client<Wallet>>, abi: Abi, bytecode: Bytes) -> Contract<Wallet> {
     let factory = ContractFactory::new(abi, bytecode, client);
     factory
         .deploy("initial value".to_string())

--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -8,7 +8,7 @@ mod eth_tests {
     use super::*;
     use ethers::{
         contract::Multicall,
-        providers::{Http, Provider, StreamExt},
+        providers::{Provider, StreamExt},
         signers::Client,
         types::{Address, U256},
         utils::Ganache,
@@ -159,7 +159,7 @@ mod eth_tests {
         let ganache = Ganache::new().spawn();
 
         // connect
-        let provider = Provider::<Http>::try_from(ganache.endpoint())
+        let provider = Provider::try_from(ganache.endpoint())
             .unwrap()
             .interval(std::time::Duration::from_millis(50u64));
 
@@ -336,11 +336,7 @@ mod eth_tests {
 #[cfg(feature = "celo")]
 mod celo_tests {
     use super::*;
-    use ethers::{
-        providers::{Http, Provider},
-        signers::Wallet,
-        types::BlockNumber,
-    };
+    use ethers::{providers::Provider, signers::Wallet, types::BlockNumber};
     use std::{convert::TryFrom, sync::Arc, time::Duration};
 
     #[tokio::test]
@@ -348,8 +344,7 @@ mod celo_tests {
         let (abi, bytecode) = compile_contract("SimpleStorage", "SimpleStorage.sol");
 
         // Celo testnet
-        let provider =
-            Provider::<Http>::try_from("https://alfajores-forno.celo-testnet.org").unwrap();
+        let provider = Provider::try_from("https://alfajores-forno.celo-testnet.org").unwrap();
 
         // Funded with https://celo.org/developers/faucet
         let client = "d652abb81e8c686edba621a895531b1f291289b63b5ef09a94f686a5ecdd5db1"

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -15,7 +15,7 @@
 //! use std::convert::TryFrom;
 //!
 //! # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
-//! let provider = Provider::<Http>::try_from(
+//! let provider = Provider::try_from(
 //!     "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27"
 //! )?;
 //!
@@ -86,7 +86,7 @@
 //! # use ethers::providers::{Provider, Http};
 //! # use std::convert::TryFrom;
 //! # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
-//! # let provider = Provider::<Http>::try_from(
+//! # let provider = Provider::try_from(
 //! #     "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27"
 //! # )?;
 //! // Resolve ENS name to Address

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -69,7 +69,6 @@ impl Clone for ProviderType {
                 any(feature = "tokio-runtime", feature = "async-std-runtime")
             ))]
             ProviderType::Ws(ref ws_provider) => ProviderType::Ws(ws_provider.clone()),
-            _ => unimplemented!("unknown provider type in default implementation"),
         }
     }
 }
@@ -98,7 +97,6 @@ impl JsonRpcClient for ProviderType {
                 .request(method, params)
                 .await
                 .map_err(Into::into),
-            _ => unimplemented!("unknown provider type in default implementation"),
         }
     }
 }
@@ -113,11 +111,11 @@ impl JsonRpcClient for ProviderType {
 /// use ethers::providers::{JsonRpcClient, Provider, Http};
 /// use std::convert::TryFrom;
 ///
-/// let provider = Provider::<Http>::try_from(
+/// let provider = Provider::try_from(
 ///     "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27"
 /// ).expect("could not instantiate HTTP Provider");
 ///
-/// # async fn foo<P: JsonRpcClient>(provider: &Provider<P>) -> Result<(), Box<dyn std::error::Error>> {
+/// # async fn foo(provider: &Provider) -> Result<(), Box<dyn std::error::Error>> {
 /// let block = provider.get_block(100u64).await?;
 /// println!("Got block: {}", serde_json::to_string(&block)?);
 /// # Ok(())

--- a/ethers-providers/src/transports/mod.rs
+++ b/ethers-providers/src/transports/mod.rs
@@ -4,6 +4,6 @@ mod http;
 pub use http::Provider as Http;
 
 #[cfg(feature = "ws")]
-mod ws;
+pub(crate) mod ws;
 #[cfg(feature = "ws")]
 pub use ws::Provider as Ws;

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -9,8 +9,8 @@ use futures_util::{
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use thiserror::Error;
 
 use super::common::{JsonRpcError, Request, ResponseData};
@@ -98,9 +98,7 @@ pub struct Provider<S> {
 
 impl<S> std::fmt::Debug for Provider<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Ws provider")
-         .field("id", &self.id)
-         .finish()
+        f.debug_struct("Ws provider").field("id", &self.id).finish()
     }
 }
 
@@ -206,7 +204,7 @@ impl<S> Clone for Provider<S> {
     fn clone(&self) -> Self {
         Self {
             id: Arc::clone(&self.id),
-            ws: Arc::clone(&self.ws)
+            ws: Arc::clone(&self.ws),
         }
     }
 }

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -1,7 +1,7 @@
 #![allow(unused_braces)]
 use ethers::providers::{
     gas_oracle::{EthGasStation, Etherchain, Etherscan, GasCategory, GasNow, GasOracle},
-    Http, Provider,
+    Provider,
 };
 use std::{convert::TryFrom, time::Duration};
 
@@ -9,7 +9,6 @@ use std::{convert::TryFrom, time::Duration};
 mod eth_tests {
     use super::*;
     use ethers::{
-        providers::JsonRpcClient,
         types::TransactionRequest,
         utils::{parse_ether, Ganache},
     };
@@ -100,12 +99,10 @@ mod eth_tests {
         let data_4 = etherchain_oracle.fetch().await;
         assert!(data_4.is_ok());
 
-        // TODO: Temporarily disabled SparkPool's GasOracle while the API is still
-        // evolving.
-        // // initialize and fetch gas estimates from SparkPool
-        // let gas_now_oracle = GasNow::new().category(GasCategory::Fastest);
-        // let data_5 = gas_now_oracle.fetch().await;
-        // assert!(data_5.is_ok());
+        // initialize and fetch gas estimates from SparkPool
+        let gas_now_oracle = GasNow::new().category(GasCategory::Fastest);
+        let data_5 = gas_now_oracle.fetch().await;
+        assert!(data_5.is_ok());
     }
 
     async fn generic_pending_txs_test(provider: Provider) {
@@ -135,7 +132,7 @@ mod celo_tests {
     // https://alfajores-blockscout.celo-testnet.org/tx/0x544ea96cddb16aeeaedaf90885c1e02be4905f3eb43d6db3f28cac4dbe76a625/internal_transactions
     async fn get_transaction() {
         let provider =
-            Provider::<Http>::try_from("https://alfajores-forno.celo-testnet.org").unwrap();
+            Provider::try_from("https://alfajores-forno.celo-testnet.org").unwrap();
 
         let tx_hash = "c8496681d0ade783322980cce00c89419fce4b484635d9e09c79787a0f75d450"
             .parse::<H256>()
@@ -150,7 +147,7 @@ mod celo_tests {
     #[tokio::test]
     async fn get_block() {
         let provider =
-            Provider::<Http>::try_from("https://alfajores-forno.celo-testnet.org").unwrap();
+            Provider::try_from("https://alfajores-forno.celo-testnet.org").unwrap();
 
         let block = provider.get_block(447254).await.unwrap();
         assert_eq!(
@@ -170,7 +167,7 @@ mod celo_tests {
 
     #[tokio::test]
     async fn watch_blocks() {
-        let provider = Provider::<Http>::try_from("https://alfajores-forno.celo-testnet.org")
+        let provider = Provider::try_from("https://alfajores-forno.celo-testnet.org")
             .unwrap()
             .interval(Duration::from_millis(2000u64));
 

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -60,7 +60,7 @@ mod eth_tests {
     #[tokio::test]
     async fn pending_txs_with_confirmations_ganache() {
         let ganache = Ganache::new().block_time(2u64).spawn();
-        let provider = Provider::<Http>::try_from(ganache.endpoint())
+        let provider = Provider::try_from(ganache.endpoint())
             .unwrap()
             .interval(Duration::from_millis(500u64));
         generic_pending_txs_test(provider).await;
@@ -108,7 +108,7 @@ mod eth_tests {
         // assert!(data_5.is_ok());
     }
 
-    async fn generic_pending_txs_test<P: JsonRpcClient>(provider: Provider<P>) {
+    async fn generic_pending_txs_test(provider: Provider) {
         let accounts = provider.get_accounts().await.unwrap();
 
         let tx = TransactionRequest::pay(accounts[0], parse_ether(1u64).unwrap()).from(accounts[0]);

--- a/ethers-signers/src/client.rs
+++ b/ethers-signers/src/client.rs
@@ -69,8 +69,8 @@ use thiserror::Error;
 /// ```
 ///
 /// [`Provider`]: ethers_providers::Provider
-pub struct Client<P, S> {
-    pub(crate) provider: Provider<P>,
+pub struct Client<S> {
+    pub(crate) provider: Provider,
     pub(crate) signer: Option<S>,
     pub(crate) address: Address,
     pub(crate) gas_oracle: Option<Box<dyn GasOracle>>,
@@ -97,13 +97,9 @@ pub enum ClientError {
 }
 
 // Helper functions for locally signing transactions
-impl<P, S> Client<P, S>
-where
-    P: JsonRpcClient,
-    S: Signer,
-{
+impl<S: Signer> Client<S> {
     /// Creates a new client from the provider and signer.
-    pub fn new(provider: Provider<P>, signer: S) -> Self {
+    pub fn new(provider: Provider, signer: S) -> Self {
         let address = signer.address();
         Client {
             provider,
@@ -189,7 +185,7 @@ where
     }
 
     /// Returns a reference to the client's provider
-    pub fn provider(&self) -> &Provider<P> {
+    pub fn provider(&self) -> &Provider {
         &self.provider
     }
 
@@ -212,7 +208,7 @@ where
     /// calls.
     ///
     /// Clones internally.
-    pub fn with_provider(&mut self, provider: Provider<P>) -> &Self {
+    pub fn with_provider(&mut self, provider: Provider) -> &Self {
         self.provider = provider;
         self
     }
@@ -267,16 +263,16 @@ where
 // Abuse Deref to use the Provider's methods without re-writing everything.
 // This is an anti-pattern and should not be encouraged, but this improves the UX while
 // keeping the LoC low
-impl<P, S> Deref for Client<P, S> {
-    type Target = Provider<P>;
+impl<S> Deref for Client<S> {
+    type Target = Provider;
 
     fn deref(&self) -> &Self::Target {
         &self.provider
     }
 }
 
-impl<P: JsonRpcClient, S> From<Provider<P>> for Client<P, S> {
-    fn from(provider: Provider<P>) -> Self {
+impl<S> From<Provider> for Client<S> {
+    fn from(provider: Provider) -> Self {
         Self {
             provider,
             signer: None,

--- a/ethers-signers/src/client.rs
+++ b/ethers-signers/src/client.rs
@@ -5,7 +5,7 @@ use ethers_core::types::{
 };
 use ethers_providers::{
     gas_oracle::{GasOracle, GasOracleError},
-    JsonRpcClient, Provider, ProviderError,
+    Provider, ProviderError,
 };
 
 use futures_util::{future::ok, join};
@@ -27,7 +27,7 @@ use thiserror::Error;
 /// use std::convert::TryFrom;
 ///
 /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
-/// let provider = Provider::<Http>::try_from("http://localhost:8545")
+/// let provider = Provider::try_from("http://localhost:8545")
 ///     .expect("could not instantiate HTTP Provider");
 ///
 /// // By default, signing of messages and transactions is done locally

--- a/ethers-signers/src/lib.rs
+++ b/ethers-signers/src/lib.rs
@@ -11,7 +11,7 @@
 //! # use std::convert::TryFrom;
 //! # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
 //! // connect to the network
-//! let provider = Provider::<Http>::try_from("http://localhost:8545")?;
+//! let provider = Provider::try_from("http://localhost:8545")?;
 //!
 //! // instantiate the wallet and connect it to the provider to get a client
 //! let client = "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7"

--- a/ethers-signers/src/lib.rs
+++ b/ethers-signers/src/lib.rs
@@ -44,7 +44,6 @@ mod client;
 pub use client::{Client, ClientError};
 
 use ethers_core::types::{Address, Signature, Transaction, TransactionRequest};
-use ethers_providers::Http;
 use std::error::Error;
 
 /// Trait for signing transactions and messages
@@ -62,6 +61,3 @@ pub trait Signer: Clone + Send + Sync {
     /// Returns the signer's Ethereum Address
     fn address(&self) -> Address;
 }
-
-/// An HTTP client configured to work with ANY blockchain without replay protection
-pub type HttpClient = Client<Http, Wallet>;

--- a/ethers-signers/src/wallet.rs
+++ b/ethers-signers/src/wallet.rs
@@ -50,7 +50,7 @@ use std::str::FromStr;
 /// use std::convert::TryFrom;
 ///
 /// // create a provider
-/// let provider = Provider::<Http>::try_from("http://localhost:8545")
+/// let provider = Provider::try_from("http://localhost:8545")
 ///     .expect("could not instantiate HTTP Provider");
 ///
 /// // generate a wallet and connect to the provider

--- a/ethers-signers/src/wallet.rs
+++ b/ethers-signers/src/wallet.rs
@@ -115,7 +115,7 @@ impl Wallet {
     }
 
     /// Connects to a provider and returns a client
-    pub fn connect<P: JsonRpcClient>(self, provider: Provider<P>) -> Client<P, Wallet> {
+    pub fn connect(self, provider: Provider) -> Client<Wallet> {
         let address = self.address();
         Client {
             address,

--- a/ethers-signers/src/wallet.rs
+++ b/ethers-signers/src/wallet.rs
@@ -1,6 +1,6 @@
 use crate::{Client, ClientError, Signer};
 
-use ethers_providers::{JsonRpcClient, Provider};
+use ethers_providers::Provider;
 
 use ethers_core::{
     rand::Rng,

--- a/ethers-signers/tests/signer.rs
+++ b/ethers-signers/tests/signer.rs
@@ -1,7 +1,7 @@
 use ethers::{
     providers::{
         gas_oracle::{Etherchain, GasCategory, GasOracle},
-        Http, Provider,
+        Provider,
     },
     signers::Wallet,
     types::TransactionRequest,
@@ -112,7 +112,7 @@ mod celo_tests {
     #[tokio::test]
     async fn test_send_transaction() {
         // Celo testnet
-        let provider = Provider::<Http>::try_from("https://alfajores-forno.celo-testnet.org")
+        let provider = Provider::try_from("https://alfajores-forno.celo-testnet.org")
             .unwrap()
             .interval(Duration::from_millis(3000u64));
 

--- a/ethers-signers/tests/signer.rs
+++ b/ethers-signers/tests/signer.rs
@@ -18,11 +18,10 @@ mod eth_tests {
 
     #[tokio::test]
     async fn pending_txs_with_confirmations_rinkeby_infura() {
-        let provider = Provider::<Http>::try_from(
-            "https://rinkeby.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27",
-        )
-        .unwrap()
-        .interval(Duration::from_millis(2000u64));
+        let provider =
+            Provider::try_from("https://rinkeby.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27")
+                .unwrap()
+                .interval(Duration::from_millis(2000u64));
 
         // pls do not drain this key :)
         // note: this works even if there's no EIP-155 configured!
@@ -55,7 +54,7 @@ mod eth_tests {
         let wallet2: Wallet = ganache.keys()[1].clone().into();
 
         // connect to the network
-        let provider = Provider::<Http>::try_from(ganache.endpoint())
+        let provider = Provider::try_from(ganache.endpoint())
             .unwrap()
             .interval(Duration::from_millis(10u64));
 
@@ -84,7 +83,7 @@ mod eth_tests {
         let wallet2: Wallet = ganache.keys()[1].clone().into();
 
         // connect to the network
-        let provider = Provider::<Http>::try_from(ganache.endpoint())
+        let provider = Provider::try_from(ganache.endpoint())
             .unwrap()
             .interval(Duration::from_millis(10u64));
 

--- a/ethers/examples/contract.rs
+++ b/ethers/examples/contract.rs
@@ -27,8 +27,7 @@ async fn main() -> Result<()> {
     let wallet: Wallet = ganache.keys()[0].clone().into();
 
     // 4. connect to the network
-    let provider =
-        Provider::<Http>::try_from(ganache.endpoint())?.interval(Duration::from_millis(10u64));
+    let provider = Provider::try_from(ganache.endpoint())?.interval(Duration::from_millis(10u64));
 
     // 5. instantiate the client with the wallet
     let client = wallet.connect(provider);

--- a/ethers/examples/ens.rs
+++ b/ethers/examples/ens.rs
@@ -5,9 +5,8 @@ use std::convert::TryFrom;
 #[tokio::main]
 async fn main() -> Result<()> {
     // connect to the network
-    let provider = Provider::<Http>::try_from(
-        "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27",
-    )?;
+    let provider =
+        Provider::try_from("https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27")?;
 
     // create a wallet and connect it to the provider
     let client = "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7"

--- a/ethers/examples/local_signer.rs
+++ b/ethers/examples/local_signer.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<()> {
     let wallet2: Wallet = ganache.keys()[1].clone().into();
 
     // connect to the network
-    let provider = Provider::<Http>::try_from(ganache.endpoint())?;
+    let provider = Provider::try_from(ganache.endpoint())?;
 
     // connect the wallet to the provider
     let client = wallet.connect(provider);

--- a/ethers/examples/transfer_eth.rs
+++ b/ethers/examples/transfer_eth.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<()> {
     let ganache = Ganache::new().spawn();
 
     // connect to the network
-    let provider = Provider::<Http>::try_from(ganache.endpoint())?;
+    let provider = Provider::try_from(ganache.endpoint())?;
     let accounts = provider.get_accounts().await?;
     let from = accounts[0];
     let to = accounts[1];


### PR DESCRIPTION
Replaces the generic `T: JsonRpcClient` with an `enum ProviderType` which contains Http and Ws internally. While this creates nicer interfaces, it makes the provider/client slightly less extendable, as it means you need to add an extra enum variant for every new provider type (vs just defining your own implementation of the trait and passing it to `Provider::new`). Unfortunately we cannot use `JsonRpcClient` as a trait object, due to the existence of generic parameters in the `request` function.