### PR TITLE
Upgrade to Tokio 1.0 and remove async-std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,12 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-
       - name: Install ganache-cli
         uses: actions/setup-node@v1
         with:
           node-version: 10
       - name: Install ganache
         run: npm install -g ganache-cli
-      - name: Install libusb (for Ledger)
-        run: sudo apt update && sudo apt install pkg-config libudev-dev
-
       - name: Install Solc
         run: |
             mkdir -p "$HOME/bin"
@@ -42,7 +38,6 @@ jobs:
             chmod u+x "$HOME/bin/geth"
             export PATH=$HOME/bin:$PATH
             geth version
-
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -50,19 +45,69 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
-
       - name: cargo test
         run: |
             export PATH=$HOME/bin:$PATH
             cargo test
 
+  feature-tests:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install ganache-cli
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      # TODO: can we combine these shared steps in github actions?
+      - name: Install ganache
+        run: npm install -g ganache-cli
+      - name: Install Solc
+        run: |
+            mkdir -p "$HOME/bin"
+            wget -q https://github.com/ethereum/solidity/releases/download/v0.6.6/solc-static-linux -O $HOME/bin/solc
+            chmod u+x "$HOME/bin/solc"
+            export PATH=$HOME/bin:$PATH
+            solc --version
+      - name: Install geth
+        run: |
+            mkdir -p "$HOME/bin"
+            wget -q https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.9.23-8c2f2715.tar.gz
+            tar -xvf geth-linux-amd64-1.9.23-8c2f2715.tar.gz
+            mv geth-linux-amd64-1.9.23-8c2f2715/geth $HOME/bin/geth
+            chmod u+x "$HOME/bin/geth"
+            export PATH=$HOME/bin:$PATH
+            geth version
+
+      - name: Install libusb (for Ledger)
+        run: sudo apt update && sudo apt install pkg-config libudev-dev
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
       - name: cargo test (Celo)
         run: |
             export PATH=$HOME/bin:$PATH
             cargo test --all-features
 
+  lint:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
       - name: cargo fmt
         run: cargo fmt --all -- --check
