### PR TITLE
feature: report path on failed abigen load

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/source.rs
+++ b/ethers-contract/ethers-contract-abigen/src/source.rs
@@ -171,7 +171,10 @@ fn get_local_contract(path: &Path) -> Result<String> {
         Cow::Borrowed(path)
     };
 
-    let json = fs::read_to_string(path).context("failed to read artifact JSON file")?;
+    let json = fs::read_to_string(&path).context(format!(
+        "failed to read artifact JSON file with path {}",
+        &path.display()
+    ))?;
     Ok(json)
 }
 


### PR DESCRIPTION
This PR improves an error message by printing the path that the abigen macro tries to read whenever it fails to do so. This error is triggered when the path does not exist or does not contain valid JSON

I'm unsure the best way to write automated tests for this, but I have confirmed it works great locally by pointing it at `../`