### PR TITLE
fix: reschedule waker even if receipt is not available

### DIFF
--- a/ethers-providers/src/pending_transaction.rs
+++ b/ethers-providers/src/pending_transaction.rs
@@ -75,7 +75,6 @@ impl<'a, P: JsonRpcClient> Future for PendingTransaction<'a, P> {
             PendingTxState::GettingReceipt(fut) => {
                 if let Ok(receipt) = futures_util::ready!(fut.as_mut().poll(ctx)) {
                     if let Some(receipt) = receipt {
-                        ctx.waker().wake_by_ref();
                         *this.state = PendingTxState::CheckingReceipt(Box::new(receipt))
                     } else {
                         *this.state = PendingTxState::PausedGettingReceipt
@@ -83,6 +82,7 @@ impl<'a, P: JsonRpcClient> Future for PendingTransaction<'a, P> {
                 } else {
                     *this.state = PendingTxState::PausedGettingReceipt
                 }
+                ctx.waker().wake_by_ref();
             }
             PendingTxState::CheckingReceipt(receipt) => {
                 // If we requested more than 1 confirmation, we need to compare the receipt's


### PR DESCRIPTION
Fixes https://github.com/gakonst/ethers-rs/issues/102

PR #103 did not address the Future hanging when the receipt was not
immediately available, e.g. in non dev environments