### PR TITLE
add Sync trait to middleware error

### DIFF
--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -144,7 +144,7 @@ pub trait FromErr<T> {
 
 #[async_trait]
 pub trait Middleware: Sync + Send + Debug {
-    type Error: Send + Error + FromErr<<Self::Inner as Middleware>::Error>;
+    type Error: Sync + Send + Error + FromErr<<Self::Inner as Middleware>::Error>;
     type Provider: JsonRpcClient;
     type Inner: Middleware<Provider = Self::Provider>;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Since `Middleware::Error` does not implement the `std::marker::Sync` trait, a middleware error cannot be converted into `anyhow::Error`. This is for convenience of using the `?` operator for a middleware error being returned.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add `Sync` trait to `Middleware::Error`