### PR TITLE
Refactor human readable abi parsing

### DIFF
--- a/ethers-core/src/abi/human_readable.rs
+++ b/ethers-core/src/abi/human_readable.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use thiserror::Error;
 
 use super::{
-    Abi, Event, EventParam, Function, Param, param_type::Reader, ParamType, StateMutability, Constructor
+    param_type::Reader, Abi, Constructor, Event, EventParam, Function, Param, StateMutability,
 };
 
 /// Parses a "human readable abi" string vector
@@ -24,23 +24,24 @@ pub fn parse(input: &[&str]) -> Result<Abi, ParseError> {
         fallback: false,
     };
 
-    for line in input {
-        if line.contains("function") {
+    for mut line in input.iter().map(|s| escape_quotes(s)) {
+        line = line.trim_start();
+        if line.starts_with("function") {
             let function = parse_function(&line)?;
             abi.functions
                 .entry(function.name.clone())
                 .or_default()
                 .push(function);
-        } else if line.contains("event") {
-            let event = parse_event(&line)?;
+        } else if line.starts_with("event") {
+            let event = parse_event(line)?;
             abi.events
                 .entry(event.name.clone())
                 .or_default()
                 .push(event);
-        } else if line.starts_with("struct") {
-            panic!("Got tuple");
+        } else if line.starts_with("constructor") {
+            abi.constructor = Some(parse_constructor(line)?);
         } else {
-            panic!("unknown sig")
+            return Err(ParseError::ParseError(super::Error::InvalidData));
         }
     }
 
@@ -51,7 +52,9 @@ pub fn parse(input: &[&str]) -> Result<Abi, ParseError> {
 fn parse_identifier(input: &mut &str) -> Result<String, ParseError> {
     let mut chars = input.trim_start().chars();
     let mut name = String::new();
-    let c = chars.next().ok_or(ParseError::ParseError(super::Error::InvalidData))?;
+    let c = chars
+        .next()
+        .ok_or(ParseError::ParseError(super::Error::InvalidData))?;
     if is_first_ident_char(c) {
         name.push(c);
         loop {
@@ -69,7 +72,7 @@ fn parse_identifier(input: &mut &str) -> Result<String, ParseError> {
 }
 
 /// Parses a solidity event declaration from `event <name> (args*) anonymous?`
-fn parse_event2(mut event: &str) -> Result<Event, ParseError> {
+fn parse_event(mut event: &str) -> Result<Event, ParseError> {
     event = event.trim();
     if !event.starts_with("event ") {
         return Err(ParseError::ParseError(super::Error::InvalidData));
@@ -78,7 +81,9 @@ fn parse_event2(mut event: &str) -> Result<Event, ParseError> {
 
     let name = parse_identifier(&mut event)?;
     if name.is_empty() {
-        return Err(ParseError::ParseError(super::Error::InvalidName(event.to_owned())));
+        return Err(ParseError::ParseError(super::Error::InvalidName(
+            event.to_owned(),
+        )));
     }
 
     let mut chars = event.chars();
@@ -112,7 +117,10 @@ fn parse_event2(mut event: &str) -> Result<Event, ParseError> {
 
 /// Returns the event parameters
 fn parse_event_args(mut input: &str) -> Result<Vec<EventParam>, ParseError> {
-    input = input.trim().strip_suffix(')').ok_or(ParseError::ParseError(super::Error::InvalidData))?;
+    input = input
+        .trim()
+        .strip_suffix(')')
+        .ok_or(ParseError::ParseError(super::Error::InvalidData))?;
 
     let mut params = Vec::new();
 
@@ -122,9 +130,13 @@ fn parse_event_args(mut input: &str) -> Result<Vec<EventParam>, ParseError> {
 
     for arg in input.split(',') {
         let mut iter = arg.trim().rsplitn(3, is_whitespace);
-        let name = iter.next().ok_or(ParseError::ParseError(super::Error::InvalidData))?;
-        let mid = iter.next().ok_or(ParseError::ParseError(super::Error::InvalidData))?;
-        let mut kind = None;
+        let name = iter
+            .next()
+            .ok_or(ParseError::ParseError(super::Error::InvalidData))?;
+        let mid = iter
+            .next()
+            .ok_or(ParseError::ParseError(super::Error::InvalidData))?;
+        let kind;
         let mut indexed = false;
         if mid == "indexed" {
             indexed = true;
@@ -135,19 +147,16 @@ fn parse_event_args(mut input: &str) -> Result<Vec<EventParam>, ParseError> {
                 return Err(ParseError::ParseError(super::Error::InvalidData));
             }
         }
-        params.push(
-            EventParam {
-                name: name.to_owned(),
-                kind: kind.ok_or(ParseError::ParseError(super::Error::InvalidData))??,
-                indexed,
-            }
-        )
+        params.push(EventParam {
+            name: name.to_owned(),
+            kind: kind.ok_or(ParseError::ParseError(super::Error::InvalidData))??,
+            indexed,
+        })
     }
     Ok(params)
 }
 
-
-fn parse_function2(mut input: &str) -> Result<Function, ParseError> {
+fn parse_function(mut input: &str) -> Result<Function, ParseError> {
     input = input.trim();
     if !input.starts_with("function ") {
         return Err(ParseError::ParseError(super::Error::InvalidData));
@@ -155,12 +164,17 @@ fn parse_function2(mut input: &str) -> Result<Function, ParseError> {
     input = &input[8..];
     let name = parse_identifier(&mut input)?;
     if name.is_empty() {
-        return Err(ParseError::ParseError(super::Error::InvalidName(input.to_owned())));
+        return Err(ParseError::ParseError(super::Error::InvalidName(
+            input.to_owned(),
+        )));
     }
 
     let mut iter = input.split(" returns");
 
-    let parens = iter.next().ok_or(ParseError::ParseError(super::Error::InvalidData))?.trim_end();
+    let parens = iter
+        .next()
+        .ok_or(ParseError::ParseError(super::Error::InvalidData))?
+        .trim_end();
 
     let mut parens_iter = parens.rsplitn(2, ')');
     let mut modifiers = parens_iter.next();
@@ -168,15 +182,31 @@ fn parse_function2(mut input: &str) -> Result<Function, ParseError> {
     let input_params = if let Some(args) = parens_iter.next() {
         args
     } else {
-        modifiers.take().ok_or(ParseError::ParseError(super::Error::InvalidData))?
-    }.trim_start().strip_prefix('(').ok_or(ParseError::ParseError(super::Error::InvalidData))?;
+        modifiers
+            .take()
+            .ok_or(ParseError::ParseError(super::Error::InvalidData))?
+    }
+    .trim_start()
+    .strip_prefix('(')
+    .ok_or(ParseError::ParseError(super::Error::InvalidData))?;
 
-
-    let inputs = input_params.split(',').filter(|s|!s.is_empty()).map(parse_param2).collect::<Result<Vec<_>,_>>()?;
+    let inputs = input_params
+        .split(',')
+        .filter(|s| !s.is_empty())
+        .map(parse_param)
+        .collect::<Result<Vec<_>, _>>()?;
 
     let outputs = if let Some(params) = iter.next() {
-        let params = params.trim().strip_prefix('(').and_then(|s|s.strip_suffix(')')).ok_or(ParseError::ParseError(super::Error::InvalidData))?;
-        params.split(',').filter(|s|!s.is_empty()).map(parse_param2).collect::<Result<Vec<_>,_>>()?
+        let params = params
+            .trim()
+            .strip_prefix('(')
+            .and_then(|s| s.strip_suffix(')'))
+            .ok_or(ParseError::ParseError(super::Error::InvalidData))?;
+        params
+            .split(',')
+            .filter(|s| !s.is_empty())
+            .map(parse_param)
+            .collect::<Result<Vec<_>, _>>()?
     } else {
         Vec::new()
     };
@@ -184,7 +214,7 @@ fn parse_function2(mut input: &str) -> Result<Function, ParseError> {
     let state_mutability = modifiers.map(detect_state_mutability).unwrap_or_default();
 
     #[allow(deprecated)]
-        Ok(Function {
+    Ok(Function {
         name,
         inputs,
         outputs,
@@ -198,51 +228,24 @@ fn parse_constructor(mut input: &str) -> Result<Constructor, ParseError> {
     if !input.starts_with("constructor") {
         return Err(ParseError::ParseError(super::Error::InvalidData));
     }
-    input = input[11..].trim_start().strip_prefix('(').ok_or(ParseError::ParseError(super::Error::InvalidData))?;
+    input = input[11..]
+        .trim_start()
+        .strip_prefix('(')
+        .ok_or(ParseError::ParseError(super::Error::InvalidData))?;
 
-    let  params = input.rsplitn(2, ')').last().ok_or(ParseError::ParseError(super::Error::InvalidData))?;
+    let params = input
+        .rsplitn(2, ')')
+        .last()
+        .ok_or(ParseError::ParseError(super::Error::InvalidData))?;
 
-    let inputs = params.split(',').filter(|s|!s.is_empty()).map(parse_param2).collect::<Result<Vec<_>,_>>()?;
+    let inputs = params
+        .split(',')
+        .filter(|s| !s.is_empty())
+        .map(parse_param)
+        .collect::<Result<Vec<_>, _>>()?;
 
     #[allow(deprecated)]
-        Ok(Constructor {
-        inputs,
-    })
-}
-
-fn parse2(input: &[&str]) -> Result<Abi, ParseError> {
-    let mut abi = Abi {
-        constructor: None,
-        functions: HashMap::new(),
-        events: HashMap::new(),
-        receive: false,
-        fallback: false,
-    };
-
-    for line in input {
-        let line = line.trim_start();
-        if line.starts_with("function") {
-            let function = parse_function2(&line)?;
-            abi.functions
-                .entry(function.name.clone())
-                .or_default()
-                .push(function);
-        } else if line.starts_with("event") {
-            let event = parse_event2(line)?;
-            abi.events
-                .entry(event.name.clone())
-                .or_default()
-                .push(event);
-        } else if line.starts_with("constructor") {
-            abi.constructor = Some(parse_constructor(line)?);
-        } else {
-
-
-            return Err(ParseError::ParseError(super::Error::InvalidData));
-        }
-    }
-
-    Ok(abi)
+    Ok(Constructor { inputs })
 }
 
 fn detect_state_mutability(s: &str) -> StateMutability {
@@ -257,6 +260,33 @@ fn detect_state_mutability(s: &str) -> StateMutability {
     }
 }
 
+fn parse_param(param: &str) -> Result<Param, ParseError> {
+    let mut iter = param.trim().rsplitn(3, is_whitespace);
+
+    let name = iter
+        .next()
+        .ok_or(ParseError::ParseError(super::Error::InvalidData))?;
+
+    if let Some(ty) = iter.last() {
+        if name == "memory" || name == "calldata" {
+            Ok(Param {
+                name: "".to_owned(),
+                kind: Reader::read(ty)?,
+            })
+        } else {
+            Ok(Param {
+                name: name.to_owned(),
+                kind: Reader::read(ty)?,
+            })
+        }
+    } else {
+        Ok(Param {
+            name: "".to_owned(),
+            kind: Reader::read(name)?,
+        })
+    }
+}
+
 fn is_first_ident_char(c: char) -> bool {
     matches!(c, 'a'..='z' | 'A'..='Z' | '_')
 }
@@ -266,136 +296,11 @@ fn is_ident_char(c: char) -> bool {
 }
 
 fn is_whitespace(c: char) -> bool {
-    matches!(c, ' ' | '\t' )
+    matches!(c, ' ' | '\t')
 }
 
-fn parse_event(event: &str) -> Result<Event, ParseError> {
-    let split: Vec<&str> = event.split("event ").collect();
-    let split: Vec<&str> = split[1].split('(').collect();
-    let name = split[0].trim_end();
-    let rest = split[1];
-
-    let args = rest.replace(")", "");
-    let anonymous = rest.contains("anonymous");
-
-    let inputs = if args.contains(',') {
-        let args: Vec<&str> = args.split(", ").collect();
-        args.iter()
-            .map(|arg| parse_event_arg(arg))
-            .collect::<Result<Vec<EventParam>, _>>()?
-    } else {
-        vec![]
-    };
-
-    Ok(Event {
-        name: name.to_owned(),
-        anonymous,
-        inputs,
-    })
-}
-
-// Parses an event's argument as indexed if neded
-fn parse_event_arg(param: &str) -> Result<EventParam, ParseError> {
-    let tokens: Vec<&str> = param.split(' ').collect();
-    let kind: ParamType = Reader::read(tokens[0])?;
-    let (name, indexed) = if tokens.len() == 2 {
-        (tokens[1], false)
-    } else {
-        (tokens[2], true)
-    };
-
-    Ok(EventParam {
-        name: name.to_owned(),
-        kind,
-        indexed,
-    })
-}
-
-fn parse_function(fn_string: &str) -> Result<Function, ParseError> {
-    let fn_string = fn_string.to_owned();
-    let delim = if fn_string.starts_with("function ") {
-        "function "
-    } else {
-        " "
-    };
-    let split: Vec<&str> = fn_string.split(delim).collect();
-    let split: Vec<&str> = split[1].split('(').collect();
-
-    // function name is the first char
-    let fn_name = split[0];
-
-    // internal args
-    let args: Vec<&str> = split[1].split(')').collect();
-    let args: Vec<&str> = args[0].split(", ").collect();
-
-    let inputs = args
-        .into_iter()
-        .filter(|x| !x.is_empty())
-        .filter(|x| !x.contains("returns"))
-        .map(|x| parse_param(x))
-        .collect::<Result<Vec<Param>, _>>()?;
-
-    // return value
-    let outputs: Vec<Param> = if split.len() > 2 {
-        let ret = split[2].strip_suffix(")").expect("no right paren");
-        let ret: Vec<&str> = ret.split(", ").collect();
-
-        ret.into_iter()
-            // remove modifiers etc
-            .filter(|x| !x.is_empty())
-            .map(|x| parse_param(x))
-            .collect::<Result<Vec<Param>, _>>()?
-    } else {
-        vec![]
-    };
-
-    #[allow(deprecated)]
-        Ok(Function {
-        name: fn_name.to_owned(),
-        inputs,
-        outputs,
-        // this doesn't really matter
-        state_mutability: StateMutability::NonPayable,
-        constant: false,
-    })
-}
-
-fn parse_param2(param: &str) -> Result<Param, ParseError> {
-    let mut iter = param.trim().rsplitn(3, is_whitespace);
-
-    let name = iter.next().ok_or(ParseError::ParseError(super::Error::InvalidData))?;
-
-    if let Some(ty) = iter.last() {
-        if name == "memory" || name == "calldata" {
-            Ok(Param { name: "".to_owned(), kind: Reader::read(ty)? })
-        } else {
-            Ok(Param { name: name.to_owned(), kind: Reader::read(ty)? })
-        }
-    } else {
-        Ok(Param { name: "".to_owned(), kind: Reader::read(name)? })
-    }
-}
-
-// address x
-fn parse_param(param: &str) -> Result<Param, ParseError> {
-    let mut param = param
-        .split(' ')
-        .filter(|x| !x.contains("memory") || !x.contains("calldata"));
-
-    let kind = param.next().ok_or(ParseError::Kind)?;
-    let kind: ParamType = Reader::read(kind).unwrap();
-
-    // strip memory/calldata from the name
-    // e.g. uint256[] memory x
-    let mut name = param.next().unwrap_or_default();
-    if name == "memory" || name == "calldata" {
-        name = param.next().unwrap_or_default();
-    }
-
-    Ok(Param {
-        name: name.to_owned(),
-        kind,
-    })
+fn escape_quotes(input: &str) -> &str {
+    input.trim_matches(is_whitespace).trim_matches('\"')
 }
 
 #[derive(Error, Debug)]
@@ -410,19 +315,7 @@ pub enum ParseError {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn parses_approve2() {
-        let fn_str = "function approve(address _spender, uint256 value) external returns(bool)";
-        let parsed = parse_function2(fn_str).unwrap();
-        assert_eq!(parsed.name, "approve");
-        assert_eq!(parsed.inputs[0].name, "_spender");
-        assert_eq!(parsed.inputs[0].kind, ParamType::Address, );
-        assert_eq!(parsed.inputs[1].name, "value");
-        assert_eq!(parsed.inputs[1].kind, ParamType::Uint(256), );
-        assert_eq!(parsed.outputs[0].name, "");
-        assert_eq!(parsed.outputs[0].kind, ParamType::Bool);
-    }
+    use crate::abi::ParamType;
 
     #[test]
     fn parses_approve() {
@@ -430,25 +323,11 @@ mod tests {
         let parsed = parse_function(fn_str).unwrap();
         assert_eq!(parsed.name, "approve");
         assert_eq!(parsed.inputs[0].name, "_spender");
-        assert_eq!(parsed.inputs[0].kind, ParamType::Address, );
+        assert_eq!(parsed.inputs[0].kind, ParamType::Address,);
         assert_eq!(parsed.inputs[1].name, "value");
-        assert_eq!(parsed.inputs[1].kind, ParamType::Uint(256), );
+        assert_eq!(parsed.inputs[1].kind, ParamType::Uint(256),);
         assert_eq!(parsed.outputs[0].name, "");
         assert_eq!(parsed.outputs[0].kind, ParamType::Bool);
-    }
-
-    #[test]
-    fn parses_function_arguments_return2() {
-        let fn_str = "function foo(uint32[] memory x) external view returns (address)";
-        let parsed = parse_function2(fn_str).unwrap();
-        assert_eq!(parsed.name, "foo");
-        assert_eq!(parsed.inputs[0].name, "x");
-        assert_eq!(
-            parsed.inputs[0].kind,
-            ParamType::Array(Box::new(ParamType::Uint(32)))
-        );
-        assert_eq!(parsed.outputs[0].name, "");
-        assert_eq!(parsed.outputs[0].kind, ParamType::Address);
     }
 
     #[test]
@@ -466,36 +345,6 @@ mod tests {
     }
 
     #[test]
-    fn parses_function_empty2() {
-        let fn_str = "function foo()";
-        let parsed = parse_function2(fn_str).unwrap();
-        assert_eq!(parsed.name, "foo");
-        assert!(parsed.inputs.is_empty());
-        assert!(parsed.outputs.is_empty());
-    }
-
-    #[test]
-    fn parses_function_payable() {
-        let fn_str = "function foo() public payable";
-        let parsed = parse_function2(fn_str).unwrap();
-        assert_eq!(parsed.state_mutability, StateMutability::Payable);
-    }
-
-    #[test]
-    fn parses_function_view() {
-        let fn_str = "function foo() external view";
-        let parsed = parse_function2(fn_str).unwrap();
-        assert_eq!(parsed.state_mutability, StateMutability::View);
-    }
-
-    #[test]
-    fn parses_function_pure() {
-        let fn_str = "function foo()  pure";
-        let parsed = parse_function2(fn_str).unwrap();
-        assert_eq!(parsed.state_mutability, StateMutability::Pure);
-    }
-
-    #[test]
     fn parses_function_empty() {
         let fn_str = "function foo()";
         let parsed = parse_function(fn_str).unwrap();
@@ -505,37 +354,30 @@ mod tests {
     }
 
     #[test]
-    fn parses_event2() {
-        assert_eq!(
-            parse_event2(&mut "event Foo (address indexed x, uint y, bytes32[] z)").unwrap(),
-            Event {
-                anonymous: false,
-                name: "Foo".to_owned(),
-                inputs: vec![
-                    EventParam {
-                        name: "x".to_owned(),
-                        kind: ParamType::Address,
-                        indexed: true,
-                    },
-                    EventParam {
-                        name: "y".to_owned(),
-                        kind: ParamType::Uint(256),
-                        indexed: false,
-                    },
-                    EventParam {
-                        name: "z".to_owned(),
-                        kind: ParamType::Array(Box::new(ParamType::FixedBytes(32))),
-                        indexed: false,
-                    },
-                ],
-            }
-        );
+    fn parses_function_payable() {
+        let fn_str = "function foo() public payable";
+        let parsed = parse_function(fn_str).unwrap();
+        assert_eq!(parsed.state_mutability, StateMutability::Payable);
+    }
+
+    #[test]
+    fn parses_function_view() {
+        let fn_str = "function foo() external view";
+        let parsed = parse_function(fn_str).unwrap();
+        assert_eq!(parsed.state_mutability, StateMutability::View);
+    }
+
+    #[test]
+    fn parses_function_pure() {
+        let fn_str = "function foo()  pure";
+        let parsed = parse_function(fn_str).unwrap();
+        assert_eq!(parsed.state_mutability, StateMutability::Pure);
     }
 
     #[test]
     fn parses_event() {
         assert_eq!(
-            parse_event("event Foo (address indexed x, uint y, bytes32[] z)").unwrap(),
+            parse_event(&mut "event Foo (address indexed x, uint y, bytes32[] z)").unwrap(),
             Event {
                 anonymous: false,
                 name: "Foo".to_owned(),
@@ -556,18 +398,6 @@ mod tests {
                         indexed: false,
                     },
                 ],
-            }
-        );
-    }
-
-    #[test]
-    fn parses_anonymous_event2() {
-        assert_eq!(
-            parse_event2(&mut "event Foo() anonymous").unwrap(),
-            Event {
-                anonymous: true,
-                name: "Foo".to_owned(),
-                inputs: vec![],
             }
         );
     }
@@ -575,7 +405,7 @@ mod tests {
     #[test]
     fn parses_anonymous_event() {
         assert_eq!(
-            parse_event("event Foo() anonymous").unwrap(),
+            parse_event(&mut "event Foo() anonymous").unwrap(),
             Event {
                 anonymous: true,
                 name: "Foo".to_owned(),
@@ -584,42 +414,26 @@ mod tests {
         );
     }
 
-    #[test]
-    fn parse_event_input() {
-        assert_eq!(
-            parse_event_arg("address indexed x").unwrap(),
-            EventParam {
-                name: "x".to_owned(),
-                kind: ParamType::Address,
-                indexed: true,
-            }
-        );
-
-        assert_eq!(
-            parse_event_arg("address x").unwrap(),
-            EventParam {
-                name: "x".to_owned(),
-                kind: ParamType::Address,
-                indexed: false,
-            }
-        );
-    }
-
-    #[test]
-    fn can_parse_functions2() {
-        [
-            "function foo(uint256[] memory x) external view returns (address)",
-            "function bar(uint256[] memory x) returns (address)",
-            "function bar(uint256[] memory x, uint32 y) returns (address, uint256)",
-            "function foo(address[] memory, bytes memory) returns (bytes memory)",
-            "function bar(uint256[] memory x)",
-            "function bar()",
-        ]
-            .iter()
-            .for_each(|x| {
-                parse_function2(x).unwrap();
-            });
-    }
+    // #[test]
+    // fn parse_event_input() {
+    //     assert_eq!(
+    //         parse_event_arg("address indexed x").unwrap(),
+    //         EventParam {
+    //             name: "x".to_owned(),
+    //             kind: ParamType::Address,
+    //             indexed: true,
+    //         }
+    //     );
+    //
+    //     assert_eq!(
+    //         parse_event_arg("address x").unwrap(),
+    //         EventParam {
+    //             name: "x".to_owned(),
+    //             kind: ParamType::Address,
+    //             indexed: false,
+    //         }
+    //     );
+    // }
 
     #[test]
     fn can_parse_functions() {
@@ -631,10 +445,10 @@ mod tests {
             "function bar(uint256[] memory x)",
             "function bar()",
         ]
-            .iter()
-            .for_each(|x| {
-                parse_function(x).unwrap();
-            });
+        .iter()
+        .for_each(|x| {
+            parse_function(x).unwrap();
+        });
     }
 
     #[test]
@@ -647,18 +461,18 @@ mod tests {
             "bytes32[] memory",
             "bytes32[] memory z",
         ]
-            .iter()
-            .for_each(|x| {
-                parse_param(x).unwrap();
-            });
+        .iter()
+        .for_each(|x| {
+            parse_param(x).unwrap();
+        });
     }
 
     #[test]
     fn can_read_backslashes() {
         parse(&[
             "\"function setValue(string)\"",
-            "\"function getValue() external view (string)\"",
+            "\"function getValue() external view returns(string)\"",
         ])
-            .unwrap();
+        .unwrap();
     }
 }

--- a/ethers-core/src/abi/human_readable.rs
+++ b/ethers-core/src/abi/human_readable.rs
@@ -47,16 +47,11 @@ pub fn parse(input: &[&str]) -> Result<Abi, ParseError> {
     Ok(abi)
 }
 
-/// Parses a solidity event declaration from `event <name> (args*) anonymous?`
-fn parse_event2(mut event: &str) -> Result<Event, ParseError> {
-    if !event.starts_with("event ") {
-        return Err(ParseError::ParseError(super::Error::InvalidData));
-    }
-    event = &event[6..];
-    let mut chars = event.chars();
+/// Parses an identifier like event or function name
+fn parse_identifier(input: &mut &str) -> Result<String, ParseError> {
+    let mut chars = input.trim_start().chars();
     let mut name = String::new();
-
-    let c = chars.next().unwrap();
+    let c = chars.next().ok_or(ParseError::ParseError(super::Error::InvalidData))?;
     if is_first_ident_char(c) {
         name.push(c);
         loop {
@@ -69,34 +64,41 @@ fn parse_event2(mut event: &str) -> Result<Event, ParseError> {
             }
         }
     }
+    *input = chars.as_str();
+    Ok(name)
+}
+
+/// Parses a solidity event declaration from `event <name> (args*) anonymous?`
+fn parse_event2(mut event: &str) -> Result<Event, ParseError> {
+    event = event.trim();
+    if !event.starts_with("event ") {
+        return Err(ParseError::ParseError(super::Error::InvalidData));
+    }
+    event = &event[6..];
+
+    let name = parse_identifier(&mut event)?;
     if name.is_empty() {
         return Err(ParseError::ParseError(super::Error::InvalidName(event.to_owned())));
     }
+
+    let mut chars = event.chars();
+
     loop {
         match chars.next() {
             None => return Err(ParseError::ParseError(super::Error::InvalidData)),
             Some('(') => {
                 event = chars.as_str().trim();
-                let (inputs, anonymous) = parse_event_args(event)?;
+                let mut anonymous = false;
+                if event.ends_with("anonymous") {
+                    anonymous = true;
+                    event = event[..event.len() - 9].trim_end();
+                }
+                let inputs = parse_event_args(event)?;
                 return Ok(Event {
                     name,
                     anonymous,
                     inputs,
-                })
-            }
-            Some('\\') => {
-                return match chars.next() {
-                    Some('(') => {
-                        event = chars.as_str().trim();
-                        let (inputs, anonymous) = parse_event_args(event)?;
-                        Ok(Event {
-                            name,
-                            anonymous,
-                            inputs,
-                        })
-                    }
-                    _ => Err(ParseError::ParseError(super::Error::InvalidData)),
-                }
+                });
             }
             Some(' ') | Some('\t') => {
                 continue;
@@ -108,21 +110,14 @@ fn parse_event2(mut event: &str) -> Result<Event, ParseError> {
     }
 }
 
-/// Returns the event parameters and whether the event was declared as anonymous
-fn parse_event_args(mut input: &str) -> Result<(Vec<EventParam>, bool), ParseError> {
-    let mut anonymous = false;
-    if input.ends_with("anonymous") {
-        anonymous = true;
-        input = input[..input.len()-9].trim_end();
-    }
-
+/// Returns the event parameters
+fn parse_event_args(mut input: &str) -> Result<Vec<EventParam>, ParseError> {
     input = input.trim().strip_suffix(')').ok_or(ParseError::ParseError(super::Error::InvalidData))?;
-    input = input.trim_end_matches('\\');
 
     let mut params = Vec::new();
 
     if input.is_empty() {
-        return  Ok((params, anonymous))
+        return Ok(params);
     }
 
     for arg in input.split(',') {
@@ -148,9 +143,67 @@ fn parse_event_args(mut input: &str) -> Result<(Vec<EventParam>, bool), ParseErr
             }
         )
     }
-    Ok((params, anonymous))
+    Ok(params)
 }
 
+
+fn parse_function2(mut input: &str) -> Result<Function, ParseError> {
+    input = input.trim();
+    if !input.starts_with("function ") {
+        return Err(ParseError::ParseError(super::Error::InvalidData));
+    }
+    input = &input[9..];
+    let name = parse_identifier(&mut input)?;
+    if name.is_empty() {
+        return Err(ParseError::ParseError(super::Error::InvalidName(input.to_owned())));
+    }
+
+    let mut iter = input.split(" returns");
+
+    let parens = iter.next().ok_or(ParseError::ParseError(super::Error::InvalidData))?.trim_end();
+
+    let mut parens_iter = parens.rsplitn(2, ')');
+    let mut modifiers = parens_iter.next();
+
+    let input_params = if let Some(args) = parens_iter.next() {
+        args
+    } else {
+        modifiers.take().ok_or(ParseError::ParseError(super::Error::InvalidData))?
+    }.trim_start().strip_prefix('(').ok_or(ParseError::ParseError(super::Error::InvalidData))?;
+
+
+    let inputs = input_params.split(',').filter(|s|!s.is_empty()).map(parse_param2).collect::<Result<Vec<_>,_>>()?;
+
+    let outputs = if let Some(params) = iter.next() {
+        let params = params.trim().strip_prefix('(').and_then(|s|s.strip_suffix(')')).ok_or(ParseError::ParseError(super::Error::InvalidData))?;
+        params.split(',').filter(|s|!s.is_empty()).map(parse_param2).collect::<Result<Vec<_>,_>>()?
+    } else {
+        Vec::new()
+    };
+
+    let state_mutability = if let Some(modifiers) = modifiers {
+        if modifiers.contains("pure") {
+            StateMutability::Pure
+        } else if modifiers.contains("view") {
+            StateMutability::View
+        } else if modifiers.contains("payable") {
+            StateMutability::Payable
+        } else {
+            StateMutability::NonPayable
+        }
+    } else {
+        StateMutability::NonPayable
+    };
+
+    #[allow(deprecated)]
+        Ok(Function {
+        name,
+        inputs,
+        outputs,
+        state_mutability,
+        constant: false,
+    })
+}
 
 fn parse2(input: &[&str]) -> Result<Abi, ParseError> {
     let mut abi = Abi {
@@ -162,22 +215,23 @@ fn parse2(input: &[&str]) -> Result<Abi, ParseError> {
     };
 
     for line in input {
-        let line = line.trim();
-        let (prefix, mut remainder) = line.split_once(' ').ok_or(ParseError::ParseError(super::Error::InvalidData))?;
-        match prefix {
-            "event" => {
-                let event = parse_event2(&mut remainder)?;
-                abi.events
-                    .entry(event.name.clone())
-                    .or_default()
-                    .push(event);
-            }
-            "function" => {}
-            "constructor" => {}
-            _ => return Err(ParseError::ParseError(super::Error::InvalidData))
+        let line = line.trim_start();
+        if line.starts_with("function") {
+            let function = parse_function2(&line)?;
+            abi.functions
+                .entry(function.name.clone())
+                .or_default()
+                .push(function);
+        } else if line.starts_with("event") {
+            let event = parse_event2(line)?;
+            abi.events
+                .entry(event.name.clone())
+                .or_default()
+                .push(event);
+        } else if line.starts_with("constructor") {} else {
+            return Err(ParseError::ParseError(super::Error::InvalidData));
         }
     }
-
 
     Ok(abi)
 }
@@ -286,6 +340,22 @@ fn parse_function(fn_string: &str) -> Result<Function, ParseError> {
     })
 }
 
+fn parse_param2(param: &str) -> Result<Param, ParseError> {
+    let mut iter = param.trim().rsplitn(3, is_whitespace);
+
+    let name = iter.next().ok_or(ParseError::ParseError(super::Error::InvalidData))?;
+
+    if let Some(ty) = iter.last() {
+        if name == "memory" || name == "calldata" {
+            Ok(Param { name: "".to_owned(), kind: Reader::read(ty)? })
+        } else {
+            Ok(Param { name: name.to_owned(), kind: Reader::read(ty)? })
+        }
+    } else {
+        Ok(Param { name: "".to_owned(), kind: Reader::read(name)? })
+    }
+}
+
 // address x
 fn parse_param(param: &str) -> Result<Param, ParseError> {
     let mut param = param
@@ -322,6 +392,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn parses_approve2() {
+        let fn_str = "function approve(address _spender, uint256 value) external returns(bool)";
+        let parsed = parse_function2(fn_str).unwrap();
+        assert_eq!(parsed.name, "approve");
+        assert_eq!(parsed.inputs[0].name, "_spender");
+        assert_eq!(parsed.inputs[0].kind, ParamType::Address, );
+        assert_eq!(parsed.inputs[1].name, "value");
+        assert_eq!(parsed.inputs[1].kind, ParamType::Uint(256), );
+        assert_eq!(parsed.outputs[0].name, "");
+        assert_eq!(parsed.outputs[0].kind, ParamType::Bool);
+    }
+
+    #[test]
     fn parses_approve() {
         let fn_str = "function approve(address _spender, uint256 value) external returns(bool)";
         let parsed = parse_function(fn_str).unwrap();
@@ -332,6 +415,20 @@ mod tests {
         assert_eq!(parsed.inputs[1].kind, ParamType::Uint(256), );
         assert_eq!(parsed.outputs[0].name, "");
         assert_eq!(parsed.outputs[0].kind, ParamType::Bool);
+    }
+
+    #[test]
+    fn parses_function_arguments_return2() {
+        let fn_str = "function foo(uint32[] memory x) external view returns (address)";
+        let parsed = parse_function2(fn_str).unwrap();
+        assert_eq!(parsed.name, "foo");
+        assert_eq!(parsed.inputs[0].name, "x");
+        assert_eq!(
+            parsed.inputs[0].kind,
+            ParamType::Array(Box::new(ParamType::Uint(32)))
+        );
+        assert_eq!(parsed.outputs[0].name, "");
+        assert_eq!(parsed.outputs[0].kind, ParamType::Address);
     }
 
     #[test]
@@ -346,6 +443,36 @@ mod tests {
         );
         assert_eq!(parsed.outputs[0].name, "");
         assert_eq!(parsed.outputs[0].kind, ParamType::Address);
+    }
+
+    #[test]
+    fn parses_function_empty2() {
+        let fn_str = "function foo()";
+        let parsed = parse_function2(fn_str).unwrap();
+        assert_eq!(parsed.name, "foo");
+        assert!(parsed.inputs.is_empty());
+        assert!(parsed.outputs.is_empty());
+    }
+
+    #[test]
+    fn parses_function_payable() {
+        let fn_str = "function foo() public payable";
+        let parsed = parse_function2(fn_str).unwrap();
+        assert_eq!(parsed.state_mutability, StateMutability::Payable);
+    }
+
+    #[test]
+    fn parses_function_view() {
+        let fn_str = "function foo() external view";
+        let parsed = parse_function2(fn_str).unwrap();
+        assert_eq!(parsed.state_mutability, StateMutability::View);
+    }
+
+    #[test]
+    fn parses_function_pure() {
+        let fn_str = "function foo()  pure";
+        let parsed = parse_function2(fn_str).unwrap();
+        assert_eq!(parsed.state_mutability, StateMutability::Pure);
     }
 
     #[test]
@@ -456,6 +583,22 @@ mod tests {
                 indexed: false,
             }
         );
+    }
+
+    #[test]
+    fn can_parse_functions2() {
+        [
+            "function foo(uint256[] memory x) external view returns (address)",
+            "function bar(uint256[] memory x) returns (address)",
+            "function bar(uint256[] memory x, uint32 y) returns (address, uint256)",
+            "function foo(address[] memory, bytes memory) returns (bytes memory)",
+            "function bar(uint256[] memory x)",
+            "function bar()",
+        ]
+            .iter()
+            .for_each(|x| {
+                parse_function2(x).unwrap();
+            });
     }
 
     #[test]

--- a/ethers-core/src/abi/human_readable.rs
+++ b/ethers-core/src/abi/human_readable.rs
@@ -113,8 +113,8 @@ fn parse_event(mut event: &str) -> Result<Event, ParseError> {
                 };
                 return Ok(Event {
                     name,
-                    anonymous,
                     inputs,
+                    anonymous,
                 });
             }
             Some(' ') | Some('\t') => {

--- a/ethers/examples/contract_human_readable.rs
+++ b/ethers/examples/contract_human_readable.rs
@@ -11,7 +11,7 @@ abigen!(
     SimpleContract,
     r#"[
         function setValue(string)
-        function getValue() external view (string)
+        function getValue() external view returns (string)
         event ValueChanged(address indexed author, string oldValue, string newValue)
     ]"#,
     event_derives(serde::Deserialize, serde::Serialize)


### PR DESCRIPTION
This includes a more sophisticated human readable abi parser that should be on par with `ethers-js`'s interface parser.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
The existing parser followed the grammar loosely; 
False positives were possible, so that for example `event SetValue_function_called()` would be detected as `Function`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
All parser function are replaced with a handwritten parser that follows `ethers-js` abi parsing rules.
This also detects `StateMutability` and constructors.
All tests are successfully updated with the new parsers.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Up for discussion

* **mandatory `returns` statement**: The new parser will fail if a function lacks a `returns` statement before its outputs. The `contract_human_readable` example did not succeed because a missing `returns` statement (`function getValue() external view (string)`) was detected and fixed in #
f3bd156 . I'm not sure wether the preferential behavior would be to allow a missing `returns` or require it. `ethers-js` treats a missing `returns` before ouputs as an `INVALID_ARGUMENT` exception.
* **error handling**: This introduces a lot more error checking. Right now there is not a lot feedback about what was the root cause of an error, most of the time a simple `ParseError::ParseError(super::Error::InvalidData)` is returned. I'm open to make this responsive by introducing a `Message(String)` error type or provide the `ParseError::ParseError(super::Error::Other(anyow::Error))` with a message.
* **Side effects of constructor parsing**: `constructor`s are handled as `Constructor` now and asigned to `Contract::constructor`, I'm not sure about potential side effects of the constructor now missing from `Contract::functions`


