### PR TITLE
feat: bytes 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,9 @@ name = "bytes"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -675,6 +678,7 @@ version = "0.1.3"
 dependencies = [
  "arrayvec",
  "bincode",
+ "bytes 1.0.0",
  "ecdsa",
  "elliptic-curve",
  "ethabi-next",

--- a/ethers-contract/src/base.rs
+++ b/ethers-contract/src/base.rs
@@ -139,7 +139,7 @@ pub(crate) fn decode_event<D: Detokenize>(
     let tokens = event
         .parse_log(RawLog {
             topics,
-            data: data.0,
+            data: data.to_vec(),
         })?
         .params
         .into_iter()
@@ -214,7 +214,7 @@ mod tests {
 
         let encoded = abi.encode("approve", (spender, amount)).unwrap();
 
-        assert_eq!(encoded.0.to_hex::<String>(), "095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        assert_eq!(encoded.as_ref().to_hex::<String>(), "095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
         let (spender2, amount2): (Address, U256) = abi.decode("approve", encoded).unwrap();
         assert_eq!(spender, spender2);

--- a/ethers-contract/src/factory.rs
+++ b/ethers-contract/src/factory.rs
@@ -143,9 +143,9 @@ impl<M: Middleware> ContractFactory<M> {
                 return Err(ContractError::ConstructorError);
             }
             (None, true) => self.bytecode.clone(),
-            (Some(constructor), _) => {
-                Bytes(constructor.encode_input(self.bytecode.0.clone(), &params)?)
-            }
+            (Some(constructor), _) => constructor
+                .encode_input(self.bytecode.to_vec(), &params)?
+                .into(),
         };
 
         // create the tx object. Since we're deploying a contract, `to` is `None`

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -1,6 +1,6 @@
 use ethers_core::{
     abi::{Detokenize, Function, Token},
-    types::{Address, BlockNumber, NameOrAddress, TxHash, U256},
+    types::{Address, BlockNumber, Bytes, NameOrAddress, TxHash, U256},
 };
 use ethers_providers::Middleware;
 
@@ -139,7 +139,7 @@ pub struct Multicall<M> {
 /// with `data`
 pub struct Call {
     target: Address,
-    data: Vec<u8>,
+    data: Bytes,
     function: Function,
 }
 
@@ -207,7 +207,7 @@ impl<M: Middleware> Multicall<M> {
             (Some(NameOrAddress::Address(target)), Some(data)) => {
                 let call = Call {
                     target,
-                    data: data.0,
+                    data,
                     function: call.function,
                 };
                 self.calls.push(call);
@@ -357,7 +357,7 @@ impl<M: Middleware> Multicall<M> {
         let calls: Vec<(Address, Vec<u8>)> = self
             .calls
             .iter()
-            .map(|call| (call.target, call.data.clone()))
+            .map(|call| (call.target, call.data.to_vec()))
             .collect();
 
         // Construct the ContractCall for `aggregate` function to broadcast the transaction

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = { version = "1.0.60", default-features = false }
 rustc-hex = { version = "2.1.0", default-features = false }
 thiserror = { version = "1.0.22", default-features = false }
 glob = { version = "0.3.0", default-features = false }
+bytes = { version = "1.0.0", features = ["serde"] }
 
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }

--- a/ethers-core/src/abi/tokens.rs
+++ b/ethers-core/src/abi/tokens.rs
@@ -161,7 +161,7 @@ impl Tokenizable for Bytes {
     }
 
     fn into_token(self) -> Token {
-        Token::Bytes(self.0)
+        Token::Bytes(self.to_vec())
     }
 }
 

--- a/ethers-core/src/types/bytes.rs
+++ b/ethers-core/src/types/bytes.rs
@@ -2,32 +2,32 @@ use rustc_hex::{FromHex, ToHex};
 use serde::de::{Error, Unexpected};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-/// Wrapper type around Vec<u8> to deserialize/serialize "0x" prefixed ethereum hex strings
+/// Wrapper type around Bytes to deserialize/serialize "0x" prefixed ethereum hex strings
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
 pub struct Bytes(
     #[serde(
         serialize_with = "serialize_bytes",
         deserialize_with = "deserialize_bytes"
     )]
-    pub Vec<u8>,
+    pub bytes::Bytes,
 );
+
+impl Bytes {
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.as_ref().to_vec()
+    }
+
+}
 
 impl AsRef<[u8]> for Bytes {
     fn as_ref(&self) -> &[u8] {
-        &self.0[..]
-    }
-}
-
-impl Bytes {
-    /// Returns an empty bytes vector
-    pub fn new() -> Self {
-        Bytes(vec![])
+        &self.0.as_ref()
     }
 }
 
 impl From<Vec<u8>> for Bytes {
     fn from(src: Vec<u8>) -> Self {
-        Self(src)
+        Self(src.into())
     }
 }
 
@@ -39,15 +39,15 @@ where
     s.serialize_str(&format!("0x{}", x.as_ref().to_hex::<String>()))
 }
 
-pub fn deserialize_bytes<'de, D>(d: D) -> Result<Vec<u8>, D::Error>
+pub fn deserialize_bytes<'de, D>(d: D) -> Result<bytes::Bytes, D::Error>
 where
     D: Deserializer<'de>,
 {
     let value = String::deserialize(d)?;
     if value.len() >= 2 && &value[0..2] == "0x" {
-        let bytes = FromHex::from_hex(&value[2..])
+        let bytes: Vec<u8> = FromHex::from_hex(&value[2..])
             .map_err(|e| Error::custom(format!("Invalid hex: {}", e)))?;
-        Ok(bytes)
+        Ok(bytes.into())
     } else {
         Err(Error::invalid_value(Unexpected::Str(&value), &"0x prefix"))
     }

--- a/ethers-core/src/types/mod.rs
+++ b/ethers-core/src/types/mod.rs
@@ -11,7 +11,7 @@ mod transaction;
 pub use transaction::{Transaction, TransactionReceipt, TransactionRequest};
 
 mod bytes;
-pub use bytes::Bytes;
+pub use self::bytes::Bytes;
 
 mod block;
 pub use block::{Block, BlockId, BlockNumber};

--- a/ethers-core/src/types/transaction.rs
+++ b/ethers-core/src/types/transaction.rs
@@ -196,7 +196,7 @@ impl TransactionRequest {
 
         rlp_opt(rlp, self.to.as_ref());
         rlp_opt(rlp, self.value);
-        rlp_opt(rlp, self.data.as_ref().map(|d| &d.0[..]));
+        rlp_opt(rlp, self.data.as_ref().map(|d| d.as_ref()));
     }
 }
 
@@ -328,7 +328,7 @@ impl Transaction {
     }
 
     pub fn hash(&self) -> H256 {
-        keccak256(&self.rlp().0).into()
+        keccak256(&self.rlp().as_ref()).into()
     }
 
     pub fn rlp(&self) -> Bytes {
@@ -343,7 +343,7 @@ impl Transaction {
 
         rlp_opt(&mut rlp, self.to);
         rlp.append(&self.value);
-        rlp.append(&self.input.0);
+        rlp.append(&self.input.as_ref());
         rlp.append(&self.v);
         rlp.append(&self.r);
         rlp.append(&self.s);

--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -135,7 +135,7 @@ where
 
         // Get the actual transaction hash
         let rlp = tx.rlp_signed(&signature);
-        let hash = keccak256(&rlp.0);
+        let hash = keccak256(&rlp.as_ref());
 
         // This function should not be called with ENS names
         let to = tx.to.map(|to| match to {
@@ -337,7 +337,7 @@ mod tests {
                 .unwrap()
         );
 
-        let expected_rlp = Bytes("f869808504e3b29200831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a0c9cf86333bcb065d140032ecaab5d9281bde80f21b9687b3e94161de42d51895a0727a108a0b8d101465414033c3f705a9c7b826e596766046ee1183dbc8aeaa68".from_hex().unwrap());
+        let expected_rlp = Bytes::from("f869808504e3b29200831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca008025a0c9cf86333bcb065d140032ecaab5d9281bde80f21b9687b3e94161de42d51895a0727a108a0b8d101465414033c3f705a9c7b826e596766046ee1183dbc8aeaa68".from_hex::<Vec<u8>>().unwrap());
         assert_eq!(tx.rlp(), expected_rlp);
     }
 }

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -46,5 +46,6 @@ rustc-hex = "2.1.0"
 tokio = { version = "1.0", default-features = false, features = ["rt", "macros"] }
 
 [features]
+default = ["ws"]
 celo = ["ethers-core/celo"]
 ws = ["tokio", "tokio-tungstenite"]

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -730,8 +730,8 @@ impl Provider<MockProvider> {
 ///
 /// If the provided bytes were not an interpretation of an address
 fn decode_bytes<T: Detokenize>(param: ParamType, bytes: Bytes) -> T {
-    let tokens =
-        abi::decode(&[param], &bytes.0).expect("could not abi-decode bytes to address tokens");
+    let tokens = abi::decode(&[param], &bytes.as_ref())
+        .expect("could not abi-decode bytes to address tokens");
     T::from_tokens(tokens).expect("could not parse tokens as address")
 }
 


### PR DESCRIPTION
Switches to Bytes 1.0. This should make our code more efficient by avoiding redundant clones on large stuff e.g. the input data on txs.

(usual flaky Celo test causes CI failure)