### PR TITLE
release: 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "ethers-contract",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "ethers",
  "ethers-contract-abigen",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "arrayvec",
  "bincode",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "ethers",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "coins-ledger",
@@ -768,7 +768,6 @@ dependencies = [
  "futures-util",
  "hex",
  "rand 0.7.3",
- "serde",
  "serde_json",
  "sha2",
  "tempfile",

--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ethers-contract"
 license = "MIT OR Apache-2.0"
-version = "0.2.0"
+version = "0.2.2"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"
 description = "Smart contract bindings for the ethers-rs crate"
@@ -10,11 +10,11 @@ repository = "https://github.com/gakonst/ethers-rs"
 keywords = ["ethereum", "web3", "celo", "ethers"]
 
 [dependencies]
-ethers-providers = { version = "0.2", path = "../ethers-providers", default-features = false }
-ethers-core = { version = "0.2", path = "../ethers-core", default-features = false }
+ethers-providers = { version = "0.2.2", path = "../ethers-providers", default-features = false }
+ethers-core = { version = "0.2.2", path = "../ethers-core", default-features = false }
 
-ethers-contract-abigen = { version = "0.2", path = "ethers-contract-abigen", optional = true }
-ethers-contract-derive = { version = "0.2", path = "ethers-contract-derive", optional = true }
+ethers-contract-abigen = { version = "0.2.2", path = "ethers-contract-abigen", optional = true }
+ethers-contract-derive = { version = "0.2.2", path = "ethers-contract-derive", optional = true }
 
 serde = { version = "1.0.123", default-features = false }
 serde_json = { version = "1.0.64", default-features = false }

--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-contract-abigen"
-version = "0.2.0"
+version = "0.2.2"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>", "Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ repository = "https://github.com/gakonst/ethers-rs"
 keywords = ["ethereum", "web3", "celo", "ethers"]
 
 [dependencies]
-ethers-core = { version = "0.2", path = "../../ethers-core" }
+ethers-core = { version = "0.2.2", path = "../../ethers-core" }
 
 anyhow = "1.0.37"
 curl = "0.4"

--- a/ethers-contract/ethers-contract-derive/Cargo.toml
+++ b/ethers-contract/ethers-contract-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-contract-derive"
-version = "0.2.0"
+version = "0.2.2"
 authors = ["Nicholas Rodrigues Lordello <nlordell@gmail.com>", "Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -13,8 +13,8 @@ keywords = ["ethereum", "web3", "celo", "ethers"]
 proc-macro = true
 
 [dependencies]
-ethers-core = { version = "0.2", path = "../../ethers-core" }
-ethers-contract-abigen = { version = "0.2", path = "../ethers-contract-abigen" }
+ethers-core = { version = "0.2.2", path = "../../ethers-core" }
+ethers-contract-abigen = { version = "0.2.2", path = "../ethers-contract-abigen" }
 
 serde_json = "1.0.53"
 

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ethers-core"
 license = "MIT OR Apache-2.0"
-version = "0.2.0"
+version = "0.2.2"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"
 description = "Core structures for the ethers-rs crate"

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ethers-middleware"
 license = "MIT OR Apache-2.0"
-version = "0.2.0"
+version = "0.2.2"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"
 description = "Middleware implementations for the ethers-rs crate"
@@ -14,10 +14,10 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-ethers-contract = { version = "0.2", path = "../ethers-contract", default-features = false, features = ["abigen"] }
-ethers-core = { version = "0.2", path = "../ethers-core", default-features = false }
-ethers-providers = { version = "0.2", path = "../ethers-providers", default-features = false }
-ethers-signers = { version = "0.2", path = "../ethers-signers", default-features = false }
+ethers-contract = { version = "0.2.2", path = "../ethers-contract", default-features = false, features = ["abigen"] }
+ethers-core = { version = "0.2.2", path = "../ethers-core", default-features = false }
+ethers-providers = { version = "0.2.2", path = "../ethers-providers", default-features = false }
+ethers-signers = { version = "0.2.2", path = "../ethers-signers", default-features = false }
 
 async-trait = { version = "0.1.42", default-features = false }
 serde = { version = "1.0.123", default-features = false, features = ["derive"] }

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ethers-providers"
 license = "MIT OR Apache-2.0"
-version = "0.2.0"
+version = "0.2.2"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"
 description = "Provider implementations for the ethers-rs crate"
@@ -14,7 +14,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-ethers-core = { version = "0.2", path = "../ethers-core", default-features = false }
+ethers-core = { version = "0.2.2", path = "../ethers-core", default-features = false }
 
 async-trait = { version = "0.1.42", default-features = false }
 hex = { version = "0.4.2", default-features = false, features = ["std"] }
@@ -34,7 +34,7 @@ pin-project = { version = "1.0.5", default-features = false }
 
 # tracing
 tracing = { version = "0.1.25", default-features = false }
-tracing-futures = { version = "0.2.5", default-features = false }
+tracing-futures = { version = "0.2.5", default-features = false, features = ["std-future"] }
 
 # tokio
 tokio = { version = "1.2", default-features = false, optional = true }

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ethers-signers"
 license = "MIT OR Apache-2.0"
-version = "0.2.0"
+version = "0.2.2"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"
 description = "Signer implementations for the ethers-rs crate"
@@ -14,9 +14,8 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-ethers-core = { version = "0.2", path = "../ethers-core" }
+ethers-core = { version = "0.2.2", path = "../ethers-core" }
 thiserror = { version = "1.0.24", default-features = false }
-serde = { version = "1.0.123", default-features = false }
 
 coins-ledger = { version = "0.1.0", default-features = false, optional = true }
 eth-keystore = { version = "0.2.0" }

--- a/ethers/Cargo.toml
+++ b/ethers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers"
-version = "0.2.0"
+version = "0.2.2"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
@@ -34,11 +34,11 @@ ws = ["ethers-providers/ws"]
 abigen = ["ethers-contract/abigen"]
 
 [dependencies]
-ethers-contract = { version = "0.2", path = "../ethers-contract" }
-ethers-core = { version = "0.2", path = "../ethers-core" }
-ethers-providers = { version = "0.2", path = "../ethers-providers" }
-ethers-signers = { version = "0.2", path = "../ethers-signers" }
-ethers-middleware = { version = "0.2", path = "../ethers-middleware" }
+ethers-contract = { version = "0.2.2", path = "../ethers-contract" }
+ethers-core = { version = "0.2.2", path = "../ethers-core" }
+ethers-providers = { version = "0.2.2", path = "../ethers-providers" }
+ethers-signers = { version = "0.2.2", path = "../ethers-signers" }
+ethers-middleware = { version = "0.2.2", path = "../ethers-middleware" }
 
 [dev-dependencies]
 ethers-contract = { version = "0.2", path = "../ethers-contract", features = ["abigen"] }


### PR DESCRIPTION
Mainly bugfixes.

1. Adds the `std-future` feature to `tracing-futures`, because we were getting the following error:
```
    |
120 |           let res = async move {
    |  ___________________^
121 | |             trace!("tx");
122 | |             let res: R = self.0.request(method, params).await.map_err(Into::into)?;
123 | |             trace!(rx = ?serde_json::to_string(&res)?);
...   |
126 | |         .instrument(span)
127 | |         .await?;
    | |______________^ `tracing_futures::Instrumented<impl futures_core::Future>` is not a future
    |
    = help: the trait `futures_core::Future` is not implemented for `tracing_futures::Instrumented<impl futures_core::Future>`
    = note: required by `futures_core::Future::poll`
```

2. prevent interleaving websocket ID load/store operations #217 (thank you @prestwich for the PR and @palkeo for surfacing!)