-
       - name: cargo clippy
         run: cargo clippy -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,9 +634,9 @@ dependencies = [
  "ethers-providers",
  "ethers-signers",
  "futures-util",
+ "hex",
  "once_cell",
  "pin-project 1.0.2",
- "rustc-hex",
  "serde",
  "serde_json",
  "thiserror",
@@ -651,9 +651,9 @@ dependencies = [
  "anyhow",
  "curl",
  "ethers-core",
+ "hex",
  "proc-macro2",
  "quote",
- "rustc-hex",
  "serde_json",
  "syn",
  "url",
@@ -685,10 +685,10 @@ dependencies = [
  "ethers",
  "generic-array",
  "glob",
+ "hex",
  "k256",
  "rand 0.7.3",
  "rlp",
- "rustc-hex",
  "serde",
  "serde_json",
  "thiserror",
@@ -706,8 +706,8 @@ dependencies = [
  "ethers-signers",
  "futures-executor",
  "futures-util",
+ "hex",
  "reqwest",
- "rustc-hex",
  "serde",
  "serde-aux",
  "thiserror",
@@ -729,9 +729,9 @@ dependencies = [
  "futures-core",
  "futures-timer",
  "futures-util",
+ "hex",
  "pin-project 1.0.2",
  "reqwest",
- "rustc-hex",
  "serde",
  "serde_json",
  "thiserror",
@@ -753,8 +753,8 @@ dependencies = [
  "ethers-core",
  "futures-executor",
  "futures-util",
+ "hex",
  "rand 0.7.3",
- "rustc-hex",
  "serde",
  "serde_json",
  "sha2",
@@ -1032,6 +1032,12 @@ checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "hidapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
 dependencies = [
  "byteorder",
  "digest",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize",
 ]
@@ -527,7 +527,7 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand",
+ "rand 0.7.3",
  "serde",
  "sha2",
  "zeroize",
@@ -551,7 +551,7 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
  "zeroize",
 ]
@@ -616,7 +616,7 @@ dependencies = [
  "ethers-middleware",
  "ethers-providers",
  "ethers-signers",
- "rand",
+ "rand 0.7.3",
  "serde",
  "serde_json",
  "tokio",
@@ -686,7 +686,7 @@ dependencies = [
  "generic-array",
  "glob",
  "k256",
- "rand",
+ "rand 0.7.3",
  "rlp",
  "rustc-hex",
  "serde",
@@ -753,7 +753,7 @@ dependencies = [
  "ethers-core",
  "futures-executor",
  "futures-util",
- "rand",
+ "rand 0.7.3",
  "rustc-hex",
  "serde",
  "serde_json",
@@ -770,7 +770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01646e077d4ebda82b73f1bca002ea1e91561a77df2431a9e79729bcc31950ef"
 dependencies = [
  "bitvec 0.18.4",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
 ]
 
@@ -793,7 +793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.7.3",
  "rustc-hex",
  "static_assertions",
 ]
@@ -959,6 +959,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "gimli"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,7 +988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc11f9f5fbf1943b48ae7c2bf6846e7d827a512d1be4f23af708f5ca5d01dde1"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle",
 ]
 
@@ -1663,11 +1674,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76330fb486679b4ace3670f117bbc9e16204005c4bde9c4bd372f45bed34f12"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.0",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1677,7 +1700,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.0",
 ]
 
 [[package]]
@@ -1686,7 +1719,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8b34ba8cfb21243bd8df91854c830ff0d785fff2e82ebd4434c2644cb9ada18"
+dependencies = [
+ "getrandom 0.2.0",
 ]
 
 [[package]]
@@ -1695,7 +1737,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.0",
 ]
 
 [[package]]
@@ -1979,7 +2030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.5.1",
  "signature_derive",
 ]
 
@@ -2073,7 +2124,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "rand",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -2215,7 +2266,7 @@ dependencies = [
 [[package]]
 name = "tokio-tungstenite"
 version = "0.12.0"
-source = "git+https://github.com/dnaka91/tokio-tungstenite?branch=tokio-1.0#0f0665b4106c36dd3945616e96089bab14c1d7aa"
+source = "git+https://github.com/dnaka91/tokio-tungstenite?branch=tokio-1.0#078a227476d90bfd3ef68a70d0b78148a489dc26"
 dependencies = [
  "futures-util",
  "log",
@@ -2286,7 +2337,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "tungstenite"
 version = "0.11.1"
-source = "git+https://github.com/nickelc/tungstenite-rs.git?branch=bytes#75bf9b87301fd31e25b2cd0459b33b20772c66f8"
+source = "git+https://github.com/snapview/tungstenite-rs.git?rev=208061ba284eaf95a54c1b9b6968f570004c90de#208061ba284eaf95a54c1b9b6968f570004c90de"
 dependencies = [
  "base64",
  "byteorder",
@@ -2296,7 +2347,7 @@ dependencies = [
  "input_buffer",
  "log",
  "native-tls",
- "rand",
+ "rand 0.8.0",
  "sha-1",
  "url",
  "utf-8",
@@ -2593,7 +2644,7 @@ dependencies = [
  "p256",
  "p384",
  "pbkdf2",
- "rand_core",
+ "rand_core 0.5.1",
  "rusb",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,9 +12,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
+checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
 dependencies = [
  "gimli",
 ]
@@ -651,7 +651,6 @@ dependencies = [
  "anyhow",
  "curl",
  "ethers-core",
- "once_cell",
  "proc-macro2",
  "quote",
  "rustc-hex",
@@ -1180,9 +1179,9 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
@@ -1317,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33bc887064ef1fd66020c9adfc45bb9f33d75a42096c81e7c56c65b75dd1a8b"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
  "libc",
  "log",
@@ -1340,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1735,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.10.10"
-source = "git+https://github.com/messense/reqwest?branch=tokio-0-3#af8513e2efd572efdd418548a43c8f059a820a30"
+source = "git+https://github.com/seanmonstar/reqwest?branch=master#1f425a0244bcd7b4565dceb9076450d951f2ec03"
 dependencies = [
  "base64",
  "bytes 1.0.0",
@@ -1914,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -2033,9 +2032,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a571a711dddd09019ccc628e1b17fe87c59b09d513c06c026877aa708334f37a"
+checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2082,18 +2081,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,9 @@ name = "bytes"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -675,6 +678,7 @@ version = "0.1.3"
 dependencies = [
  "arrayvec",
  "bincode",
+ "bytes 1.0.0",
  "ecdsa",
  "elliptic-curve",
  "ethabi-next",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68803225a7b13e47191bab76f2687382b60d259e8cf37f6e1893658b84bb9479"
+checksum = "ee67c11feeac938fae061b232e38e0b6d94f97a9df10e6271319325ac4c56a86"
 
 [[package]]
 name = "arrayref"
@@ -108,127 +108,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "async-attributes"
-version = "1.1.1"
+name = "async-stream"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd3d156917d94862e779f356c5acae312b08fd3121e792c857d7928c8088423"
+checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
 dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59740d83946db6a5af71ae25ddf9562c2b176b2ca42cf99a455f09f4a220d6b9"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "once_cell",
- "vec-arena",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73079b49cd26b8fd5a15f68fc7707fc78698dc2a3d61430f2a7a9430230dfa04"
-dependencies = [
- "async-executor",
- "async-io",
- "futures-lite",
- "num_cpus",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
-dependencies = [
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "libc",
- "log",
- "nb-connect",
- "once_cell",
- "parking",
- "polling",
- "vec-arena",
- "waker-fn",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-std"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f84f1280a2b436a2c77c2582602732b6c2f4321d5494d6e799e6c367859a8"
-dependencies = [
- "async-attributes",
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-mutex",
- "blocking",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "num_cpus",
- "once_cell",
- "pin-project-lite 0.2.0",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
-
-[[package]]
-name = "async-tls"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fd83426b89b034bf4e9ceb9c533c2f2386b813fd3dcae0a425ec6f1837d78a"
-dependencies = [
- "futures",
- "rustls 0.17.0",
- "webpki",
- "webpki-roots 0.19.0",
 ]
 
 [[package]]
@@ -241,30 +138,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "async-tungstenite"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ea20d9a2b068769745fbe27942952ea2b9a3967c52b5f0139637c7eca6f547"
-dependencies = [
- "async-std",
- "async-tls",
- "futures-io",
- "futures-util",
- "log",
- "native-tls",
- "pin-project 0.4.27",
- "tokio",
- "tokio-native-tls",
- "tungstenite",
-]
-
-[[package]]
-name = "atomic-waker"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "auto_impl"
@@ -297,18 +170,6 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -391,20 +252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
-name = "blocking"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
-dependencies = [
- "async-channel",
- "async-task",
- "atomic-waker",
- "fastrand",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,10 +276,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
-name = "cache-padded"
-version = "1.1.1"
+name = "bytes"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
 
 [[package]]
 name = "cc"
@@ -474,7 +321,7 @@ dependencies = [
  "num-traits",
  "serde",
  "time",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -517,15 +364,6 @@ dependencies = [
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
-dependencies = [
- "cache-padded",
 ]
 
 [[package]]
@@ -572,17 +410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
-dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
- "lazy_static",
-]
-
-[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,7 +438,7 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -626,7 +453,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -869,7 +696,6 @@ dependencies = [
 name = "ethers-middleware"
 version = "0.1.3"
 dependencies = [
- "async-std",
  "async-trait",
  "ethers",
  "ethers-core",
@@ -892,10 +718,7 @@ dependencies = [
 name = "ethers-providers"
 version = "0.1.3"
 dependencies = [
- "async-std",
- "async-tls",
  "async-trait",
- "async-tungstenite",
  "auto_impl",
  "ethers",
  "ethers-core",
@@ -910,7 +733,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-native-tls",
+ "tokio-tungstenite",
  "tracing",
  "tracing-futures",
  "url",
@@ -938,21 +761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
-
-[[package]]
-name = "fastrand"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
-dependencies = [
- "instant",
-]
-
-[[package]]
 name = "ff"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,7 +780,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1017,22 +825,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "funty"
@@ -1088,21 +880,6 @@ name = "futures-io"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
-
-[[package]]
-name = "futures-lite"
-version = "1.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite 0.2.0",
- "waker-fn",
-]
 
 [[package]]
 name = "futures-macro"
@@ -1191,19 +968,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "group"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,11 +980,11 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
 dependencies = [
- "bytes",
+ "bytes 1.0.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1282,18 +1046,18 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
- "bytes",
+ "bytes 1.0.0",
  "http",
 ]
 
@@ -1311,11 +1075,11 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
 dependencies = [
- "bytes",
+ "bytes 1.0.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1335,15 +1099,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
- "bytes",
  "futures-util",
  "hyper",
  "log",
- "rustls 0.18.1",
+ "rustls",
  "tokio",
  "tokio-rustls",
  "webpki",
@@ -1399,29 +1162,10 @@ dependencies = [
 
 [[package]]
 name = "input_buffer"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
+version = "0.4.0"
+source = "git+https://github.com/snapview/input_buffer.git#e04d16751485f14c024b332658a1ce683af2c384"
 dependencies = [
- "bytes",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
+ "bytes 1.0.0",
 ]
 
 [[package]]
@@ -1463,25 +1207,6 @@ name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
 
 [[package]]
 name = "lazy_static"
@@ -1588,33 +1313,25 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+checksum = "f33bc887064ef1fd66020c9adfc45bb9f33d75a42096c81e7c56c65b75dd1a8b"
 dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
  "libc",
  "log",
  "miow",
- "net2",
- "slab",
- "winapi 0.2.8",
+ "ntapi",
+ "winapi",
 ]
 
 [[package]]
 name = "miow"
-version = "0.2.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "socket2",
+ "winapi",
 ]
 
 [[package]]
@@ -1636,27 +1353,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nb-connect"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "nix"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,6 +1363,15 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "void",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1783,12 +1488,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
-
-[[package]]
 name = "pbkdf2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,12 +1544,6 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
-
-[[package]]
-name = "pin-project-lite"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
@@ -1875,19 +1568,6 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
-
-[[package]]
-name = "polling"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "log",
- "wepoll-sys",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -2045,17 +1725,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "reqwest"
 version = "0.10.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+source = "git+https://github.com/messense/reqwest?branch=tokio-0-3#af8513e2efd572efdd418548a43c8f059a820a30"
 dependencies = [
- "base64 0.13.0",
- "bytes",
+ "base64",
+ "bytes 1.0.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -2070,8 +1749,8 @@ dependencies = [
  "mime",
  "mime_guess",
  "percent-encoding",
- "pin-project-lite 0.2.0",
- "rustls 0.18.1",
+ "pin-project-lite",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2081,7 +1760,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.20.0",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -2097,7 +1776,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2139,24 +1818,11 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustls"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d4a31f5d68413404705d6982529b0e11a9aacd4839d1d6222ee3b8cb4015e1"
+checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
 dependencies = [
- "base64 0.11.0",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
-dependencies = [
- "base64 0.12.3",
+ "base64",
  "log",
  "ring",
  "sct",
@@ -2176,7 +1842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2340,7 +2006,7 @@ checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2407,7 +2073,7 @@ dependencies = [
  "rand",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2447,7 +2113,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2485,27 +2151,25 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.24"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
+checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
 dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
+ "autocfg",
+ "bytes 1.0.0",
+ "libc",
  "memchr",
  "mio",
- "pin-project-lite 0.1.11",
- "slab",
+ "num_cpus",
+ "pin-project-lite",
  "tokio-macros",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2514,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd608593a919a8e05a7d1fc6df885e40f6a88d3a70a3a7eff23ff27964eda069"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
@@ -2524,28 +2188,54 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.14.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "futures-core",
- "rustls 0.18.1",
+ "rustls",
  "tokio",
  "webpki",
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.3.1"
+name = "tokio-stream"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "3f3be913b74b13210c8fe04b17ab833f5a124f45b93d0f99f59fff621f64392a"
 dependencies = [
- "bytes",
+ "async-stream",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.12.0"
+source = "git+https://github.com/dnaka91/tokio-tungstenite?branch=tokio-1.0#0f0665b4106c36dd3945616e96089bab14c1d7aa"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "pin-project 1.0.2",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36135b7e7da911f5f8b9331209f7fab4cc13498f3fff52f72a710c78187e3148"
+dependencies = [
+ "bytes 1.0.0",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.11",
+ "pin-project-lite",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2561,8 +2251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
- "log",
- "pin-project-lite 0.2.0",
+ "pin-project-lite",
  "tracing-core",
 ]
 
@@ -2594,12 +2283,11 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "tungstenite"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
+source = "git+https://github.com/nickelc/tungstenite-rs.git?branch=bytes#75bf9b87301fd31e25b2cd0459b33b20772c66f8"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "byteorder",
- "bytes",
+ "bytes 1.0.0",
  "http",
  "httparse",
  "input_buffer",
@@ -2702,12 +2390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
-name = "vec-arena"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
-
-[[package]]
 name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,12 +2400,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "want"
@@ -2837,36 +2513,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
  "webpki",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
-dependencies = [
- "webpki",
-]
-
-[[package]]
-name = "wepoll-sys"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
@@ -2877,12 +2529,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2902,17 +2548,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ members = [
 ]
 
 [patch.crates-io]
-reqwest = { git = "https://github.com/messense/reqwest", branch = "tokio-0-3" }
+reqwest = { git = "https://github.com/seanmonstar/reqwest", branch = "master" }
 tokio-tungstenite = { git = "https://github.com/dnaka91/tokio-tungstenite", branch = "tokio-1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ members = [
     "./ethers-core",
     "./ethers-middleware",
 ]
+
+[patch.crates-io]
+reqwest = { git = "https://github.com/messense/reqwest", branch = "tokio-0-3" }
+tokio-tungstenite = { git = "https://github.com/dnaka91/tokio-tungstenite", branch = "tokio-1.0" }

--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = { version = "0.3.8", default-features = false }
 
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }
-tokio = { version = "0.2.21", default-features = false, features = ["macros"] }
+tokio = { version = "1.0", default-features = false, features = ["macros"] }
 
 ethers-signers = { version = "0.1.3", path = "../ethers-signers" }
 ethers-middleware = { version = "0.1.3", path = "../ethers-middleware" }

--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -17,9 +17,9 @@ ethers-contract-abigen = { version = "0.1.3", path = "ethers-contract-abigen", o
 ethers-contract-derive = { version = "0.1.3", path = "ethers-contract-derive", optional = true }
 
 serde = { version = "1.0.118", default-features = false }
-serde_json = { version = "1.0.60", default-features = false }
+serde_json = { version = "1.0.61", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
-thiserror = { version = "1.0.22", default-features = false }
+thiserror = { version = "1.0.23", default-features = false }
 once_cell = { version = "1.5.2", default-features = false }
 pin-project = {version = "1.0.2", default-features = false }
 futures-util = { version = "0.3.8", default-features = false }

--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -26,6 +26,7 @@ futures-util = { version = "0.3.8", default-features = false }
 
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }
+ethers-providers = { version = "0.1.3", path = "../ethers-providers", default-features = false, features = ["ws"] }
 tokio = { version = "1.0", default-features = false, features = ["macros"] }
 
 ethers-signers = { version = "0.1.3", path = "../ethers-signers" }

--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -18,11 +18,11 @@ ethers-contract-derive = { version = "0.1.3", path = "ethers-contract-derive", o
 
 serde = { version = "1.0.118", default-features = false }
 serde_json = { version = "1.0.61", default-features = false }
-rustc-hex = { version = "2.1.0", default-features = false }
 thiserror = { version = "1.0.23", default-features = false }
 once_cell = { version = "1.5.2", default-features = false }
 pin-project = {version = "1.0.2", default-features = false }
 futures-util = { version = "0.3.8", default-features = false }
+hex = { version = "0.4.2", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }

--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -20,7 +20,7 @@ quote = "1.0"
 syn = "1.0.12"
 url = "2.1"
 serde_json = "1.0.61"
-rustc-hex = { version = "2.1.0", default-features = false }
+hex = { version = "0.4.2", default-features = false, features = ["std"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -12,15 +12,14 @@ keywords = ["ethereum", "web3", "celo", "ethers"]
 [dependencies]
 ethers-core = { version = "0.1.3", path = "../../ethers-core" }
 
-anyhow = "1.0.36"
+anyhow = "1.0.37"
 curl = "0.4"
 Inflector = "0.11"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0.12"
 url = "2.1"
-serde_json = "1.0.53"
-once_cell = "1.3.1"
+serde_json = "1.0.61"
 rustc-hex = { version = "2.1.0", default-features = false }
 
 [package.metadata.docs.rs]

--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -8,7 +8,6 @@ use anyhow::{anyhow, Context as _, Result};
 use inflector::Inflector;
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
-use rustc_hex::ToHex;
 use syn::Ident;
 
 /// Expands a context into a method struct containing all the generated bindings
@@ -46,7 +45,7 @@ fn expand_function(function: &Function, alias: Option<Ident>) -> Result<TokenStr
     let doc = util::expand_doc(&format!(
         "Calls the contract's `{}` (0x{}) function",
         function.name,
-        function.selector().to_hex::<String>()
+        hex::encode(function.selector())
     ));
     Ok(quote! {
 

--- a/ethers-contract/src/base.rs
+++ b/ethers-contract/src/base.rs
@@ -8,7 +8,6 @@ use ethers_core::{
 };
 use ethers_providers::Middleware;
 
-use rustc_hex::ToHex;
 use std::{collections::HashMap, fmt::Debug, hash::Hash, sync::Arc};
 use thiserror::Error;
 
@@ -107,7 +106,7 @@ impl BaseContract {
             .methods
             .get(&signature)
             .map(|(name, index)| &self.abi.functions[name][*index])
-            .ok_or_else(|| Error::InvalidName(signature.to_hex::<String>()))?)
+            .ok_or_else(|| Error::InvalidName(hex::encode(signature)))?)
     }
 
     /// Returns a reference to the contract's ABI
@@ -199,7 +198,6 @@ where
 mod tests {
     use super::*;
     use ethers_core::{abi::parse_abi, types::U256};
-    use rustc_hex::FromHex;
 
     #[test]
     fn can_parse_function_inputs() {
@@ -214,7 +212,7 @@ mod tests {
 
         let encoded = abi.encode("approve", (spender, amount)).unwrap();
 
-        assert_eq!(encoded.as_ref().to_hex::<String>(), "095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        assert_eq!(hex::encode(&encoded), "095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
         let (spender2, amount2): (Address, U256) = abi.decode("approve", encoded).unwrap();
         assert_eq!(spender, spender2);
@@ -239,8 +237,7 @@ mod tests {
         .map(|hash| hash.parse::<H256>().unwrap())
         .collect::<Vec<_>>();
         let data = Bytes::from(
-            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                .from_hex::<Vec<u8>>()
+            hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .unwrap(),
         );
 

--- a/ethers-contract/src/base.rs
+++ b/ethers-contract/src/base.rs
@@ -139,7 +139,7 @@ pub(crate) fn decode_event<D: Detokenize>(
     let tokens = event
         .parse_log(RawLog {
             topics,
-            data: data.0,
+            data: data.to_vec(),
         })?
         .params
         .into_iter()
@@ -214,7 +214,7 @@ mod tests {
 
         let encoded = abi.encode("approve", (spender, amount)).unwrap();
 
-        assert_eq!(encoded.0.to_hex::<String>(), "095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        assert_eq!(encoded.as_ref().to_hex::<String>(), "095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
         let (spender2, amount2): (Address, U256) = abi.decode("approve", encoded).unwrap();
         assert_eq!(spender, spender2);

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -10,7 +10,6 @@ use ethers_core::{
 };
 use ethers_providers::Middleware;
 
-use rustc_hex::ToHex;
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
 /// A Contract is an abstraction of an executable program on the Ethereum Blockchain.
@@ -219,7 +218,7 @@ impl<M: Middleware> Contract<M> {
             .methods
             .get(&signature)
             .map(|(name, index)| &self.base_contract.abi.functions[name][*index])
-            .ok_or_else(|| Error::InvalidName(signature.to_hex::<String>()))?;
+            .ok_or_else(|| Error::InvalidName(hex::encode(signature)))?;
         self.method_func(function, args)
     }
 

--- a/ethers-contract/src/factory.rs
+++ b/ethers-contract/src/factory.rs
@@ -143,9 +143,9 @@ impl<M: Middleware> ContractFactory<M> {
                 return Err(ContractError::ConstructorError);
             }
             (None, true) => self.bytecode.clone(),
-            (Some(constructor), _) => {
-                Bytes(constructor.encode_input(self.bytecode.0.clone(), &params)?)
-            }
+            (Some(constructor), _) => constructor
+                .encode_input(self.bytecode.to_vec(), &params)?
+                .into(),
         };
 
         // create the tx object. Since we're deploying a contract, `to` is `None`

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -1,6 +1,6 @@
 use ethers_core::{
     abi::{Detokenize, Function, Token},
-    types::{Address, BlockNumber, NameOrAddress, TxHash, U256},
+    types::{Address, BlockNumber, Bytes, NameOrAddress, TxHash, U256},
 };
 use ethers_providers::Middleware;
 
@@ -139,7 +139,7 @@ pub struct Multicall<M> {
 /// with `data`
 pub struct Call {
     target: Address,
-    data: Vec<u8>,
+    data: Bytes,
     function: Function,
 }
 
@@ -207,7 +207,7 @@ impl<M: Middleware> Multicall<M> {
             (Some(NameOrAddress::Address(target)), Some(data)) => {
                 let call = Call {
                     target,
-                    data: data.0,
+                    data,
                     function: call.function,
                 };
                 self.calls.push(call);
@@ -357,7 +357,7 @@ impl<M: Middleware> Multicall<M> {
         let calls: Vec<(Address, Vec<u8>)> = self
             .calls
             .iter()
-            .map(|call| (call.target, call.data.clone()))
+            .map(|call| (call.target, call.data.to_vec()))
             .collect();
 
         // Construct the ContractCall for `aggregate` function to broadcast the transaction

--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -384,9 +384,12 @@ mod celo_tests {
         assert_eq!(value, "initial value");
 
         // make a state mutating transaction
+        // gas estimation costs are sometimes under-reported on celo,
+        // so we manually set it to avoid failures
         let call = contract
             .method::<_, H256>("setValue", "hi".to_owned())
-            .unwrap();
+            .unwrap()
+            .gas(100000);
         let pending_tx = call.send().await.unwrap();
         let _receipt = pending_tx.await.unwrap();
 

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -27,10 +27,10 @@ tiny-keccak = { version = "2.0.2", default-features = false }
 # misc
 serde = { version = "1.0.118", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.61", default-features = false }
-rustc-hex = { version = "2.1.0", default-features = false }
 thiserror = { version = "1.0.23", default-features = false }
 glob = { version = "0.3.0", default-features = false }
 bytes = { version = "1.0.0", features = ["serde"] }
+hex = { version = "0.4.2", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -26,9 +26,9 @@ tiny-keccak = { version = "2.0.2", default-features = false }
 
 # misc
 serde = { version = "1.0.118", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.60", default-features = false }
+serde_json = { version = "1.0.61", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
-thiserror = { version = "1.0.22", default-features = false }
+thiserror = { version = "1.0.23", default-features = false }
 glob = { version = "0.3.0", default-features = false }
 bytes = { version = "1.0.0", features = ["serde"] }
 

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = { version = "1.0.60", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
 thiserror = { version = "1.0.22", default-features = false }
 glob = { version = "0.3.0", default-features = false }
+bytes = { version = "1.0.0", features = ["serde"] }
 
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }

--- a/ethers-core/src/abi/tokens.rs
+++ b/ethers-core/src/abi/tokens.rs
@@ -161,7 +161,7 @@ impl Tokenizable for Bytes {
     }
 
     fn into_token(self) -> Token {
-        Token::Bytes(self.0)
+        Token::Bytes(self.to_vec())
     }
 }
 

--- a/ethers-core/src/types/bytes.rs
+++ b/ethers-core/src/types/bytes.rs
@@ -2,32 +2,32 @@ use rustc_hex::{FromHex, ToHex};
 use serde::de::{Error, Unexpected};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-/// Wrapper type around Vec<u8> to deserialize/serialize "0x" prefixed ethereum hex strings
+/// Wrapper type around Bytes to deserialize/serialize "0x" prefixed ethereum hex strings
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
 pub struct Bytes(
     #[serde(
         serialize_with = "serialize_bytes",
         deserialize_with = "deserialize_bytes"
     )]
-    pub Vec<u8>,
+    pub bytes::Bytes,
 );
+
+impl Bytes {
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.as_ref().to_vec()
+    }
+
+}
 
 impl AsRef<[u8]> for Bytes {
     fn as_ref(&self) -> &[u8] {
-        &self.0[..]
-    }
-}
-
-impl Bytes {
-    /// Returns an empty bytes vector
-    pub fn new() -> Self {
-        Bytes(vec![])
+        &self.0.as_ref()
     }
 }
 
 impl From<Vec<u8>> for Bytes {
     fn from(src: Vec<u8>) -> Self {
-        Self(src)
+        Self(src.into())
     }
 }
 
@@ -39,15 +39,15 @@ where
     s.serialize_str(&format!("0x{}", x.as_ref().to_hex::<String>()))
 }
 
-pub fn deserialize_bytes<'de, D>(d: D) -> Result<Vec<u8>, D::Error>
+pub fn deserialize_bytes<'de, D>(d: D) -> Result<bytes::Bytes, D::Error>
 where
     D: Deserializer<'de>,
 {
     let value = String::deserialize(d)?;
     if value.len() >= 2 && &value[0..2] == "0x" {
-        let bytes = FromHex::from_hex(&value[2..])
+        let bytes: Vec<u8> = FromHex::from_hex(&value[2..])
             .map_err(|e| Error::custom(format!("Invalid hex: {}", e)))?;
-        Ok(bytes)
+        Ok(bytes.into())
     } else {
         Err(Error::invalid_value(Unexpected::Str(&value), &"0x prefix"))
     }

--- a/ethers-core/src/types/bytes.rs
+++ b/ethers-core/src/types/bytes.rs
@@ -1,4 +1,3 @@
-use rustc_hex::{FromHex, ToHex};
 use serde::de::{Error, Unexpected};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -35,7 +34,7 @@ where
     S: Serializer,
     T: AsRef<[u8]>,
 {
-    s.serialize_str(&format!("0x{}", x.as_ref().to_hex::<String>()))
+    s.serialize_str(&format!("0x{}", hex::encode(x.as_ref())))
 }
 
 pub fn deserialize_bytes<'de, D>(d: D) -> Result<bytes::Bytes, D::Error>
@@ -44,8 +43,8 @@ where
 {
     let value = String::deserialize(d)?;
     if value.len() >= 2 && &value[0..2] == "0x" {
-        let bytes: Vec<u8> = FromHex::from_hex(&value[2..])
-            .map_err(|e| Error::custom(format!("Invalid hex: {}", e)))?;
+        let bytes: Vec<u8> =
+            hex::decode(&value[2..]).map_err(|e| Error::custom(format!("Invalid hex: {}", e)))?;
         Ok(bytes.into())
     } else {
         Err(Error::invalid_value(Unexpected::Str(&value), &"0x prefix"))

--- a/ethers-core/src/types/bytes.rs
+++ b/ethers-core/src/types/bytes.rs
@@ -16,7 +16,6 @@ impl Bytes {
     pub fn to_vec(&self) -> Vec<u8> {
         self.as_ref().to_vec()
     }
-
 }
 
 impl AsRef<[u8]> for Bytes {

--- a/ethers-core/src/types/log.rs
+++ b/ethers-core/src/types/log.rs
@@ -4,7 +4,6 @@ use crate::{
     utils::keccak256,
 };
 use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
-use std::str::FromStr;
 
 /// A log produced by a transaction.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -147,11 +146,6 @@ impl Filter {
         self
     }
 
-    pub fn address_str(mut self, address: &str) -> Result<Self, rustc_hex::FromHexError> {
-        self.address = Some(Address::from_str(address)?);
-        Ok(self)
-    }
-
     /// given the event in string form, it hashes it and adds it to the topics to monitor
     pub fn event(self, event_name: &str) -> Self {
         let hash = H256::from(keccak256(event_name.as_bytes()));
@@ -259,7 +253,7 @@ mod tests {
 
         let event = "ValueChanged(address,string,string)";
         let t0 = H256::from(keccak256(event.as_bytes()));
-        let addr = Address::from_str("f817796F60D268A36a57b8D2dF1B97B14C0D0E1d").unwrap();
+        let addr: Address = "f817796F60D268A36a57b8D2dF1B97B14C0D0E1d".parse().unwrap();
         let filter = Filter::new();
 
         let ser = serialize(&filter.clone());

--- a/ethers-core/src/types/mod.rs
+++ b/ethers-core/src/types/mod.rs
@@ -11,7 +11,7 @@ mod transaction;
 pub use transaction::{Transaction, TransactionReceipt, TransactionRequest};
 
 mod bytes;
-pub use bytes::Bytes;
+pub use self::bytes::Bytes;
 
 mod block;
 pub use block::{Block, BlockId, BlockNumber};

--- a/ethers-core/src/types/signature.rs
+++ b/ethers-core/src/types/signature.rs
@@ -4,7 +4,6 @@ use crate::{
     utils::hash_message,
 };
 
-use rustc_hex::{FromHex, ToHex};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fmt, str::FromStr};
 
@@ -26,7 +25,7 @@ pub enum SignatureError {
     InvalidLength(usize),
     /// When parsing a signature from string to hex
     #[error(transparent)]
-    DecodingError(#[from] rustc_hex::FromHexError),
+    DecodingError(#[from] hex::FromHexError),
     /// Thrown when signature verification failed (i.e. when the address that
     /// produced the signature did not match the expected address)
     #[error("Signature verification failed. Expected {0}, got {1}")]
@@ -66,7 +65,7 @@ pub struct Signature {
 impl fmt::Display for Signature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let sig = <[u8; 65]>::from(self);
-        write!(f, "{}", sig.to_hex::<String>())
+        write!(f, "{}", hex::encode(sig))
     }
 }
 
@@ -174,7 +173,7 @@ impl FromStr for Signature {
     type Err = SignatureError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = s.from_hex::<Vec<u8>>()?;
+        let bytes = hex::decode(s)?;
         Signature::try_from(&bytes[..])
     }
 }

--- a/ethers-core/src/types/transaction.rs
+++ b/ethers-core/src/types/transaction.rs
@@ -6,7 +6,6 @@ use crate::{
 
 use rlp::RlpStream;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
 
 // Number of tx fields before signing
 #[cfg(not(feature = "celo"))]
@@ -92,12 +91,6 @@ impl TransactionRequest {
     pub fn from<T: Into<Address>>(mut self, from: T) -> Self {
         self.from = Some(from.into());
         self
-    }
-
-    /// Sets the `to` field in the transaction to the provided value
-    pub fn send_to_str(mut self, to: &str) -> Result<Self, rustc_hex::FromHexError> {
-        self.to = Some(Address::from_str(to)?.into());
-        Ok(self)
     }
 
     /// Sets the `to` field in the transaction to the provided value

--- a/ethers-core/src/types/transaction.rs
+++ b/ethers-core/src/types/transaction.rs
@@ -196,7 +196,7 @@ impl TransactionRequest {
 
         rlp_opt(rlp, self.to.as_ref());
         rlp_opt(rlp, self.value);
-        rlp_opt(rlp, self.data.as_ref().map(|d| &d.0[..]));
+        rlp_opt(rlp, self.data.as_ref().map(|d| d.as_ref()));
     }
 }
 
@@ -328,7 +328,7 @@ impl Transaction {
     }
 
     pub fn hash(&self) -> H256 {
-        keccak256(&self.rlp().0).into()
+        keccak256(&self.rlp().as_ref()).into()
     }
 
     pub fn rlp(&self) -> Bytes {
@@ -343,7 +343,7 @@ impl Transaction {
 
         rlp_opt(&mut rlp, self.to);
         rlp.append(&self.value);
-        rlp.append(&self.input.0);
+        rlp.append(&self.input.as_ref());
         rlp.append(&self.v);
         rlp.append(&self.r);
         rlp.append(&self.s);

--- a/ethers-core/src/utils/ganache.rs
+++ b/ethers-core/src/utils/ganache.rs
@@ -3,7 +3,6 @@ use crate::{
     utils::{secret_key_to_address, unused_port},
 };
 use k256::{ecdsa::SigningKey, SecretKey as K256SecretKey};
-use rustc_hex::FromHex;
 use std::{
     io::{BufRead, BufReader},
     process::{Child, Command},
@@ -161,9 +160,7 @@ impl Ganache {
 
             if is_private_key && line.starts_with('(') {
                 let key_str = &line[6..line.len() - 1];
-                let key_hex = key_str
-                    .from_hex::<Vec<u8>>()
-                    .expect("could not parse as hex");
+                let key_hex = hex::decode(key_str).expect("could not parse as hex");
                 let key = K256SecretKey::from_bytes(&key_hex).expect("did not get private key");
                 addresses.push(secret_key_to_address(&SigningKey::from(&key)));
                 private_keys.push(key);

--- a/ethers-core/src/utils/hash.rs
+++ b/ethers-core/src/utils/hash.rs
@@ -59,13 +59,12 @@ pub fn serialize<T: serde::Serialize>(t: &T) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustc_hex::ToHex;
 
     #[test]
     // from https://emn178.github.io/online-tools/keccak_256.html
     fn test_keccak256() {
         assert_eq!(
-            keccak256(b"hello").to_hex::<String>(),
+            hex::encode(keccak256(b"hello")),
             "1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8"
         );
     }

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -25,7 +25,6 @@ pub use rlp;
 
 use crate::types::{Address, Bytes, U256};
 use k256::{ecdsa::SigningKey, EncodedPoint as K256PublicKey};
-use rustc_hex::ToHex;
 use std::convert::TryInto;
 
 /// 1 Ether = 1e18 Wei == 0x0de0b6b3a7640000 Wei
@@ -125,10 +124,10 @@ pub fn to_checksum(addr: &Address, chain_id: Option<u8>) -> String {
         Some(chain_id) => format!("{}0x{:x}", chain_id, addr),
         None => format!("{:x}", addr),
     };
-    let hash = keccak256(&prefixed_addr).to_hex::<String>();
+    let hash = hex::encode(keccak256(&prefixed_addr));
     let hash = hash.as_bytes();
 
-    let addr_hex = addr.as_bytes().to_hex::<String>();
+    let addr_hex = hex::encode(addr.as_bytes());
     let addr_hex = addr_hex.as_bytes();
 
     addr_hex
@@ -161,7 +160,6 @@ pub(crate) fn unused_port() -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustc_hex::FromHex;
 
     #[test]
     fn wei_in_ether() {
@@ -324,8 +322,8 @@ mod tests {
             ),
         ] {
             let from = from.parse::<Address>().unwrap();
-            let salt = salt.from_hex::<Vec<u8>>().unwrap();
-            let init_code = init_code.from_hex::<Vec<u8>>().unwrap();
+            let salt = hex::decode(salt).unwrap();
+            let init_code = hex::decode(init_code).unwrap();
             let expected = expected.parse::<Address>().unwrap();
             assert_eq!(expected, get_create2_address(from, salt, init_code))
         }

--- a/ethers-core/src/utils/solc.rs
+++ b/ethers-core/src/utils/solc.rs
@@ -1,6 +1,5 @@
 use crate::{abi::Abi, types::Bytes};
 use glob::glob;
-use rustc_hex::FromHex;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, fmt, io::BufRead, path::PathBuf, process::Command};
 use thiserror::Error;
@@ -145,9 +144,7 @@ impl Solc {
                     .expect("could not parse `solc` abi, this should never happen");
 
                 // parse the bytecode
-                let bytecode = contract
-                    .bin
-                    .from_hex::<Vec<u8>>()
+                let bytecode = hex::decode(contract.bin)
                     .expect("solc did not produce valid bytecode")
                     .into();
                 (name, CompiledContract { abi, bytecode })

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -30,15 +30,13 @@ serde-aux = { version = "2.1.0", default-features = false }
 reqwest = { version = "0.10.10", default-features = false, features = ["json", "rustls-tls"] }
 url = { version = "2.2.0", default-features = false }
 
-# optional for runtime
-tokio = { version = "0.2.22", optional = true }
-async-std = { version = "1.6.5", optional = true }
+tokio = { version = "1.0" }
 
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }
 futures-executor = { version = "0.3.5", features = ["thread-pool"] }
 rustc-hex = "2.1.0"
-tokio = { version = "0.2.21", default-features = false, features = ["rt-core", "macros"] }
+tokio = { version = "1.0", default-features = false, features = ["rt", "macros", "time"] }
 
 [features]
 celo = ["ethers-core/celo", "ethers-providers/celo", "ethers-signers/celo"]

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1.0" }
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }
 futures-executor = { version = "0.3.5", features = ["thread-pool"] }
-rustc-hex = "2.1.0"
+hex = { version = "0.4.2", default-features = false, features = ["std"] }
 tokio = { version = "1.0", default-features = false, features = ["rt", "macros", "time"] }
 
 [features]

--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -298,7 +298,6 @@ where
 mod tests {
     use super::*;
     use ethers::{providers::Provider, signers::LocalWallet};
-    use rustc_hex::FromHex;
     use std::convert::TryFrom;
 
     #[tokio::test]
@@ -337,7 +336,7 @@ mod tests {
                 .unwrap()
         );
 
-        let expected_rlp = Bytes::from("f869808504e3b29200831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a0c9cf86333bcb065d140032ecaab5d9281bde80f21b9687b3e94161de42d51895a0727a108a0b8d101465414033c3f705a9c7b826e596766046ee1183dbc8aeaa68".from_hex::<Vec<u8>>().unwrap());
+        let expected_rlp = Bytes::from(hex::decode("f869808504e3b29200831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a0c9cf86333bcb065d140032ecaab5d9281bde80f21b9687b3e94161de42d51895a0727a108a0b8d101465414033c3f705a9c7b826e596766046ee1183dbc8aeaa68").unwrap());
         assert_eq!(tx.rlp(), expected_rlp);
     }
 }

--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -135,7 +135,7 @@ where
 
         // Get the actual transaction hash
         let rlp = tx.rlp_signed(&signature);
-        let hash = keccak256(&rlp.0);
+        let hash = keccak256(&rlp.as_ref());
 
         // This function should not be called with ENS names
         let to = tx.to.map(|to| match to {
@@ -337,7 +337,7 @@ mod tests {
                 .unwrap()
         );
 
-        let expected_rlp = Bytes("f869808504e3b29200831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a0c9cf86333bcb065d140032ecaab5d9281bde80f21b9687b3e94161de42d51895a0727a108a0b8d101465414033c3f705a9c7b826e596766046ee1183dbc8aeaa68".from_hex().unwrap());
+        let expected_rlp = Bytes::from("f869808504e3b29200831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a0c9cf86333bcb065d140032ecaab5d9281bde80f21b9687b3e94161de42d51895a0727a108a0b8d101465414033c3f705a9c7b826e596766046ee1183dbc8aeaa68".from_hex::<Vec<u8>>().unwrap());
         assert_eq!(tx.rlp(), expected_rlp);
     }
 }

--- a/ethers-middleware/tests/gas_escalator.rs
+++ b/ethers-middleware/tests/gas_escalator.rs
@@ -43,7 +43,7 @@ async fn gas_escalator_live() {
         .unwrap();
 
     // Wait a bunch of seconds and refresh etherscan to see the transactions get bumped
-    tokio::time::delay_for(std::time::Duration::from_secs(100)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(100)).await;
 
     // TODO: Figure out how to test this behavior properly in a local network. If the gas price was bumped
     // then the tx hash will be different

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -35,47 +35,16 @@ pin-project = { version = "1.0.2", default-features = false }
 tracing = { version = "0.1.22", default-features = false }
 tracing-futures = { version = "0.2.4", default-features = false }
 
-# ws support async-std and tokio runtimes for the convenience methods
-async-tungstenite = { version = "0.6.0", default-features = false, optional = true }
-async-std = { version = "1.6.2", default-features = false, optional = true }
-tokio = { version = "0.2.21", default-features = false, optional = true }
-# needed for tls
-real-tokio-native-tls = { package = "tokio-native-tls", version = "0.1.0", default-features = false, optional = true }
-async-tls = { version = "0.7.0", optional = true }
+# tokio
+tokio = { version = "1.0", default-features = false, optional = true }
+tokio-tungstenite = { version = "0.12.0", default-features = false, features = ["connect", "tls"], optional = true }
 
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }
 
 rustc-hex = "2.1.0"
-tokio = { version = "0.2.21", default-features = false, features = ["rt-core", "macros"] }
-async-std = { version = "1.6.2", default-features = false, features = ["attributes"] }
-async-tungstenite = { version = "0.6.0", default-features = false, features = ["tokio-runtime"] }
+tokio = { version = "1.0", default-features = false, features = ["rt", "macros"] }
 
 [features]
-# slightly opinionated, but for convenience we default to tokio-tls
-# to allow websockets w/ TLS support
-default = ["tokio-tls"]
 celo = ["ethers-core/celo"]
-ws = ["async-tungstenite"]
-
-tokio-runtime = [
-    "ws",
-    "tokio",
-    "async-tungstenite/tokio-runtime"
-]
-tokio-tls = [
-    "tokio-runtime",
-    "async-tungstenite/tokio-native-tls",
-    "real-tokio-native-tls"
-]
-
-async-std-runtime = [
-    "ws",
-    "async-std",
-    "async-tungstenite/async-std-runtime"
-]
-async-std-tls = [
-    "async-std-runtime",
-    "async-tungstenite/async-tls",
-    "async-tls"
-]
+ws = ["tokio", "tokio-tungstenite"]

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -41,9 +41,8 @@ tokio-tungstenite = { version = "0.12.0", default-features = false, features = [
 
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }
-
-rustc-hex = "2.1.0"
 tokio = { version = "1.0", default-features = false, features = ["rt", "macros"] }
+hex = { version = "0.4.2", default-features = false, features = ["std"] }
 
 [features]
 default = ["ws"]

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -46,5 +46,6 @@ rustc-hex = "2.1.0"
 tokio = { version = "1.0", default-features = false, features = ["rt", "macros"] }
 
 [features]
+default = ["ws"]
 celo = ["ethers-core/celo"]
 ws = ["tokio", "tokio-tungstenite"]

--- a/ethers-providers/src/ens.rs
+++ b/ethers-providers/src/ens.rs
@@ -69,7 +69,6 @@ pub fn namehash(name: &str) -> H256 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rustc_hex::FromHex;
 
     fn assert_hex(hash: H256, val: &str) {
         let v = if val.starts_with("0x") {
@@ -78,14 +77,11 @@ mod tests {
             val
         };
 
-        assert_eq!(hash.0.to_vec(), v.from_hex::<Vec<u8>>().unwrap());
+        assert_eq!(hash.0.to_vec(), hex::decode(v).unwrap());
     }
 
     #[test]
     fn test_namehash() {
-        dbg!("00000000000C2E074eC69A0dFb2997BA6C7d2e1e"
-            .from_hex::<Vec<u8>>()
-            .unwrap());
         for (name, expected) in &[
             (
                 "",

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -30,49 +30,12 @@
 //!
 //! # Websockets
 //!
-//! The crate has support for WebSockets. If none of the provided async runtime
-//! features are enabled, you must manually instantiate the WS connection and wrap
-//! it with with a [`Ws::new`](method@crate::Ws::new) call.
+//! The crate has support for WebSockets via Tokio.
 //!
-//! ```ignore
-//! use ethers::providers::Ws;
-//!
-//! let ws = Ws::new(...);
 //! ```
-//!
-//! If you have compiled the library with any of the following features, you may
-//! instantiate the websocket instance with the `connect` call and your URL:
-//! - `tokio-runtime`: Uses `tokio` as the runtime
-//! - `async-std-runtime`: Uses `async-std-runtime`
-//!
-//! ```no_run
-//! # #[cfg(any(
-//! #     feature = "tokio-runtime",
-//! #     feature = "tokio-tls",
-//! #     feature = "async-std-runtime",
-//! #     feature = "async-std-tls",
-//! # ))]
 //! # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
 //! # use ethers::providers::Ws;
 //! let ws = Ws::connect("ws://localhost:8545").await?;
-//! # Ok(())
-//! # }
-//! ```
-//!
-//! TLS support is also provided via the following feature flags:
-//! - `tokio-tls`
-//! - `async-tls`
-//!
-//! ```no_run
-//! # #[cfg(any(
-//! #     feature = "tokio-runtime",
-//! #     feature = "tokio-tls",
-//! #     feature = "async-std-runtime",
-//! #     feature = "async-std-tls",
-//! # ))]
-//! # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
-//! # use ethers::providers::Ws;
-//! let ws = Ws::connect("wss://localhost:8545").await?;
 //! # Ok(())
 //! # }
 //! ```

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -685,11 +685,11 @@ impl<P: JsonRpcClient> Provider<P> {
     }
 }
 
-#[cfg(any(feature = "tokio-runtime", feature = "async-std-runtime"))]
+#[cfg(feature = "ws")]
 impl Provider<crate::Ws> {
     /// Direct connection to a websocket endpoint
     pub async fn connect(
-        url: impl async_tungstenite::tungstenite::client::IntoClientRequest + Unpin,
+        url: impl tokio_tungstenite::tungstenite::client::IntoClientRequest + Unpin,
     ) -> Result<Self, ProviderError> {
         let ws = crate::Ws::connect(url).await?;
         Ok(Self::new(ws))

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -730,8 +730,8 @@ impl Provider<MockProvider> {
 ///
 /// If the provided bytes were not an interpretation of an address
 fn decode_bytes<T: Detokenize>(param: ParamType, bytes: Bytes) -> T {
-    let tokens =
-        abi::decode(&[param], &bytes.0).expect("could not abi-decode bytes to address tokens");
+    let tokens = abi::decode(&[param], &bytes.as_ref())
+        .expect("could not abi-decode bytes to address tokens");
     T::from_tokens(tokens).expect("could not parse tokens as address")
 }
 

--- a/ethers-providers/src/pubsub.rs
+++ b/ethers-providers/src/pubsub.rs
@@ -84,7 +84,7 @@ where
 }
 
 #[pinned_drop]
-impl<'a, P, R> PinnedDrop for SubscriptionStream<'a, P, R>
+impl<P, R> PinnedDrop for SubscriptionStream<'_, P, R>
 where
     P: PubsubClient,
     R: DeserializeOwned,

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -6,7 +6,6 @@ use crate::{
 use ethers_core::types::U256;
 
 use async_trait::async_trait;
-use async_tungstenite::tungstenite::{self, protocol::Message};
 use futures_channel::{mpsc, oneshot};
 use futures_util::{
     sink::{Sink, SinkExt},
@@ -22,53 +21,21 @@ use std::{
     },
 };
 use thiserror::Error;
-
-// `connect_async` adapter
-#[cfg(all(feature = "async-std-runtime", not(feature = "tokio-runtime")))]
-use async_tungstenite::async_std::connect_async;
-#[cfg(feature = "tokio-runtime")]
-use async_tungstenite::tokio::connect_async;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{self, protocol::Message},
+};
 
 /// A JSON-RPC Client over Websockets.
 ///
-/// If the library is not compiled with any runtime support, then you will have
-/// to manually instantiate a websocket connection and call `Provider::new` on it.
-///
-/// ```ignore
-/// use ethers::providers::Ws;
-///
-/// let ws = Ws::new(...)
-/// ```
-///
-/// If you have compiled the library with any of the following features, you may
-/// instantiate the websocket instance with the `connect` call and your URL:
-/// - `tokio-runtime`: Uses `tokio` as the runtime
-/// - `tokio-tls`: Same as `tokio-runtime` but with TLS support
-/// - `async-std-runtime`: Uses `async-std-runtime`
-/// - `async-tls`: Same as `async-std-runtime` but with TLS support
-///
 /// ```no_run
-/// # #[cfg(any(
-/// #     feature = "tokio-runtime",
-/// #     feature = "tokio-tls",
-/// #     feature = "async-std-runtime",
-/// #     feature = "async-std-tls",
-/// # ))]
 /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
 /// use ethers::providers::Ws;
 ///
-/// let ws = Ws::connect("ws://localhost:8545").await?;
-///
-/// // If built with TLS support (otherwise will get a "TLS Support not compiled in" error)
 /// let ws = Ws::connect("wss://localhost:8545").await?;
 /// # Ok(())
 /// # }
 /// ```
-///
-/// This feature is built using [`async-tungstenite`](https://docs.rs/async-tungstenite). If you need other runtimes,
-/// consider importing `async-tungstenite` with the [corresponding feature
-/// flag](https://github.com/sdroege/async-tungstenite/blob/master/Cargo.toml#L15-L22)
-/// for your runtime.
 #[derive(Clone)]
 pub struct Ws {
     id: Arc<AtomicU64>,
@@ -123,8 +90,7 @@ impl Ws {
         }
     }
 
-    /// Initializes a new WebSocket Client, assuming usage of tokio or async-std
-    #[cfg(any(feature = "tokio-runtime", feature = "async-std-runtime"))]
+    /// Initializes a new WebSocket Client
     pub async fn connect(
         url: impl tungstenite::client::IntoClientRequest + Unpin,
     ) -> Result<Self, ClientError> {
@@ -214,7 +180,6 @@ where
     }
 
     /// Spawns the event loop
-    #[allow(unused)]
     fn spawn(mut self)
     where
         S: 'static,
@@ -225,12 +190,7 @@ where
             }
         };
 
-        #[cfg(all(not(feature = "async-std-runtime"), feature = "tokio-runtime"))]
         tokio::spawn(f);
-        // TODO: Ensure that this works with both async-std and tokio.
-        // Remove allow(unused) when fixed.
-        #[cfg(all(feature = "async-std-runtime", not(feature = "tokio-runtime")))]
-        async_std::task::spawn(f);
     }
 
     /// Processes 1 item selected from the incoming `requests` or `ws`

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -136,7 +136,6 @@ mod celo_tests {
     use super::*;
     use ethers::types::{Randomness, H256};
     use futures_util::stream::StreamExt;
-    use rustc_hex::FromHex;
 
     #[tokio::test]
     // https://alfajores-blockscout.celo-testnet.org/tx/0x544ea96cddb16aeeaedaf90885c1e02be4905f3eb43d6db3f28cac4dbe76a625/internal_transactions
@@ -163,14 +162,16 @@ mod celo_tests {
         assert_eq!(
             block.randomness,
             Randomness {
-                committed: "003e12deb86292844274493e9ab6e57ed1e276202c16799d97af723eb0d3253f"
-                    .from_hex::<Vec<u8>>()
-                    .unwrap()
-                    .into(),
-                revealed: "1333b3b45e0385da48a01b4459aeda7607867ef6a41167cfdeefa49b9fdce6d7"
-                    .from_hex::<Vec<u8>>()
-                    .unwrap()
-                    .into(),
+                committed: hex::decode(
+                    "003e12deb86292844274493e9ab6e57ed1e276202c16799d97af723eb0d3253f"
+                )
+                .unwrap()
+                .into(),
+                revealed: hex::decode(
+                    "1333b3b45e0385da48a01b4459aeda7607867ef6a41167cfdeefa49b9fdce6d7"
+                )
+                .unwrap()
+                .into(),
             }
         );
     }

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = { version = "1.0.22", default-features = false }
 serde = { version = "1.0.118", default-features = false }
 
 coins-ledger = { git = "https://github.com/summa-tx/bitcoins-rs", default-features = false, optional = true, branch = "master" }
-rustc-hex = { version = "2.1.0", default-features = false }
+hex = { version = "0.4.2", default-features = false, features = ["std"] }
 async-trait = { version = "0.1.40", default-features = false }
 elliptic-curve = { version = "0.8.4", default-features = false }
 sha2 = { version = "0.9.2", default-features = false }

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -32,7 +32,7 @@ yubihsm = { version = "0.37.0", features = ["secp256k1", "http", "usb"], optiona
 ethers = { version = "0.1.3", path = "../ethers" }
 yubihsm = { version = "0.37.0", features = ["secp256k1", "usb", "mockhsm"] }
 
-tokio = { version = "0.2.21", default-features = false, features = ["macros"] }
+tokio = { version = "1.0", default-features = false, features = ["macros"] }
 serde_json = { version = "1.0.55", default-features = false }  
 
 [features]

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -16,8 +16,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 ethers-core = { version = "0.1.3", path = "../ethers-core" }
 thiserror = { version = "1.0.22", default-features = false }
-futures-util = { version = "0.3.8", default-features = false }
-futures-executor = { version = "0.3.8", default-features = false }
 serde = { version = "1.0.118", default-features = false }
 
 coins-ledger = { git = "https://github.com/summa-tx/bitcoins-rs", default-features = false, optional = true, branch = "master" }
@@ -27,6 +25,8 @@ elliptic-curve = { version = "0.8.4", default-features = false }
 sha2 = { version = "0.9.2", default-features = false }
 rand = { version = "0.7.3", default-features = false }
 yubihsm = { version = "0.37.0", features = ["secp256k1", "http", "usb"], optional = true }
+futures-util = "0.3.8"
+futures-executor = "0.3.8"
 
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }

--- a/ethers-signers/src/ledger/app.rs
+++ b/ethers-signers/src/ledger/app.rs
@@ -95,8 +95,10 @@ impl LedgerEthereum {
         let address = {
             // extract the address from the response
             let offset = 1 + result[0] as usize;
-            let address = &result[offset + 1..offset + 1 + result[offset] as usize];
-            std::str::from_utf8(address)?.parse::<Address>()?
+            let address_str = &result[offset + 1..offset + 1 + result[offset] as usize];
+            let mut address = [0; 20];
+            address.copy_from_slice(&hex::decode(address_str)?);
+            Address::from(address)
         };
 
         Ok(address)

--- a/ethers-signers/src/ledger/app.rs
+++ b/ethers-signers/src/ledger/app.rs
@@ -207,7 +207,6 @@ mod tests {
     use super::*;
     use crate::Signer;
     use ethers::prelude::*;
-    use rustc_hex::FromHex;
     use std::str::FromStr;
 
     #[tokio::test]
@@ -239,7 +238,7 @@ mod tests {
             .unwrap();
 
         // approve uni v2 router 0xff
-        let data = "095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".from_hex::<Vec<u8>>().unwrap();
+        let data = hex::decode("095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap();
 
         let tx_req = TransactionRequest::new()
             .send_to_str("2ed7afa17473e17ac59908f088b4371d28585476")

--- a/ethers-signers/src/ledger/app.rs
+++ b/ethers-signers/src/ledger/app.rs
@@ -243,8 +243,9 @@ mod tests {
         let data = hex::decode("095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap();
 
         let tx_req = TransactionRequest::new()
-            .send_to_str("2ed7afa17473e17ac59908f088b4371d28585476")
-            .unwrap()
+            .to("2ed7afa17473e17ac59908f088b4371d28585476"
+                .parse::<Address>()
+                .unwrap())
             .gas(1000000)
             .gas_price(400e9 as u64)
             .nonce(5)

--- a/ethers-signers/src/ledger/types.rs
+++ b/ethers-signers/src/ledger/types.rs
@@ -34,7 +34,7 @@ pub enum LedgerError {
     UnexpectedNullResponse,
 
     #[error(transparent)]
-    HexError(#[from] rustc_hex::FromHexError),
+    HexError(#[from] hex::FromHexError),
 
     #[error("Error when decoding UTF8 Response: {0}")]
     Utf8Error(#[from] std::str::Utf8Error),

--- a/ethers-signers/src/wallet/private_key.rs
+++ b/ethers-signers/src/wallet/private_key.rs
@@ -86,8 +86,7 @@ impl FromStr for Wallet<SigningKey> {
     type Err = K256Error;
 
     fn from_str(src: &str) -> Result<Self, Self::Err> {
-        let src = hex::decode(src)
-            .expect("invalid hex when reading PrivateKey");
+        let src = hex::decode(src).expect("invalid hex when reading PrivateKey");
         let sk = SigningKey::from_bytes(&src).unwrap(); // TODO
         Ok(sk.into())
     }

--- a/ethers-signers/src/wallet/private_key.rs
+++ b/ethers-signers/src/wallet/private_key.rs
@@ -9,7 +9,6 @@ use ethers_core::{
     types::Address,
     utils::keccak256,
 };
-use rustc_hex::FromHex;
 use std::str::FromStr;
 
 impl Clone for Wallet<SigningKey> {
@@ -87,8 +86,7 @@ impl FromStr for Wallet<SigningKey> {
     type Err = K256Error;
 
     fn from_str(src: &str) -> Result<Self, Self::Err> {
-        let src = src
-            .from_hex::<Vec<u8>>()
+        let src = hex::decode(src)
             .expect("invalid hex when reading PrivateKey");
         let sk = SigningKey::from_bytes(&src).unwrap(); // TODO
         Ok(sk.into())

--- a/ethers-signers/src/wallet/yubi.rs
+++ b/ethers-signers/src/wallet/yubi.rs
@@ -67,13 +67,11 @@ impl From<YubiSigner<Secp256k1>> for Wallet<YubiSigner<Secp256k1>> {
 mod tests {
     use super::*;
     use crate::Signer;
-    use rustc_hex::FromHex;
     use std::str::FromStr;
 
     #[tokio::test]
     async fn from_key() {
-        let key = "2d8c44dc2dd2f0bea410e342885379192381e82d855b1b112f9b55544f1e0900"
-            .from_hex::<Vec<u8>>()
+        let key = hex::decode("2d8c44dc2dd2f0bea410e342885379192381e82d855b1b112f9b55544f1e0900")
             .unwrap();
 
         let connector = yubihsm::Connector::mockhsm();

--- a/ethers/Cargo.toml
+++ b/ethers/Cargo.toml
@@ -20,16 +20,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 features = ["full"]
 
 [features]
-abigen = ["contract", "ethers-contract/abigen"]
-default = ["full"]
-full = [
-    "contract",
-    "providers",
-    "signers",
-    "core",
-    "middleware",
-]
-
 celo = [
     "ethers-core/celo",
     "ethers-providers/celo",
@@ -38,24 +28,20 @@ celo = [
     "ethers-middleware/celo",
 ]
 
-core = ["ethers-core"]
-contract = ["ethers-contract"]
-providers = ["ethers-providers"]
-middleware = ["ethers-middleware"]
-signers = ["ethers-signers"]
 ledger = ["ethers-signers/ledger"]
 yubi = ["ethers-signers/yubi"]
+ws = ["ethers-providers/ws"]
+abigen = ["ethers-contract/abigen"]
 
 [dependencies]
-ethers-contract = { version = "0.1.3", path = "../ethers-contract", optional = true }
-ethers-core = { version = "0.1.3", path = "../ethers-core", optional = true }
-ethers-providers = { version = "0.1.3", path = "../ethers-providers", optional = true }
-ethers-signers = { version = "0.1.3", path = "../ethers-signers", optional = true }
-ethers-middleware = { version = "0.1.3", path = "../ethers-middleware", optional = true }
+ethers-contract = { version = "0.1.3", path = "../ethers-contract" }
+ethers-core = { version = "0.1.3", path = "../ethers-core" }
+ethers-providers = { version = "0.1.3", path = "../ethers-providers" }
+ethers-signers = { version = "0.1.3", path = "../ethers-signers" }
+ethers-middleware = { version = "0.1.3", path = "../ethers-middleware" }
 
 [dev-dependencies]
 ethers-contract = { version = "0.1.3", path = "../ethers-contract", features = ["abigen"] }
-ethers-providers = { version = "0.1.3", path = "../ethers-providers" }
 
 anyhow = "1.0.36"
 rand = "0.7"

--- a/ethers/Cargo.toml
+++ b/ethers/Cargo.toml
@@ -61,4 +61,4 @@ anyhow = "1.0.31"
 rand = "0.7"
 serde = { version = "1.0.110", features = ["derive"] }
 serde_json = "1.0.53"
-tokio = { version = "0.2.21", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/ethers/Cargo.toml
+++ b/ethers/Cargo.toml
@@ -57,7 +57,7 @@ ethers-middleware = { version = "0.1.3", path = "../ethers-middleware", optional
 ethers-contract = { version = "0.1.3", path = "../ethers-contract", features = ["abigen"] }
 ethers-providers = { version = "0.1.3", path = "../ethers-providers" }
 
-anyhow = "1.0.31"
+anyhow = "1.0.36"
 rand = "0.7"
 serde = { version = "1.0.110", features = ["derive"] }
 serde_json = "1.0.53"

--- a/ethers/src/lib.rs
+++ b/ethers/src/lib.rs
@@ -82,50 +82,28 @@
 //! [`utils`]: core::utils
 //! [`abi`]: core::abi
 //! [`types`]: core::types
-
-#[cfg(feature = "contract")]
 pub use ethers_contract as contract;
-
-#[cfg(feature = "providers")]
-pub use ethers_providers as providers;
-
-#[cfg(feature = "signers")]
-pub use ethers_signers as signers;
-
-#[cfg(feature = "core")]
 pub use ethers_core as core;
-
-#[cfg(feature = "middleware")]
 pub use ethers_middleware as middleware;
+pub use ethers_providers as providers;
+pub use ethers_signers as signers;
 
 // Re-export ethers_core::utils/types/abi
 // We hide these docs so that the rustdoc links send the visitor
 // to the corresponding crate, instead of the re-export
 #[doc(hidden)]
-#[cfg(feature = "core")]
 pub use ethers_core::abi;
 #[doc(hidden)]
-#[cfg(feature = "core")]
 pub use ethers_core::types;
 #[doc(hidden)]
-#[cfg(feature = "core")]
 pub use ethers_core::utils;
 
 /// Easy imports of frequently used type definitions and traits
 #[doc(hidden)]
 pub mod prelude {
-    #[cfg(feature = "contract")]
     pub use ethers_contract::*;
-
-    #[cfg(feature = "providers")]
-    pub use ethers_providers::*;
-
-    #[cfg(feature = "signers")]
-    pub use ethers_signers::*;
-
-    #[cfg(feature = "middleware")]
-    pub use ethers_middleware::*;
-
-    #[cfg(feature = "core")]
     pub use ethers_core::types::*;
+    pub use ethers_middleware::*;
+    pub use ethers_providers::*;
+    pub use ethers_signers::*;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Fixes #114 

## Solution

Updates deps to Tokio 1.0. Async-std is no longer a dep.

Blocked on reqwest and tokio-tungstenite releases:
* https://github.com/snapview/tokio-tungstenite/pull/142
* https://github.com/seanmonstar/reqwest/pull/1076