### PR TITLE
make generated contract abi code reproducible

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -14,7 +14,7 @@ use ethers_core::{
 use inflector::Inflector;
 use proc_macro2::{Ident, Literal, TokenStream};
 use quote::quote;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use syn::{Path, Visibility};
 
 /// Internal shared context for generating smart contract bindings.
@@ -32,7 +32,7 @@ pub(crate) struct Context {
     contract_name: Ident,
 
     /// Manually specified method aliases.
-    method_aliases: HashMap<String, Ident>,
+    method_aliases: BTreeMap<String, Ident>,
 
     /// Derives added to event structs and enums.
     event_derives: Vec<Path>,
@@ -122,7 +122,7 @@ impl Context {
         // NOTE: We only check for duplicate signatures here, since if there are
         //   duplicate aliases, the compiler will produce a warning because a
         //   method will be re-defined.
-        let mut method_aliases = HashMap::new();
+        let mut method_aliases = BTreeMap::new();
         for (signature, alias) in args.method_aliases.into_iter() {
             let alias = syn::parse_str(&alias)?;
             if method_aliases.insert(signature.clone(), alias).is_some() {

--- a/ethers-contract/ethers-contract-abigen/src/contract/events.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/events.rs
@@ -1,18 +1,19 @@
 use super::{types, util, Context};
-use ethers_core::abi::{Event, EventExt, EventParam, Hash, ParamType};
-
 use anyhow::Result;
+use ethers_core::abi::{Event, EventExt, EventParam, Hash, ParamType};
 use inflector::Inflector;
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
+use std::collections::BTreeMap;
 use syn::Path;
 
 impl Context {
     /// Expands each event to a struct + its impl Detokenize block
     pub fn events_declaration(&self) -> Result<TokenStream> {
-        let data_types = self
-            .abi
-            .events()
+        let sorted_events: BTreeMap<_, _> = self.abi.events.clone().into_iter().collect();
+        let data_types = sorted_events
+            .values()
+            .flatten()
             .map(|event| expand_event(event, &self.event_derives))
             .collect::<Result<Vec<_>>>()?;
 
@@ -26,9 +27,10 @@ impl Context {
     }
 
     pub fn events(&self) -> Result<TokenStream> {
-        let data_types = self
-            .abi
-            .events()
+        let sorted_events: BTreeMap<_, _> = self.abi.events.clone().into_iter().collect();
+        let data_types = sorted_events
+            .values()
+            .flatten()
             .map(|event| expand_filter(event))
             .collect::<Vec<_>>();
 

--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -1,13 +1,13 @@
 use super::{types, util, Context};
+use anyhow::{anyhow, Context as _, Result};
 use ethers_core::{
     abi::{Function, FunctionExt, Param, StateMutability},
     types::Selector,
 };
-
-use anyhow::{anyhow, Context as _, Result};
 use inflector::Inflector;
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
+use std::collections::BTreeMap;
 use syn::Ident;
 
 /// Expands a context into a method struct containing all the generated bindings
@@ -15,10 +15,10 @@ use syn::Ident;
 impl Context {
     pub(crate) fn methods(&self) -> Result<TokenStream> {
         let mut aliases = self.method_aliases.clone();
-
-        let functions = self
-            .abi
-            .functions()
+        let sorted_functions: BTreeMap<_, _> = self.abi.functions.clone().into_iter().collect();
+        let functions = sorted_functions
+            .values()
+            .flatten()
             .map(|function| {
                 let signature = function.abi_signature();
                 expand_function(function, aliases.remove(&signature))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Each time I run abigen, the generated rust code changes for a same contract abi json.
I'd like to make it reproducible.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Use BtreeMap to hold methods and events definition.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
