### PR TITLE
refactor: extract minimal features of Contract into BaseContract

### DIFF
--- a/ethers-contract/src/base.rs
+++ b/ethers-contract/src/base.rs
@@ -1,0 +1,74 @@
+use crate::Contract;
+
+use ethers_core::{
+    abi::{Abi, FunctionExt},
+    types::{Address, Selector},
+};
+use ethers_providers::Middleware;
+
+use std::{collections::HashMap, fmt::Debug, hash::Hash, sync::Arc};
+
+/// A reduced form of `Contract` which just takes the `abi` and produces
+/// ABI encoded data for its functions.
+#[derive(Debug, Clone)]
+pub struct BaseContract {
+    pub(crate) abi: Abi,
+
+    /// A mapping from method signature to a name-index pair for accessing
+    /// functions in the contract ABI. This is used to avoid allocation when
+    /// searching for matching functions by signature.
+    // Adapted from: https://github.com/gnosis/ethcontract-rs/blob/master/src/contract.rs
+    pub(crate) methods: HashMap<Selector, (String, usize)>,
+}
+
+impl From<Abi> for BaseContract {
+    /// Creates a new `BaseContract` from the abi.
+    fn from(abi: Abi) -> Self {
+        let methods = create_mapping(&abi.functions, |function| function.selector());
+        Self { abi, methods }
+    }
+}
+
+impl BaseContract {
+    /// Returns a reference to the contract's ABI
+    pub fn abi(&self) -> &Abi {
+        &self.abi
+    }
+
+    /// Upgrades a `BaseContract` into a full fledged contract with an address and middleware.
+    pub fn into_contract<M: Middleware>(
+        self,
+        address: Address,
+        client: impl Into<Arc<M>>,
+    ) -> Contract<M> {
+        Contract::new(address, self, client)
+    }
+}
+
+impl AsRef<Abi> for BaseContract {
+    fn as_ref(&self) -> &Abi {
+        self.abi()
+    }
+}
+
+/// Utility function for creating a mapping between a unique signature and a
+/// name-index pair for accessing contract ABI items.
+fn create_mapping<T, S, F>(
+    elements: &HashMap<String, Vec<T>>,
+    signature: F,
+) -> HashMap<S, (String, usize)>
+where
+    S: Hash + Eq,
+    F: Fn(&T) -> S,
+{
+    let signature = &signature;
+    elements
+        .iter()
+        .flat_map(|(name, sub_elements)| {
+            sub_elements
+                .iter()
+                .enumerate()
+                .map(move |(index, element)| (signature(element), (name.to_owned(), index)))
+        })
+        .collect()
+}

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -14,7 +14,7 @@
 //! [`abigen`]: ./macro.abigen.html
 //! [`Abigen` builder]: crate::Abigen
 mod contract;
-pub use contract::Contract;
+pub use contract::{BaseContract, Contract};
 
 mod call;
 pub use call::ContractError;

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -14,7 +14,10 @@
 //! [`abigen`]: ./macro.abigen.html
 //! [`Abigen` builder]: crate::Abigen
 mod contract;
-pub use contract::{BaseContract, Contract};
+pub use contract::Contract;
+
+mod base;
+pub use base::BaseContract;
 
 mod call;
 pub use call::ContractError;

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -234,13 +234,13 @@ impl<M: Middleware> Multicall<M> {
     ///
     /// ```no_run
     /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
-    /// # use ethers::prelude::*;
+    /// # use ethers::{abi::Abi, prelude::*};
     /// # use std::{sync::Arc, convert::TryFrom};
     /// #
     /// # let client = Provider::<Http>::try_from("http://localhost:8545")?;
     /// # let client = Arc::new(client);
     /// #
-    /// # let abi = serde_json::from_str("")?;
+    /// # let abi: Abi = serde_json::from_str("")?;
     /// # let address = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".parse::<Address>()?;
     /// # let contract = Contract::<Provider<Http>>::new(address, abi, client.clone());
     /// #

--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -385,7 +385,8 @@ mod celo_tests {
             .send()
             .await
             .unwrap();
-        let _receipt = contract.pending_transaction(tx_hash).await.unwrap();
+        let receipt = contract.pending_transaction(tx_hash).await.unwrap();
+        assert_eq!(receipt.status.unwrap(), 1.into());
 
         let value: String = contract
             .method("getValue", ())

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(intra_doc_link_resolution_failure)]
 //! # Clients for interacting with Ethereum nodes
 //!
 //! This crate provides asynchronous [Ethereum JSON-RPC](https://github.com/ethereum/wiki/wiki/JSON-RPC)

--- a/ethers/src/lib.rs
+++ b/ethers/src/lib.rs
@@ -4,7 +4,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![deny(intra_doc_link_resolution_failure)]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Resolves #80 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Refactors the `Contract` struct by extracting the `abi` into a `BaseContract` struct which does only abi encoding. 
Working on adding human-readable abis.