### PR TITLE
fix(BREAKING): return Option for txs/receipts/blocks

### DIFF
--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -53,8 +53,12 @@ mod eth_tests {
         let calldata = contract_call.calldata().unwrap();
         let gas_estimate = contract_call.estimate_gas().await.unwrap();
         let tx_hash = contract_call.send().await.unwrap();
-        let tx = client.get_transaction(tx_hash).await.unwrap();
-        let tx_receipt = client.get_transaction_receipt(tx_hash).await.unwrap();
+        let tx = client.get_transaction(tx_hash).await.unwrap().unwrap();
+        let tx_receipt = client
+            .get_transaction_receipt(tx_hash)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(last_sender.clone().call().await.unwrap(), client2.address());
         assert_eq!(get_value.clone().call().await.unwrap(), "hi");
         assert_eq!(tx.input, calldata);

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -614,10 +614,9 @@ mod ens_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Http;
     use ethers_core::types::H256;
     use futures_util::StreamExt;
-    use crate::Http;
-
 
     #[tokio::test]
     #[ignore]

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -677,33 +677,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
-    async fn non_existing_data_works() {
-        let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
-
-        assert!(provider
-            .get_transaction(H256::zero())
-            .await
-            .unwrap()
-            .is_none());
-        assert!(provider
-            .get_transaction_receipt(H256::zero())
-            .await
-            .unwrap()
-            .is_none());
-        assert!(provider
-            .get_block(BlockId::Hash(H256::zero()))
-            .await
-            .unwrap()
-            .is_none());
-        assert!(provider
-            .get_block_with_txs(BlockId::Hash(H256::zero()))
-            .await
-            .unwrap()
-            .is_none());
-    }
-
-    #[tokio::test]
     async fn receipt_on_unmined_tx() {
         use ethers_core::{
             types::TransactionRequest,

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -10,9 +10,36 @@ mod eth_tests {
     use super::*;
     use ethers::{
         providers::JsonRpcClient,
-        types::TransactionRequest,
+        types::{TransactionRequest, BlockId, H256},
         utils::{parse_ether, Ganache},
     };
+
+    #[tokio::test]
+    async fn non_existing_data_works() {
+        let provider = Provider::<Http>::try_from("https://rinkeby.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27").unwrap();
+
+        assert!(provider
+            .get_transaction(H256::zero())
+            .await
+            .unwrap()
+            .is_none());
+        assert!(provider
+            .get_transaction_receipt(H256::zero())
+            .await
+            .unwrap()
+            .is_none());
+        assert!(provider
+            .get_block(BlockId::Hash(H256::zero()))
+            .await
+            .unwrap()
+            .is_none());
+        assert!(provider
+            .get_block_with_txs(BlockId::Hash(H256::zero()))
+            .await
+            .unwrap()
+            .is_none());
+    }
+
 
     // Without TLS this would error with "TLS Support not compiled in"
     #[test]

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -10,13 +10,16 @@ mod eth_tests {
     use super::*;
     use ethers::{
         providers::JsonRpcClient,
-        types::{TransactionRequest, BlockId, H256},
+        types::{BlockId, TransactionRequest, H256},
         utils::{parse_ether, Ganache},
     };
 
     #[tokio::test]
     async fn non_existing_data_works() {
-        let provider = Provider::<Http>::try_from("https://rinkeby.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27").unwrap();
+        let provider = Provider::<Http>::try_from(
+            "https://rinkeby.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27",
+        )
+        .unwrap();
 
         assert!(provider
             .get_transaction(H256::zero())
@@ -39,7 +42,6 @@ mod eth_tests {
             .unwrap()
             .is_none());
     }
-
 
     // Without TLS this would error with "TLS Support not compiled in"
     #[test]
@@ -110,14 +112,17 @@ mod eth_tests {
         let data_1 = eth_gas_station_oracle.fetch().await;
         assert!(data_1.is_ok());
 
+        let api_key = std::env::var("ETHERSCAN_API_KEY").unwrap();
+        let api_key = Some(api_key.as_str());
+
         // initialize and fetch gas estimates from Etherscan
         // since etherscan does not support `fastest` category, we expect an error
-        let etherscan_oracle = Etherscan::new(None).category(GasCategory::Fastest);
+        let etherscan_oracle = Etherscan::new(api_key).category(GasCategory::Fastest);
         let data_2 = etherscan_oracle.fetch().await;
         assert!(data_2.is_err());
 
         // but fetching the `standard` gas price should work fine
-        let etherscan_oracle_2 = Etherscan::new(None).category(GasCategory::SafeLow);
+        let etherscan_oracle_2 = Etherscan::new(api_key).category(GasCategory::SafeLow);
 
         let data_3 = etherscan_oracle_2.fetch().await;
         assert!(data_3.is_ok());

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -138,7 +138,7 @@ mod celo_tests {
         let tx_hash = "c8496681d0ade783322980cce00c89419fce4b484635d9e09c79787a0f75d450"
             .parse::<H256>()
             .unwrap();
-        let tx = provider.get_transaction(tx_hash).await.unwrap();
+        let tx = provider.get_transaction(tx_hash).await.unwrap().unwrap();
         assert!(tx.gateway_fee_recipient.is_none());
         assert_eq!(tx.gateway_fee.unwrap(), 0.into());
         assert_eq!(tx.hash, tx_hash);
@@ -150,7 +150,7 @@ mod celo_tests {
         let provider =
             Provider::<Http>::try_from("https://alfajores-forno.celo-testnet.org").unwrap();
 
-        let block = provider.get_block(447254).await.unwrap();
+        let block = provider.get_block(447254).await.unwrap().unwrap();
         assert_eq!(
             block.randomness,
             Randomness {

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -100,12 +100,10 @@ mod eth_tests {
         let data_4 = etherchain_oracle.fetch().await;
         assert!(data_4.is_ok());
 
-        // TODO: Temporarily disabled SparkPool's GasOracle while the API is still
-        // evolving.
-        // // initialize and fetch gas estimates from SparkPool
-        // let gas_now_oracle = GasNow::new().category(GasCategory::Fastest);
-        // let data_5 = gas_now_oracle.fetch().await;
-        // assert!(data_5.is_ok());
+        // initialize and fetch gas estimates from SparkPool
+        let gas_now_oracle = GasNow::new().category(GasCategory::Fastest);
+        let data_5 = gas_now_oracle.fetch().await;
+        assert!(data_5.is_ok());
     }
 
     async fn generic_pending_txs_test<P: JsonRpcClient>(provider: Provider<P>) {

--- a/ethers-signers/tests/signer.rs
+++ b/ethers-signers/tests/signer.rs
@@ -114,6 +114,7 @@ mod eth_tests {
                     .get_transaction(tx_hash)
                     .await
                     .unwrap()
+                    .unwrap()
                     .nonce
                     .as_u64(),
             );
@@ -148,7 +149,7 @@ mod eth_tests {
         let tx = TransactionRequest::new().to(wallet2.address()).value(10000);
         let tx_hash = client.send_transaction(tx, None).await.unwrap();
 
-        let tx = client.get_transaction(tx_hash).await.unwrap();
+        let tx = client.get_transaction(tx_hash).await.unwrap().unwrap();
         assert_eq!(tx.gas_price, expected_gas_price);
     }
 }


### PR DESCRIPTION
Returns `Option<T>` instead of `T` for `Transaction`, `TransactionReceipt` and `Block` in order to avoid deserializing errors when the data requested did not exist

**THIS IS A BREAKING CHANGE**

Driveby: SparkPool seems to work now, closes #60 