### PR TITLE
YubiHSM2 Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,12 +11,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+
+[[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
+name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2bc6d3f370b5666245ff421e231cba4353df936e26986d2918e61a8fd6aef6"
+dependencies = [
+ "aes-soft",
+ "aesni",
+ "block-cipher",
+]
+
+[[package]]
+name = "aes-soft"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
+dependencies = [
+ "block-cipher",
+ "byteorder",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aesni"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6fe808308bb07d393e2ea47780043ec47683fcf19cf5efc8ca51c50cc8c68a"
+dependencies = [
+ "block-cipher",
+ "opaque-debug",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "anomaly"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "550632e31568ae1a5f47998c3aa48563030fc49b9ec91913ca337cf64fbc5ccb"
+dependencies = [
+ "backtrace",
 ]
 
 [[package]]
@@ -64,7 +135,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801"
 dependencies = [
- "async-task 4.0.2",
+ "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
@@ -74,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5586e693d02f9b439742e9d5d68bd64d923c6861954f7d78f91001a0e152d589"
+checksum = "fefeb39da249f4c33af940b779a56723ce45809ef5c54dad84bb538d4ffb6d9e"
 dependencies = [
  "async-executor",
  "async-io",
@@ -87,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33be191d05a54ec120e4667375e2ad49fe506b846463df384460ab801c7ae5dc"
+checksum = "6e727cebd055ab2861a854f79def078c4b99ea722d54c6800a0e274389882d4c"
 dependencies = [
  "concurrent-queue",
  "fastrand",
@@ -114,15 +185,14 @@ dependencies = [
 
 [[package]]
 name = "async-std"
-version = "1.6.4"
+version = "1.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c92085acfce8b32e5b261d0b59b8f3309aee69fea421ea3f271f8b93225754f"
+checksum = "a9fa76751505e8df1c7a77762f60486f60c71bbd9b8557f4da6ad47d083732ed"
 dependencies = [
  "async-attributes",
  "async-global-executor",
  "async-io",
  "async-mutex",
- "async-task 3.0.0",
  "blocking",
  "crossbeam-utils",
  "futures-channel",
@@ -140,12 +210,6 @@ dependencies = [
  "slab",
  "wasm-bindgen-futures",
 ]
-
-[[package]]
-name = "async-task"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-task"
@@ -167,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687c230d85c0a52504709705fc8a53e4a692b83a2184f03dae73e38e1e93a783"
+checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -205,6 +269,20 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "backtrace"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1931848a574faa8f7c71a12ea00453ff5effbb5f51afe7f77d7a48cace6ac1"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -277,6 +355,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-cipher"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f337a3e6da609650eb74e02bc9fac7b735049f7623ab12f2e4c719316fcc7e80"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-modes"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9b14fd8a4739e6548d4b6018696cf991dcf8c6effd9ef9eb33b29b8a650972"
+dependencies = [
+ "block-cipher",
+ "block-padding",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +430,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
 
 [[package]]
+name = "ccm"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbba800a6a55058ecb75c7a42e3d16a715a2b1f1afa9acf07365d6ab30d62ce1"
+dependencies = [
+ "aead",
+ "block-cipher",
+ "subtle",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,15 +448,26 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d021fddb7bd3e734370acfa4a83f34095571d8570c039f1420d77540f68d5772"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "cmac"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5220604fe5c112e2851b00da795c72cbb71bf112f2cbd532bdcfb4106eeb320b"
+dependencies = [
+ "crypto-mac",
+ "dbl",
 ]
 
 [[package]]
@@ -418,6 +537,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
+name = "crc32fast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +568,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
 dependencies = [
+ "block-cipher",
  "generic-array",
  "subtle",
 ]
@@ -475,6 +604,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+dependencies = [
+ "byteorder",
+ "digest",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "dbl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735145c3b9ba15f2d7a3ae8cdafcbc8c98a7bef7f62afe9d08bd99fbf7130de"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +649,29 @@ dependencies = [
  "elliptic-curve",
  "hmac",
  "signature",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07dfc993ea376e864fe29a4099a61ca0bb994c6d7745a61bf60ddb3d64e05237"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand",
+ "serde",
+ "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -722,6 +896,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "tokio",
+ "yubihsm",
 ]
 
 [[package]]
@@ -745,6 +920,18 @@ dependencies = [
  "bitvec 0.18.4",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -940,6 +1127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,10 +1182,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.9.0"
+name = "harp"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
+checksum = "60bf12c625ed5e96f81609ae4377c34e9fa3e4d1fada392404322daeace511ab"
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "hermit-abi"
@@ -1186,12 +1385,14 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.5.5"
-source = "git+https://github.com/RustCrypto/elliptic-curves#8845cc09dc55ba3fa41ffa2750d799cf6a23d405"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be18b15cf00d98162fc37081a5098647f41168604d96174726fb1dff59c18a22"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
+ "sha2",
  "sha3",
 ]
 
@@ -1228,9 +1429,41 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "aa7087f49d294270db4e1928fc110c976cd4b9e5a16348e0a1df09afa99e6c98"
+
+[[package]]
+name = "libflate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9bac9023e1db29c084f9f8cd9d3852e5e8fddf98fb47c4964a0ea4663d95949"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "libflate_lz77",
+ "rle-decode-fast",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
+
+[[package]]
+name = "libusb1-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f02e930161703cc97c0aab3a905feb9740db03a80910f31ab0f8fa309223f39"
+dependencies = [
+ "cc",
+ "libc",
+ "libflate",
+ "pkg-config",
+ "tar",
+ "vcpkg",
+]
 
 [[package]]
 name = "libz-sys"
@@ -1279,6 +1512,16 @@ checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
+dependencies = [
+ "adler",
+ "autocfg",
 ]
 
 [[package]]
@@ -1332,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "nb-connect"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e847c76b390f44529c2071ef06d0b52fbb4bdb04cc8987a5cfa63954c000abca"
+checksum = "701f47aeb98466d0a7fea67e2c2f667c33efa1f2e4fd7f76743aac1153196f72"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -1394,6 +1637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
+
+[[package]]
 name = "once_cell"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1688,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1909a5a44a469f7d21c8dec2c634721ba15379b6cad80040d16abfaa8609b37c"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ce2b1182d022bfbe2af57aeca44fe7832356dd2d998e98e423cd9b94fae4f7"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1457,6 +1727,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
+name = "pbkdf2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170d73bf11f39b4ce1809aabc95bf5c33564cdc16fc3200ddda17a5f6e5e48b"
+dependencies = [
+ "crypto-mac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,18 +1743,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48fad7cfbff853437be7cf54d7b993af21f53be7f0988cbfe4a51535aa77205"
+checksum = "2b9e280448854bd91559252582173b3bd1f8e094a0e644791c0628ca9b1f144f"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c6d293bdd3ca5a1697997854c6cf7855e43fb6a0ba1c47af57a5bcafd158ae"
+checksum = "c8c8b352676bc6a4c3d71970560b913cea444a7a921cc2e2d920225e4b91edaa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1484,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f349a4f0e70676ffb2dbafe16d0c992382d02f0a952e3ddf584fc289dac6b3"
+checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
 
 [[package]]
 name = "pin-utils"
@@ -1546,9 +1825,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ef7cd2518ead700af67bf9d1a658d90b6037d77110fd9c0445429d0ba1c6c9"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -1701,13 +1980,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "rlp"
-version = "0.4.5"
+name = "rle-decode-fast"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7d3f9bed94764eac15b8f14af59fac420c236adaff743b7bcc88e265cb4345"
+checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
+
+[[package]]
+name = "rlp"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
 dependencies = [
  "rustc-hex",
 ]
+
+[[package]]
+name = "rusb"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fa037368ee577fca9ef237c5ec129084c18e7e3e5987cc611fb8b2d78cf84a"
+dependencies = [
+ "libc",
+ "libusb1-sys",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "rustc-hex"
@@ -1824,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
 dependencies = [
  "itoa",
  "ryu",
@@ -1891,6 +2192,19 @@ checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
  "digest",
  "rand_core",
+ "signature_derive",
+]
+
+[[package]]
+name = "signature_derive"
+version = "1.0.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0656c180103507cca4b82519908e813225b2f6b90b2bd59ee119f46155ae872"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -1938,6 +2252,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489997b7557e9a43e192c527face4feacc78bfbe6eed67fd55c4c9e381cba290"
+dependencies = [
+ "filetime",
+ "libc",
+ "redox_syscall",
+ "xattr",
 ]
 
 [[package]]
@@ -2091,20 +2429,21 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
+checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if",
  "log",
+ "pin-project-lite",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
 ]
@@ -2208,6 +2547,15 @@ name = "utf-8"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "vcpkg"
@@ -2427,7 +2775,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "yubihsm"
+version = "0.35.0-rc"
+source = "git+https://github.com/iqlusioninc/yubihsm.rs.git?branch=develop#a8fa868fbc50b8a326c46ab2b178f42e3e7a4e88"
+dependencies = [
+ "aes",
+ "anomaly",
+ "bitflags",
+ "block-modes",
+ "ccm",
+ "chrono",
+ "cmac",
+ "digest",
+ "ecdsa",
+ "ed25519",
+ "ed25519-dalek",
+ "harp",
+ "hmac",
+ "k256",
+ "log",
+ "p256",
+ "p384",
+ "pbkdf2",
+ "rand_core",
+ "rusb",
+ "serde",
+ "serde_json",
+ "sha2",
+ "signature",
+ "subtle",
+ "thiserror",
+ "uuid",
+ "zeroize",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -20,7 +20,7 @@ arrayvec = { version = "0.5.1", default-features = false }
 ecdsa = { version = "0.8.0", features = ["std"] }
 elliptic-curve = { version = "0.6.1", features = ["arithmetic"] }
 generic-array = "0.14.4"
-k256 = { git = "https://github.com/RustCrypto/elliptic-curves", version = "0.5.2", features = ["keccak256", "ecdsa"] }
+k256 = { version = "0.5.2", features = ["keccak256", "ecdsa"] }
 rand = "0.7.2"
 tiny-keccak = { version = "2.0.2", default-features = false }
 

--- a/ethers-core/src/lib.rs
+++ b/ethers-core/src/lib.rs
@@ -14,10 +14,10 @@
 //!
 //! ```rust
 //! # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
-//! use ethers::signers::{Signer, Wallet};
+//! use ethers::signers::{Signer, LocalWallet};
 //!
 //! let message = "Some data";
-//! let wallet = Wallet::new(&mut rand::thread_rng());
+//! let wallet = LocalWallet::new(&mut rand::thread_rng());
 //!
 //! // Sign the message
 //! let signature = wallet.sign_message(message).await?;

--- a/ethers-middleware/src/client.rs
+++ b/ethers-middleware/src/client.rs
@@ -1,4 +1,3 @@
-use ethers_signers::Signer;
 use ethers_core::{
     types::{
         Address, BlockNumber, Bytes, NameOrAddress, Signature, Transaction, TransactionRequest,
@@ -6,7 +5,8 @@ use ethers_core::{
     },
     utils::keccak256,
 };
-use ethers_providers::{Middleware, FromErr};
+use ethers_providers::{FromErr, Middleware};
+use ethers_signers::Signer;
 
 use async_trait::async_trait;
 use futures_util::{future::ok, join};

--- a/ethers-middleware/src/client.rs
+++ b/ethers-middleware/src/client.rs
@@ -1,5 +1,4 @@
 use ethers_signers::Signer;
-
 use ethers_core::{
     types::{
         Address, BlockNumber, Bytes, NameOrAddress, Signature, Transaction, TransactionRequest,
@@ -7,7 +6,7 @@ use ethers_core::{
     },
     utils::keccak256,
 };
-use ethers_providers::Middleware;
+use ethers_providers::{Middleware, FromErr};
 
 use async_trait::async_trait;
 use futures_util::{future::ok, join};
@@ -77,8 +76,6 @@ pub struct Client<M, S> {
     pub(crate) signer: S,
     pub(crate) address: Address,
 }
-
-use ethers_providers::FromErr;
 
 impl<M: Middleware, S: Signer> FromErr<M::Error> for ClientError<M, S> {
     fn from(src: M::Error) -> ClientError<M, S> {

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -26,8 +26,12 @@ elliptic-curve = { version = "0.6.1", features = ["arithmetic"] }
 sha2 = { version = "0.9.1" }
 rand = "0.7.3"
 
+# todo: update to latest once published
+yubihsm = { git = "https://github.com/iqlusioninc/yubihsm.rs.git", branch = "develop", features = ["secp256k1", "http", "usb"], optional = true }
+
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }
+yubihsm = { git = "https://github.com/iqlusioninc/yubihsm.rs.git", branch = "develop", features = ["secp256k1", "usb", "mockhsm"] }
 
 tokio = { version = "0.2.21", features = ["macros"] }
 serde_json = "1.0.55"
@@ -35,3 +39,4 @@ serde_json = "1.0.55"
 [features]
 celo = ["ethers-core/celo"]
 ledger = ["coins-ledger"]
+yubi = ["yubihsm"]

--- a/ethers-signers/src/ledger/app.rs
+++ b/ethers-signers/src/ledger/app.rs
@@ -159,7 +159,7 @@ impl LedgerEthereum {
         let mut result = Vec::new();
 
         // Iterate in 255 byte chunks
-        while payload.len() > 0 {
+        while !payload.is_empty() {
             let chunk_size = std::cmp::min(payload.len(), 255);
             let data = payload.drain(0..chunk_size).collect::<Vec<_>>();
             command.data = APDUData::new(&data);
@@ -188,10 +188,10 @@ impl LedgerEthereum {
 
         let mut bytes = vec![depth as u8];
         for derivation_index in elements {
-            let hardened = derivation_index.contains("'");
+            let hardened = derivation_index.contains('\'');
             let mut index = derivation_index.replace("'", "").parse::<u32>().unwrap();
             if hardened {
-                index = 0x80000000 | index;
+                index |= 0x80000000;
             }
 
             bytes.extend(&index.to_be_bytes());

--- a/ethers-signers/src/ledger/types.rs
+++ b/ethers-signers/src/ledger/types.rs
@@ -1,5 +1,6 @@
 //! Helpers for interacting with the Ethereum Ledger App
 //! [Official Docs](https://github.com/LedgerHQ/app-ethereum/blob/master/doc/ethapp.asc)
+use std::fmt;
 use thiserror::Error;
 
 #[derive(Clone, Debug)]
@@ -9,13 +10,17 @@ pub enum DerivationType {
     Other(String),
 }
 
-impl DerivationType {
-    pub fn to_string(&self) -> String {
-        match self {
-            DerivationType::Legacy(index) => format!("m/44'/60'/0'/{}", index),
-            DerivationType::LedgerLive(index) => format!("m/44'/60'/{}'/0/0", index),
-            DerivationType::Other(inner) => inner.to_owned(),
-        }
+impl fmt::Display for DerivationType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "{}",
+            match self {
+                DerivationType::Legacy(index) => format!("m/44'/60'/0'/{}", index),
+                DerivationType::LedgerLive(index) => format!("m/44'/60'/{}'/0/0", index),
+                DerivationType::Other(inner) => inner.to_owned(),
+            }
+        )
     }
 }
 

--- a/ethers-signers/src/lib.rs
+++ b/ethers-signers/src/lib.rs
@@ -12,13 +12,13 @@
 //!
 //! ```no_run
 //! # use ethers::{
-//!     signers::{Wallet, Signer},
+//!     signers::{LocalWallet, Signer},
 //!     core::{k256::ecdsa::SigningKey, types::TransactionRequest},
 //! };
 //! # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
 //! // instantiate the wallet
 //! let wallet = "dcf2cbdd171a21c480aa7f53d77f31bb102282b3ff099c78e3118b37348c72f7"
-//!     .parse::<Wallet<SigningKey>>()?;
+//!     .parse::<LocalWallet>()?;
 //!
 //! // create a transaction
 //! let tx = TransactionRequest::new()
@@ -37,7 +37,13 @@
 // pub use wallet::Wallet;
 mod wallet;
 pub use wallet::Wallet;
+
+/// A wallet instantiated with a locally stored private key
 pub type LocalWallet = Wallet<ethers_core::k256::ecdsa::SigningKey>;
+
+#[cfg(feature = "yubi")]
+/// A wallet instantiated with a YubiHSM
+pub type YubiWallet = Wallet<yubihsm::ecdsa::Signer<ethers_core::k256::Secp256k1>>;
 
 #[cfg(feature = "ledger")]
 mod ledger;
@@ -46,6 +52,9 @@ pub use ledger::{
     app::LedgerEthereum as Ledger,
     types::{DerivationType as HDPath, LedgerError},
 };
+
+#[cfg(feature = "yubi")]
+pub use yubihsm;
 
 use async_trait::async_trait;
 use ethers_core::types::{Address, Signature, TransactionRequest};

--- a/ethers-signers/src/wallet/mod.rs
+++ b/ethers-signers/src/wallet/mod.rs
@@ -34,10 +34,10 @@ use std::fmt;
 ///
 /// ```
 /// use ethers_core::rand::thread_rng;
-/// use ethers_signers::{Wallet, Signer};
+/// use ethers_signers::{LocalWallet, Signer};
 ///
 /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
-/// let wallet = Wallet::new(&mut thread_rng());
+/// let wallet = LocalWallet::new(&mut thread_rng());
 ///
 /// // Optionally, the wallet's chain id can be set, in order to use EIP-155
 /// // replay protection with different chains

--- a/ethers-signers/src/wallet/mod.rs
+++ b/ethers-signers/src/wallet/mod.rs
@@ -1,6 +1,9 @@
 mod hash;
 mod private_key;
 
+#[cfg(feature = "yubihsm")]
+mod yubi;
+
 use crate::Signer;
 use ethers_core::{
     k256::{

--- a/ethers-signers/src/wallet/private_key.rs
+++ b/ethers-signers/src/wallet/private_key.rs
@@ -104,7 +104,7 @@ mod tests {
     async fn signs_msg() {
         let message = "Some data";
         let hash = ethers_core::utils::hash_message(message);
-        let key = Wallet::new(&mut rand::thread_rng());
+        let key = Wallet::<SigningKey>::new(&mut rand::thread_rng());
         let address = key.address;
 
         // sign a message

--- a/ethers-signers/src/wallet/yubi.rs
+++ b/ethers-signers/src/wallet/yubi.rs
@@ -1,0 +1,113 @@
+//! Helpers for creating wallets for YubiHSM2
+use super::Wallet;
+use ethers_core::{k256::Secp256k1, types::Address, utils::keccak256};
+use yubihsm::{
+    asymmetric::Algorithm::EcK256, ecdsa::Signer as YubiSigner, object, object::Label, Capability,
+    Client, Connector, Credentials, Domain,
+};
+
+impl Wallet<YubiSigner<Secp256k1>> {
+    /// Connects to a yubi key's ECDSA account at the provided id
+    pub fn connect(connector: Connector, credentials: Credentials, id: object::Id) -> Self {
+        let client = Client::open(connector, credentials, true).unwrap();
+        let signer = YubiSigner::create(client, id).unwrap();
+        signer.into()
+    }
+
+    /// Creates a new random ECDSA keypair on the yubi at the provided id
+    pub fn new(
+        connector: Connector,
+        credentials: Credentials,
+        id: object::Id,
+        label: Label,
+        domain: Domain,
+    ) -> Self {
+        let client = Client::open(connector, credentials, true).unwrap();
+        let id = client
+            .generate_asymmetric_key(id, label, domain, Capability::SIGN_ECDSA, EcK256)
+            .unwrap();
+        let signer = YubiSigner::create(client, id).unwrap();
+        signer.into()
+    }
+
+    /// Uploads the provided keypair on the yubi at the provided id
+    pub fn from_key(
+        connector: Connector,
+        credentials: Credentials,
+        id: object::Id,
+        label: Label,
+        domain: Domain,
+        key: impl Into<Vec<u8>>,
+    ) -> Self {
+        let client = Client::open(connector, credentials, true).unwrap();
+        let id = client
+            .put_asymmetric_key(id, label, domain, Capability::SIGN_ECDSA, EcK256, key)
+            .unwrap();
+        let signer = YubiSigner::create(client, id).unwrap();
+        signer.into()
+    }
+}
+
+impl From<YubiSigner<Secp256k1>> for Wallet<YubiSigner<Secp256k1>> {
+    fn from(signer: YubiSigner<Secp256k1>) -> Self {
+        let public_key = signer.public_key().decompress().unwrap().to_bytes();
+        debug_assert_eq!(public_key[0], 0x04);
+        let hash = keccak256(&public_key[1..]);
+        let address = Address::from_slice(&hash[12..]);
+
+        Self {
+            signer,
+            address,
+            chain_id: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Signer;
+    use rustc_hex::FromHex;
+    use std::str::FromStr;
+
+    #[tokio::test]
+    async fn from_key() {
+        let key = "2d8c44dc2dd2f0bea410e342885379192381e82d855b1b112f9b55544f1e0900"
+            .from_hex::<Vec<u8>>()
+            .unwrap();
+
+        let connector = yubihsm::Connector::mockhsm();
+        let wallet = Wallet::from_key(
+            connector,
+            Credentials::default(),
+            0,
+            Label::from_bytes(&[]).unwrap(),
+            Domain::at(1).unwrap(),
+            key,
+        );
+
+        let msg = "Some data";
+        let sig = wallet.sign_message(msg).await.unwrap();
+        assert_eq!(sig.recover(msg).unwrap(), wallet.address());
+        assert_eq!(
+            wallet.address(),
+            Address::from_str("2DE2C386082Cff9b28D62E60983856CE1139eC49").unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn new_key() {
+        let connector = yubihsm::Connector::mockhsm();
+        let wallet = Wallet::<YubiSigner<Secp256k1>>::new(
+            connector,
+            Credentials::default(),
+            0,
+            Label::from_bytes(&[]).unwrap(),
+            Domain::at(1).unwrap(),
+        );
+
+        let msg = "Some data";
+        let sig = wallet.sign_message(msg).await.unwrap();
+        assert_eq!(sig.recover(msg).unwrap(), wallet.address());
+    }
+}

--- a/ethers/Cargo.toml
+++ b/ethers/Cargo.toml
@@ -44,6 +44,7 @@ providers = ["ethers-providers"]
 middleware = ["ethers-middleware"]
 signers = ["ethers-signers"]
 ledger = ["ethers-signers/ledger"]
+yubi = ["ethers-signers/yubi"]
 
 [dependencies]
 ethers-contract = { version = "0.1.3", path = "../ethers-contract", optional = true }

--- a/ethers/examples/sign.rs
+++ b/ethers/examples/sign.rs
@@ -4,7 +4,7 @@ use ethers::prelude::*;
 #[tokio::main]
 async fn main() -> Result<()> {
     let message = "Some data";
-    let wallet = Wallet::new(&mut rand::thread_rng());
+    let wallet = LocalWallet::new(&mut rand::thread_rng());
 
     // sign a message
     let signature = wallet.sign_message(message).await?;

--- a/ethers/examples/yubi.rs
+++ b/ethers/examples/yubi.rs
@@ -1,0 +1,31 @@
+#[tokio::main]
+#[cfg(feature = "yubi")]
+async fn main() -> anyhow::Result<()> {
+    use ethers::{prelude::*, utils::parse_ether};
+    use yubihsm::{Connector, Credentials, UsbConfig};
+
+    // Connect over websockets
+    let provider = Provider::new(Ws::connect("ws://localhost:8545").await?);
+
+    // We use USB for the example, but you can connect over HTTP as well. Refer
+    // to the [YubiHSM](https://docs.rs/yubihsm/0.34.0/yubihsm/) docs for more info
+    let connector = Connector::usb(&UsbConfig::default());
+    // Instantiate the connection to the YubiKey. Alternatively, use the
+    // `from_key` method to upload a key you already have, or the `new` method
+    // to generate a new keypair.
+    let wallet = YubiWallet::connect(connector, Credentials::default(), 0);
+    let client = Client::new(provider, wallet);
+
+    // Create and broadcast a transaction (ENS enabled!)
+    let tx = TransactionRequest::new()
+        .to("vitalik.eth")
+        .value(parse_ether(10)?);
+    let tx_hash = client.send_transaction(tx, None).await?;
+
+    // Get the receipt
+    let _receipt = client.pending_transaction(tx_hash).confirmations(3).await?;
+    Ok(())
+}
+
+#[cfg(not(feature = "yubi"))]
+fn main() {}


### PR DESCRIPTION
As title, add some helper methods around `Wallet` to make sure users can easily create instances of YubiHSM2 signers that are compatible with ethers-rs.

TODO: Re-run CI when infura stops rate limiting us