### PR TITLE
Fix broken link to TG group in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ in the transactions which are fetched over JSON-RPC.
 First, see if the answer to your question can be found in the [API documentation](https://docs.rs/ethers). If the answer
 is not there, try opening an [issue](https://github.com/gakonst/ethers-rs/issues/new) with the question.
 
-Join the [ethers-rs telegram](t.me/ethers_rs) to chat with the community!
+Join the [ethers-rs telegram](https://t.me/ethers_rs) to chat with the community!
 
 ## Contributing
 


### PR DESCRIPTION
Title.

## Motivation

The link to the Telegram group added in 959b7fe9cea2c3a18f6735b803d996818e68a9f0 is broken.

## Solution

Fixed the link.
