### PR TITLE
feat: add ethers-cli and support abigen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-cli"
+version = "0.1.3"
+dependencies = [
+ "ethers-contract",
+ "ethers-core",
+ "gumdrop",
+]
+
+[[package]]
 name = "ethers-contract"
 version = "0.1.3"
 dependencies = [
@@ -760,6 +769,26 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "gumdrop"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46571f5d540478cf70d2a42dd0d6d8e9f4b9cc7531544b93311e657b86568a0b"
+dependencies = [
+ "gumdrop_derive",
+]
+
+[[package]]
+name = "gumdrop_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915ef07c710d84733522461de2a734d4d62a3fd39a4d4f404c2f385ef8618d05"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "h2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "./ethers",
+    "./ethers-cli",
     "./ethers-contract",
     "./ethers-providers",
     "./ethers-signers",

--- a/ethers-cli/Cargo.toml
+++ b/ethers-cli/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ethers-cli"
+license = "MIT OR Apache-2.0"
+version = "0.1.3"
+authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
+edition = "2018"
+description = "Command-line interface for the ethers-rs crate"
+homepage = "https://docs.rs/ethers"
+repository = "https://github.com/gakonst/ethers-rs"
+keywords = ["ethereum", "web3", "celo", "ethers"]
+
+[dependencies]
+ethers-contract = { version = "0.1.3", path = "../ethers-contract", features = ["abigen"] }
+ethers-core = { version = "0.1.3", path = "../ethers-core" }
+
+gumdrop = "0.8.0"

--- a/ethers-cli/src/bin/ethers_cli.rs
+++ b/ethers-cli/src/bin/ethers_cli.rs
@@ -1,0 +1,21 @@
+use gumdrop::Options;
+
+use std::process;
+
+use ethers_cli::cli_common::{abigen::generate, Command, EthersCliOpts};
+
+fn main() {
+    let opts = EthersCliOpts::parse_args_default_or_exit();
+
+    let command = opts.command.unwrap_or_else(|| {
+        eprintln!("No command was provided.");
+        eprintln!("{}", EthersCliOpts::usage());
+        process::exit(2);
+    });
+
+    match command {
+        Command::Abigen(opts) => {
+            generate(opts);
+        }
+    }
+}

--- a/ethers-cli/src/cli_common/abigen.rs
+++ b/ethers-cli/src/cli_common/abigen.rs
@@ -1,0 +1,44 @@
+use gumdrop::Options;
+
+use std::{io::stdout, process};
+
+use ethers_contract::Abigen;
+
+#[derive(Debug, Options)]
+pub struct AbigenOpts {
+    help: bool,
+    #[options(required, help = "name of the contract")]
+    name: String,
+    #[options(required, help = "source of the contract ABI")]
+    source: String,
+    #[options(short = "o", help = "output directory for bindings")]
+    output: Option<String>,
+}
+
+pub fn generate(opts: AbigenOpts) {
+    let bindings = Abigen::new(&opts.name, opts.source)
+        .unwrap_or_else(|err| {
+            eprintln!("Failed to instantiate Abigen builder: {:?}", err);
+            eprintln!("{}", AbigenOpts::usage());
+            process::exit(2);
+        })
+        .generate()
+        .unwrap_or_else(|err| {
+            eprintln!("Failed to generate bindings: {:?}", err);
+            eprintln!("{}", AbigenOpts::usage());
+            process::exit(2);
+        });
+
+    match opts.output {
+        Some(out_path) => {
+            bindings
+                .write_to_file(&out_path)
+                .expect(&format!("Failed to write bindings to path: {}", out_path));
+        }
+        None => {
+            bindings
+                .write(stdout())
+                .expect("Failed to write bindings to stdout");
+        }
+    }
+}

--- a/ethers-cli/src/cli_common/mod.rs
+++ b/ethers-cli/src/cli_common/mod.rs
@@ -1,0 +1,17 @@
+use gumdrop::Options;
+
+pub mod abigen;
+pub use abigen::{generate, AbigenOpts};
+
+#[derive(Debug, Options)]
+pub struct EthersCliOpts {
+    help: bool,
+    #[options(command)]
+    pub command: Option<Command>,
+}
+
+#[derive(Debug, Options)]
+pub enum Command {
+    #[options(help = "generate type-safe Rust bindings from a contract's ABI")]
+    Abigen(AbigenOpts),
+}

--- a/ethers-cli/src/lib.rs
+++ b/ethers-cli/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod cli_common;
+pub use cli_common::{Command, EthersCliOpts};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Issue existed #3 

For me `abigen` has been the most used ad-hoc functionality from `ethers-rs`. Instead of maintaining a messy boilerplate code to generate bindings for various contracts, I finally decided to implement a simple CLI for it.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Dependency added is [gumdrop](https://docs.rs/gumdrop/0.8.0/gumdrop/) as suggested in the above issue.

## Usage
```
$ cargo run --bin ethers_cli -- --help
$ cargo run --bin ethers_cli -- abigen --help
```

## Pending commands
- [x] Generate type-safe bindings
- [ ] Send ETH
- [ ] Send ERC-20 tokens
- [ ] Wrap ETH
- [ ] Unwrap ETH
- [ ] Sign data
- [ ] Compile solidity contract
- [ ] Deploy solidity contract
- [ ] Account info
- [ ] Tx info
- [ ] Wait for pending transaction