### PR TITLE
Upgrade reqwest to 0.11.0 to ensure only 1 version of tokio used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,27 +108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "async-stream"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
-dependencies = [
- "async-stream-impl",
- "futures-core",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,16 +1292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,8 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.10"
-source = "git+https://github.com/seanmonstar/reqwest?branch=master#1f425a0244bcd7b4565dceb9076450d951f2ec03"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd281b1030aa675fb90aa994d07187645bb3c8fc756ca766e7c3070b439de9de"
 dependencies = [
  "base64",
  "bytes 1.0.0",
@@ -1808,7 +1778,6 @@ dependencies = [
  "lazy_static",
  "log",
  "mime",
- "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -2260,11 +2229,10 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3be913b74b13210c8fe04b17ab833f5a124f45b93d0f99f59fff621f64392a"
+checksum = "e4cdeb73537e63f98adcd73138af75e3f368ccaecffaa29d7eb61b9f5a440457"
 dependencies = [
- "async-stream",
  "futures-core",
  "pin-project-lite",
  "tokio",
@@ -2376,15 +2344,6 @@ dependencies = [
  "crunchy",
  "rustc-hex",
  "static_assertions",
-]
-
-[[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,3 @@ members = [
     "./ethers-core",
     "./ethers-middleware",
 ]
-
-[patch.crates-io]
-reqwest = { git = "https://github.com/seanmonstar/reqwest", branch = "master" }
-tokio-tungstenite = { git = "https://github.com/dnaka91/tokio-tungstenite", branch = "tokio-1.0" }

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -27,7 +27,7 @@ tracing-futures = { version = "0.2.4", default-features = false }
 
 # for gas oracles
 serde-aux = { version = "2.1.0", default-features = false }
-reqwest = { version = "0.10.10", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.11.0", default-features = false, features = ["json", "rustls-tls"] }
 url = { version = "2.2.0", default-features = false }
 
 tokio = { version = "1.0" }

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 ethers-core = { version = "0.1.3", path = "../ethers-core", default-features = false }
 
 async-trait = { version = "0.1.42", default-features = false }
-reqwest = { version = "0.10.10", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.11.0", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.118", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.60", default-features = false }
 thiserror = { version = "1.0.22", default-features = false }
@@ -37,7 +37,7 @@ tracing-futures = { version = "0.2.4", default-features = false }
 
 # tokio
 tokio = { version = "1.0", default-features = false, optional = true }
-tokio-tungstenite = { version = "0.12.0", default-features = false, features = ["connect", "tls"], optional = true }
+tokio-tungstenite = { git = "https://github.com/dnaka91/tokio-tungstenite", branch = "tokio-1.0", default-features = false, features = ["connect", "tls"], optional = true }
 
 [dev-dependencies]
 ethers = { version = "0.1.3", path = "../ethers" }


### PR DESCRIPTION
This commit also removes the patch stanza in the top level Cargo.toml as the
older tokio tungstenite (0.12.0) is pulled in when ethers is used as a
dependency on another project.
