### PR TITLE
bug: prevent interleaving websocket ID load/store operations

### DIFF
--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -112,8 +112,7 @@ impl JsonRpcClient for Ws {
         method: &str,
         params: T,
     ) -> Result<R, ClientError> {
-        let next_id = self.id.load(Ordering::SeqCst) + 1;
-        self.id.store(next_id, Ordering::SeqCst);
+        let next_id = self.id.fetch_add(1, Ordering::SeqCst);
 
         // send the message
         let (sender, receiver) = oneshot::channel();


### PR DESCRIPTION
Closes #216.

The independent load and store operations could be interleaved between tasks in a breaking way. 

e.g. 
```
TASK A loads 5
TASK B loads 5
TASK B stores 6 (5 + 1)
TASK A stores 6 (5 + 1)
```

This causes both task A and task B to use the same ID for a WS request, replacing the previous request.

To fix this, we use `fetch_add` to atomically load, increment, and store
