### PR TITLE
Feat/is middleware signer

### DIFF
--- a/ethers-core/src/types/signature.rs
+++ b/ethers-core/src/types/signature.rs
@@ -173,6 +173,7 @@ impl FromStr for Signature {
     type Err = SignatureError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.strip_prefix("0x").unwrap_or(s);
         let bytes = hex::decode(s)?;
         Signature::try_from(&bytes[..])
     }
@@ -259,5 +260,18 @@ mod tests {
             signature.recover("Some data").unwrap(),
             Address::from_str("2c7536E3605D9C16a7a3D7b1898e529396a65c23").unwrap()
         );
+    }
+
+    #[test]
+    fn signature_from_str() {
+        let s1 = Signature::from_str(
+            "0xaa231fbe0ed2b5418e6ba7c19bee2522852955ec50996c02a2fe3e71d30ddaf1645baf4823fea7cb4fcc7150842493847cfb6a6d63ab93e8ee928ee3f61f503500"
+        ).expect("could not parse 0x-prefixed signature");
+
+        let s2 = Signature::from_str(
+            "aa231fbe0ed2b5418e6ba7c19bee2522852955ec50996c02a2fe3e71d30ddaf1645baf4823fea7cb4fcc7150842493847cfb6a6d63ab93e8ee928ee3f61f503500"
+        ).expect("could not parse non-prefixed signature");
+
+        assert_eq!(s1, s2);
     }
 }

--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -235,6 +235,11 @@ where
         &self.inner
     }
 
+    /// `SignerMiddleware` is instantiated with a signer.
+    async fn is_signer(&self) -> bool {
+        true
+    }
+
     /// Signs and broadcasts the transaction. The optional parameter `block` can be passed so that
     /// gas cost and nonce calculations take it into account. For simple transactions this can be
     /// left to `None`.

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -306,6 +306,13 @@ pub trait Middleware: Sync + Send + Debug {
             .map_err(FromErr::from)
     }
 
+    /// This returns true if either the middleware stack contains a `SignerMiddleware`, or the
+    /// JSON-RPC provider has an unlocked key that can sign using the `eth_sign` call. If none of
+    /// the above conditions are met, then the middleware stack is not capable of signing data.
+    async fn is_signer(&self) -> bool {
+        self.inner().is_signer().await
+    }
+
     async fn sign<T: Into<Bytes> + Send + Sync>(
         &self,
         data: T,

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -316,6 +316,15 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         Ok(PendingTransaction::new(tx_hash, self).interval(self.get_interval()))
     }
 
+    /// The JSON-RPC provider is at the bottom-most position in the middleware stack. Here we check
+    /// if it has the key for the sender address unlocked, as well as supports the `eth_sign` call.
+    async fn is_signer(&self) -> bool {
+        match self.3 {
+            Some(sender) => self.sign(vec![], &sender).await.is_ok(),
+            None => false,
+        }
+    }
+
     /// Signs data using a specific account. This account needs to be unlocked.
     async fn sign<T: Into<Bytes> + Send + Sync>(
         &self,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

It would be useful to have a way to know if a middleware can sign data.

A way to know if one of the two is true:
* The middleware stack contains `SignerMiddleware`
* The JSON-RPC provider has an unlocked key and it supports the `eth_sign` call

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

* Add `is_signer` method to the `Middleware` trait
* `is_signer` is always true for `SignerMiddleware`
* `is_signer` is true if the JSON-RPC provider has an unlocked key and supports `eth_sign` call