### PR TITLE
feat: add support for EIP-234 and EIP-1898

### DIFF
--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -1,7 +1,7 @@
 use super::base::{decode_function_data, AbiError};
 use ethers_core::{
     abi::{Detokenize, Function, InvalidOutputType},
-    types::{Address, BlockNumber, Bytes, TransactionRequest, U256},
+    types::{Address, BlockId, Bytes, TransactionRequest, U256},
 };
 use ethers_providers::{Middleware, PendingTransaction, ProviderError};
 
@@ -52,7 +52,7 @@ pub struct ContractCall<M, D> {
     /// The ABI of the function being called
     pub function: Function,
     /// Optional block number to be used when calculating the transaction's gas and nonce
-    pub block: Option<BlockNumber>,
+    pub block: Option<BlockId>,
     pub(crate) client: Arc<M>,
     pub(crate) datatype: PhantomData<D>,
 }
@@ -83,7 +83,7 @@ impl<M, D: Detokenize> ContractCall<M, D> {
     }
 
     /// Sets the `block` field for sending the tx to the chain
-    pub fn block<T: Into<BlockNumber>>(mut self, block: T) -> Self {
+    pub fn block<T: Into<BlockId>>(mut self, block: T) -> Self {
         self.block = Some(block.into());
         self
     }

--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -4,9 +4,7 @@ use ethers_core::{
     abi::{Detokenize, Event as AbiEvent},
     types::{BlockNumber, Filter, Log, TxHash, ValueOrArray, H256, U64},
 };
-use ethers_providers::{
-    FilterWatcher, Middleware, PubsubClient, SubscriptionStream,
-};
+use ethers_providers::{FilterWatcher, Middleware, PubsubClient, SubscriptionStream};
 use std::borrow::Cow;
 use std::marker::PhantomData;
 
@@ -96,12 +94,7 @@ where
         &'a self,
     ) -> Result<
         // Wraps the FilterWatcher with a mapping to the event
-        EventStream<
-            'a,
-            FilterWatcher<'a, M::Provider, Log>,
-            D,
-            ContractError<M>,
-        >,
+        EventStream<'a, FilterWatcher<'a, M::Provider, Log>, D, ContractError<M>>,
         ContractError<M>,
     > {
         let filter = self
@@ -128,12 +121,7 @@ where
         &'a self,
     ) -> Result<
         // Wraps the SubscriptionStream with a mapping to the event
-        EventStream<
-            'a,
-            SubscriptionStream<'a, M::Provider, Log>,
-            D,
-            ContractError<M>,
-        >,
+        EventStream<'a, SubscriptionStream<'a, M::Provider, Log>, D, ContractError<M>>,
         ContractError<M>,
     > {
         let filter = self
@@ -171,9 +159,7 @@ where
 
     /// Queries the blockchain for the selected filter and returns a vector of logs
     /// along with their metadata
-    pub async fn query_with_meta(
-        &self,
-    ) -> Result<Vec<(D, LogMeta)>, ContractError<M>> {
+    pub async fn query_with_meta(&self) -> Result<Vec<(D, LogMeta)>, ContractError<M>> {
         let logs = self
             .provider
             .get_logs(&self.filter)
@@ -209,9 +195,7 @@ impl From<&Log> for LogMeta {
     fn from(src: &Log) -> Self {
         LogMeta {
             block_number: src.block_number.expect("should have a block number"),
-            transaction_hash: src
-                .transaction_hash
-                .expect("should have a tx hash"),
+            transaction_hash: src.transaction_hash.expect("should have a tx hash"),
         }
     }
 }

--- a/ethers-contract/src/factory.rs
+++ b/ethers-contract/src/factory.rs
@@ -37,7 +37,7 @@ impl<M: Middleware> Deployer<M> {
     pub async fn send(self) -> Result<Contract<M>, ContractError<M>> {
         let pending_tx = self
             .client
-            .send_transaction(self.tx, Some(self.block))
+            .send_transaction(self.tx, Some(self.block.into()))
             .await
             .map_err(ContractError::MiddlewareError)?;
 

--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -1,4 +1,7 @@
-use ethers::{contract::ContractFactory, types::H256};
+use ethers::{
+    contract::ContractFactory,
+    types::{BlockId, H256},
+};
 
 mod common;
 pub use common::*;
@@ -8,9 +11,7 @@ mod eth_tests {
     use super::*;
     use ethers::{
         contract::Multicall,
-        providers::{
-            Http, Middleware, PendingTransaction, Provider, StreamExt,
-        },
+        providers::{Http, Middleware, PendingTransaction, Provider, StreamExt},
         types::{Address, U256},
         utils::Ganache,
     };
@@ -18,8 +19,7 @@ mod eth_tests {
 
     #[tokio::test]
     async fn deploy_and_call_contract() {
-        let (abi, bytecode) =
-            compile_contract("SimpleStorage", "SimpleStorage.sol");
+        let (abi, bytecode) = compile_contract("SimpleStorage", "SimpleStorage.sol");
 
         // launch ganache
         let ganache = Ganache::new().spawn();
@@ -39,8 +39,7 @@ mod eth_tests {
         let contract = deployer.clone().send().await.unwrap();
 
         let get_value = contract.method::<_, String>("getValue", ()).unwrap();
-        let last_sender =
-            contract.method::<_, Address>("lastSender", ()).unwrap();
+        let last_sender = contract.method::<_, Address>("lastSender", ()).unwrap();
 
         // the initial value must be the one set in the constructor
         let value = get_value.clone().call().await.unwrap();
@@ -58,10 +57,7 @@ mod eth_tests {
         let pending_tx = contract_call.send().await.unwrap();
         let tx = client.get_transaction(*pending_tx).await.unwrap().unwrap();
         let tx_receipt = pending_tx.await.unwrap();
-        assert_eq!(
-            last_sender.clone().call().await.unwrap(),
-            client2.address()
-        );
+        assert_eq!(last_sender.clone().call().await.unwrap(), client2.address());
         assert_eq!(get_value.clone().call().await.unwrap(), "hi");
         assert_eq!(tx.input, calldata);
         assert_eq!(tx_receipt.gas_used.unwrap(), gas_estimate);
@@ -98,13 +94,12 @@ mod eth_tests {
 
     #[tokio::test]
     async fn get_past_events() {
-        let (abi, bytecode) =
-            compile_contract("SimpleStorage", "SimpleStorage.sol");
+        let (abi, bytecode) = compile_contract("SimpleStorage", "SimpleStorage.sol");
         let ganache = Ganache::new().spawn();
         let client = connect(&ganache, 0);
         let contract = deploy(client.clone(), abi, bytecode).await;
 
-        // make a call with `client2`
+        // make a call with `client`
         let _tx_hash = *contract
             .method::<_, H256>("setValue", "hi".to_owned())
             .unwrap()
@@ -140,9 +135,122 @@ mod eth_tests {
     }
 
     #[tokio::test]
+    async fn call_past_state() {
+        let (abi, bytecode) = compile_contract("SimpleStorage", "SimpleStorage.sol");
+        let ganache = Ganache::new().spawn();
+        let client = connect(&ganache, 0);
+        let contract = deploy(client.clone(), abi, bytecode).await;
+        let deployed_block = client.get_block_number().await.unwrap();
+
+        // assert initial state
+        let value = contract
+            .method::<_, String>("getValue", ())
+            .unwrap()
+            .call()
+            .await
+            .unwrap();
+        assert_eq!(value, "initial value");
+
+        // make a call with `client`
+        let _tx_hash = *contract
+            .method::<_, H256>("setValue", "hi".to_owned())
+            .unwrap()
+            .send()
+            .await
+            .unwrap();
+
+        // assert new value
+        let value = contract
+            .method::<_, String>("getValue", ())
+            .unwrap()
+            .call()
+            .await
+            .unwrap();
+        assert_eq!(value, "hi");
+
+        // assert previous value
+        let value = contract
+            .method::<_, String>("getValue", ())
+            .unwrap()
+            .block(BlockId::Number(deployed_block.into()))
+            .call()
+            .await
+            .unwrap();
+        assert_eq!(value, "initial value");
+
+        // Here would be the place to test EIP-1898, specifying the `BlockId` of `call` as the
+        // first block hash. However, Ganache does not implement this :/
+
+        // let hash = client.get_block(1).await.unwrap().unwrap().hash.unwrap();
+        // let value = contract
+        //     .method::<_, String>("getValue", ())
+        //     .unwrap()
+        //     .block(BlockId::Hash(hash))
+        //     .call()
+        //     .await
+        //     .unwrap();
+        // assert_eq!(value, "initial value");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn call_past_hash_test() {
+        // geth --dev --http --http.api eth,web3
+        let (abi, bytecode) = compile_contract("SimpleStorage", "SimpleStorage.sol");
+        let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
+        let deployer = provider.get_accounts().await.unwrap()[0];
+
+        let client = Arc::new(provider.with_sender(deployer));
+        let contract = deploy(client.clone(), abi, bytecode).await;
+        let deployed_block = client.get_block_number().await.unwrap();
+
+        // assert initial state
+        let value = contract
+            .method::<_, String>("getValue", ())
+            .unwrap()
+            .call()
+            .await
+            .unwrap();
+        assert_eq!(value, "initial value");
+
+        // make a call with `client`
+        let _tx_hash = *contract
+            .method::<_, H256>("setValue", "hi".to_owned())
+            .unwrap()
+            .send()
+            .await
+            .unwrap();
+
+        // assert new value
+        let value = contract
+            .method::<_, String>("getValue", ())
+            .unwrap()
+            .call()
+            .await
+            .unwrap();
+        assert_eq!(value, "hi");
+
+        // assert previous value using block hash
+        let hash = client
+            .get_block(deployed_block)
+            .await
+            .unwrap()
+            .unwrap()
+            .hash
+            .unwrap();
+        let value = contract
+            .method::<_, String>("getValue", ())
+            .unwrap()
+            .block(BlockId::Hash(hash))
+            .call()
+            .await
+            .unwrap();
+        assert_eq!(value, "initial value");
+    }
+
+    #[tokio::test]
     async fn watch_events() {
-        let (abi, bytecode) =
-            compile_contract("SimpleStorage", "SimpleStorage.sol");
+        let (abi, bytecode) = compile_contract("SimpleStorage", "SimpleStorage.sol");
         let ganache = Ganache::new().spawn();
         let client = connect(&ganache, 0);
         let contract = deploy(client, abi.clone(), bytecode).await;
@@ -154,8 +262,7 @@ mod eth_tests {
 
         // Also set up a subscription for the same thing
         let ws = Provider::connect(ganache.ws_endpoint()).await.unwrap();
-        let contract2 =
-            ethers_contract::Contract::new(contract.address(), abi, ws);
+        let contract2 = ethers_contract::Contract::new(contract.address(), abi, ws);
         let event2 = contract2.event::<ValueChanged>("ValueChanged").unwrap();
         let mut subscription = event2.subscribe().await.unwrap();
         assert_eq!(subscription.id, 2.into());
@@ -182,8 +289,7 @@ mod eth_tests {
 
     #[tokio::test]
     async fn signer_on_node() {
-        let (abi, bytecode) =
-            compile_contract("SimpleStorage", "SimpleStorage.sol");
+        let (abi, bytecode) = compile_contract("SimpleStorage", "SimpleStorage.sol");
         // spawn ganache
         let ganache = Ganache::new().spawn();
 
@@ -220,16 +326,14 @@ mod eth_tests {
     #[tokio::test]
     async fn multicall_aggregate() {
         // get ABI and bytecode for the Multcall contract
-        let (multicall_abi, multicall_bytecode) =
-            compile_contract("Multicall", "Multicall.sol");
+        let (multicall_abi, multicall_bytecode) = compile_contract("Multicall", "Multicall.sol");
 
         // get ABI and bytecode for the NotSoSimpleStorage contract
         let (not_so_simple_abi, not_so_simple_bytecode) =
             compile_contract("NotSoSimpleStorage", "NotSoSimpleStorage.sol");
 
         // get ABI and bytecode for the SimpleStorage contract
-        let (abi, bytecode) =
-            compile_contract("SimpleStorage", "SimpleStorage.sol");
+        let (abi, bytecode) = compile_contract("SimpleStorage", "SimpleStorage.sol");
 
         // launch ganache
         let ganache = Ganache::new().spawn();
@@ -246,24 +350,13 @@ mod eth_tests {
         let client4 = connect(&ganache, 3);
 
         // create a factory which will be used to deploy instances of the contract
-        let multicall_factory = ContractFactory::new(
-            multicall_abi,
-            multicall_bytecode,
-            client.clone(),
-        );
-        let simple_factory = ContractFactory::new(
-            abi.clone(),
-            bytecode.clone(),
-            client2.clone(),
-        );
-        let not_so_simple_factory = ContractFactory::new(
-            not_so_simple_abi,
-            not_so_simple_bytecode,
-            client3.clone(),
-        );
+        let multicall_factory =
+            ContractFactory::new(multicall_abi, multicall_bytecode, client.clone());
+        let simple_factory = ContractFactory::new(abi.clone(), bytecode.clone(), client2.clone());
+        let not_so_simple_factory =
+            ContractFactory::new(not_so_simple_abi, not_so_simple_bytecode, client3.clone());
 
-        let multicall_contract =
-            multicall_factory.deploy(()).unwrap().send().await.unwrap();
+        let multicall_contract = multicall_factory.deploy(()).unwrap().send().await.unwrap();
         let addr = multicall_contract.address();
 
         let simple_contract = simple_factory
@@ -296,8 +389,7 @@ mod eth_tests {
             .unwrap();
 
         // get the calls for `value` and `last_sender` for both SimpleStorage contracts
-        let value =
-            simple_contract.method::<_, String>("getValue", ()).unwrap();
+        let value = simple_contract.method::<_, String>("getValue", ()).unwrap();
         let value2 = not_so_simple_contract
             .method::<_, (String, Address)>("getValues", ())
             .unwrap();
@@ -309,8 +401,7 @@ mod eth_tests {
             .unwrap();
 
         // initiate the Multicall instance and add calls one by one in builder style
-        let mut multicall =
-            Multicall::new(client4.clone(), Some(addr)).await.unwrap();
+        let mut multicall = Multicall::new(client4.clone(), Some(addr)).await.unwrap();
 
         multicall
             .add_call(value)
@@ -395,29 +486,24 @@ mod celo_tests {
 
     #[tokio::test]
     async fn deploy_and_call_contract() {
-        let (abi, bytecode) =
-            compile_contract("SimpleStorage", "SimpleStorage.sol");
+        let (abi, bytecode) = compile_contract("SimpleStorage", "SimpleStorage.sol");
 
         // Celo testnet
-        let provider = Provider::<Http>::try_from(
-            "https://alfajores-forno.celo-testnet.org",
-        )
-        .unwrap()
-        .interval(Duration::from_millis(6000));
+        let provider = Provider::<Http>::try_from("https://alfajores-forno.celo-testnet.org")
+            .unwrap()
+            .interval(Duration::from_millis(6000));
 
         // Funded with https://celo.org/developers/faucet
-        let wallet =
-            "d652abb81e8c686edba621a895531b1f291289b63b5ef09a94f686a5ecdd5db1"
-                .parse::<LocalWallet>()
-                .unwrap();
+        let wallet = "d652abb81e8c686edba621a895531b1f291289b63b5ef09a94f686a5ecdd5db1"
+            .parse::<LocalWallet>()
+            .unwrap();
 
         let client = SignerMiddleware::new(provider, wallet);
         let client = Arc::new(client);
 
         let factory = ContractFactory::new(abi, bytecode, client);
         let deployer = factory.deploy("initial value".to_string()).unwrap();
-        let contract =
-            deployer.block(BlockNumber::Pending).send().await.unwrap();
+        let contract = deployer.block(BlockNumber::Pending).send().await.unwrap();
 
         let value: String = contract
             .method("getValue", ())

--- a/ethers-core/src/types/log.rs
+++ b/ethers-core/src/types/log.rs
@@ -62,14 +62,64 @@ pub struct Log {
     pub removed: Option<bool>,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum FilterBlockOption {
+    Range {
+        from_block: Option<BlockNumber>,
+        to_block: Option<BlockNumber>,
+    },
+    AtBlockHash(H256),
+}
+
+impl Default for FilterBlockOption {
+    fn default() -> Self {
+        FilterBlockOption::Range {
+            from_block: None,
+            to_block: None,
+        }
+    }
+}
+
+impl FilterBlockOption {
+    pub fn set_from_block(&self, block: BlockNumber) -> Self {
+        let to_block = if let FilterBlockOption::Range { to_block, .. } = self {
+            *to_block
+        } else {
+            None
+        };
+
+        FilterBlockOption::Range {
+            from_block: Some(block.into()),
+            to_block: to_block,
+        }
+    }
+
+    pub fn set_to_block(&self, block: BlockNumber) -> Self {
+        let from_block =
+            if let FilterBlockOption::Range { from_block, .. } = self {
+                *from_block
+            } else {
+                None
+            };
+
+        FilterBlockOption::Range {
+            from_block: from_block,
+            to_block: Some(block.into()),
+        }
+    }
+
+    pub fn set_hash(&self, hash: H256) -> Self {
+        FilterBlockOption::AtBlockHash(hash)
+    }
+}
+
 /// Filter for
 #[derive(Default, Debug, PartialEq, Clone)]
 pub struct Filter {
-    /// From Block
-    pub from_block: Option<BlockNumber>,
-
-    /// To Block
-    pub to_block: Option<BlockNumber>,
+    /// Filter block options, specifying on which blocks the filter should
+    /// match.
+    // https://eips.ethereum.org/EIPS/eip-234
+    pub block_option: FilterBlockOption,
 
     /// Address
     // TODO: The spec says that this can also be an array, do we really want to
@@ -91,12 +141,23 @@ impl Serialize for Filter {
         S: Serializer,
     {
         let mut s = serializer.serialize_struct("Filter", 5)?;
-        if let Some(ref from_block) = self.from_block {
-            s.serialize_field("fromBlock", from_block)?;
-        }
+        match self.block_option {
+            FilterBlockOption::Range {
+                from_block,
+                to_block,
+            } => {
+                if let Some(ref from_block) = from_block {
+                    s.serialize_field("fromBlock", from_block)?;
+                }
 
-        if let Some(ref to_block) = self.to_block {
-            s.serialize_field("toBlock", to_block)?;
+                if let Some(ref to_block) = to_block {
+                    s.serialize_field("toBlock", to_block)?;
+                }
+            }
+
+            FilterBlockOption::AtBlockHash(ref h) => {
+                s.serialize_field("blockHash", h)?
+            }
         }
 
         if let Some(ref address) = self.address {
@@ -131,13 +192,19 @@ impl Filter {
 
     #[allow(clippy::wrong_self_convention)]
     pub fn from_block<T: Into<BlockNumber>>(mut self, block: T) -> Self {
-        self.from_block = Some(block.into());
+        self.block_option = self.block_option.set_from_block(block.into());
         self
     }
 
     #[allow(clippy::wrong_self_convention)]
     pub fn to_block<T: Into<BlockNumber>>(mut self, block: T) -> Self {
-        self.to_block = Some(block.into());
+        self.block_option = self.block_option.set_to_block(block.into());
+        self
+    }
+
+    #[allow(clippy::wrong_self_convention)]
+    pub fn at_block_hash<T: Into<H256>>(mut self, hash: T) -> Self {
+        self.block_option = self.block_option.set_hash(hash.into());
         self
     }
 
@@ -253,7 +320,8 @@ mod tests {
 
         let event = "ValueChanged(address,string,string)";
         let t0 = H256::from(keccak256(event.as_bytes()));
-        let addr: Address = "f817796F60D268A36a57b8D2dF1B97B14C0D0E1d".parse().unwrap();
+        let addr: Address =
+            "f817796F60D268A36a57b8D2dF1B97B14C0D0E1d".parse().unwrap();
         let filter = Filter::new();
 
         let ser = serialize(&filter.clone());

--- a/ethers-core/src/types/log.rs
+++ b/ethers-core/src/types/log.rs
@@ -90,7 +90,7 @@ impl FilterBlockOption {
 
         FilterBlockOption::Range {
             from_block: Some(block.into()),
-            to_block: to_block,
+            to_block,
         }
     }
 
@@ -102,7 +102,7 @@ impl FilterBlockOption {
         };
 
         FilterBlockOption::Range {
-            from_block: from_block,
+            from_block,
             to_block: Some(block.into()),
         }
     }

--- a/ethers-core/src/types/log.rs
+++ b/ethers-core/src/types/log.rs
@@ -95,12 +95,11 @@ impl FilterBlockOption {
     }
 
     pub fn set_to_block(&self, block: BlockNumber) -> Self {
-        let from_block =
-            if let FilterBlockOption::Range { from_block, .. } = self {
-                *from_block
-            } else {
-                None
-            };
+        let from_block = if let FilterBlockOption::Range { from_block, .. } = self {
+            *from_block
+        } else {
+            None
+        };
 
         FilterBlockOption::Range {
             from_block: from_block,
@@ -155,9 +154,7 @@ impl Serialize for Filter {
                 }
             }
 
-            FilterBlockOption::AtBlockHash(ref h) => {
-                s.serialize_field("blockHash", h)?
-            }
+            FilterBlockOption::AtBlockHash(ref h) => s.serialize_field("blockHash", h)?,
         }
 
         if let Some(ref address) = self.address {
@@ -320,8 +317,7 @@ mod tests {
 
         let event = "ValueChanged(address,string,string)";
         let t0 = H256::from(keccak256(event.as_bytes()));
-        let addr: Address =
-            "f817796F60D268A36a57b8D2dF1B97B14C0D0E1d".parse().unwrap();
+        let addr: Address = "f817796F60D268A36a57b8D2dF1B97B14C0D0E1d".parse().unwrap();
         let filter = Filter::new();
 
         let ser = serialize(&filter.clone());

--- a/ethers-core/src/types/log.rs
+++ b/ethers-core/src/types/log.rs
@@ -89,7 +89,7 @@ impl FilterBlockOption {
         };
 
         FilterBlockOption::Range {
-            from_block: Some(block.into()),
+            from_block: Some(block),
             to_block,
         }
     }
@@ -103,7 +103,7 @@ impl FilterBlockOption {
 
         FilterBlockOption::Range {
             from_block,
-            to_block: Some(block.into()),
+            to_block: Some(block),
         }
     }
 

--- a/ethers-middleware/src/gas_escalator/mod.rs
+++ b/ethers-middleware/src/gas_escalator/mod.rs
@@ -5,7 +5,7 @@ mod linear;
 pub use linear::LinearGasPrice;
 
 use async_trait::async_trait;
-use ethers_core::types::{BlockNumber, TransactionRequest, TxHash, U256};
+use ethers_core::types::{BlockId, TransactionRequest, TxHash, U256};
 use ethers_providers::{interval, FromErr, Middleware, PendingTransaction, StreamExt};
 use futures_util::lock::Mutex;
 use std::sync::Arc;
@@ -64,7 +64,7 @@ pub struct GasEscalatorMiddleware<M, E> {
     pub(crate) escalator: E,
     /// The transactions which are currently being monitored for escalation
     #[allow(clippy::type_complexity)]
-    pub txs: Arc<Mutex<Vec<(TxHash, TransactionRequest, Instant, Option<BlockNumber>)>>>,
+    pub txs: Arc<Mutex<Vec<(TxHash, TransactionRequest, Instant, Option<BlockId>)>>>,
     frequency: Frequency,
 }
 
@@ -85,7 +85,7 @@ where
     async fn send_transaction(
         &self,
         tx: TransactionRequest,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<PendingTransaction<'_, Self::Provider>, Self::Error> {
         let pending_tx = self
             .inner()

--- a/ethers-middleware/src/gas_oracle/middleware.rs
+++ b/ethers-middleware/src/gas_oracle/middleware.rs
@@ -59,7 +59,7 @@ where
     async fn send_transaction(
         &self,
         mut tx: TransactionRequest,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<PendingTransaction<'_, Self::Provider>, Self::Error> {
         if tx.gas_price.is_none() {
             tx.gas_price = Some(self.get_gas_price().await?);

--- a/ethers-middleware/src/nonce_manager.rs
+++ b/ethers-middleware/src/nonce_manager.rs
@@ -37,7 +37,7 @@ where
 
     async fn get_transaction_count_with_manager(
         &self,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<U256, NonceManagerError<M>> {
         // initialize the nonce the first time the manager is called
         if !self.initialized.load(Ordering::SeqCst) {
@@ -87,7 +87,7 @@ where
     async fn send_transaction(
         &self,
         mut tx: TransactionRequest,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<PendingTransaction<'_, Self::Provider>, Self::Error> {
         if tx.nonce.is_none() {
             tx.nonce = Some(self.get_transaction_count_with_manager(block).await?);

--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -1,7 +1,6 @@
 use ethers_core::{
     types::{
-        Address, BlockNumber, Bytes, NameOrAddress, Signature, Transaction, TransactionRequest,
-        U256,
+        Address, BlockId, Bytes, NameOrAddress, Signature, Transaction, TransactionRequest, U256,
     },
     utils::keccak256,
 };
@@ -176,7 +175,7 @@ where
     async fn fill_transaction(
         &self,
         tx: &mut TransactionRequest,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<(), SignerMiddlewareError<M, S>> {
         // set the `from` field
         if tx.from.is_none() {
@@ -246,7 +245,7 @@ where
     async fn send_transaction(
         &self,
         mut tx: TransactionRequest,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<PendingTransaction<'_, Self::Provider>, Self::Error> {
         if let Some(NameOrAddress::Name(ens_name)) = tx.to {
             let addr = self

--- a/ethers-middleware/src/transformer/middleware.rs
+++ b/ethers-middleware/src/transformer/middleware.rs
@@ -56,7 +56,7 @@ where
     async fn send_transaction(
         &self,
         mut tx: TransactionRequest,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<PendingTransaction<'_, Self::Provider>, Self::Error> {
         // resolve the to field if that's an ENS name.
         if let Some(NameOrAddress::Name(ens_name)) = tx.to {

--- a/ethers-middleware/tests/nonce_manager.rs
+++ b/ethers-middleware/tests/nonce_manager.rs
@@ -25,7 +25,7 @@ async fn nonce_manager() {
     let provider = NonceManagerMiddleware::new(provider, address);
 
     let nonce = provider
-        .get_transaction_count(address, Some(BlockNumber::Pending))
+        .get_transaction_count(address, Some(BlockNumber::Pending.into()))
         .await
         .unwrap()
         .as_u64();

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -188,7 +188,7 @@ pub trait Middleware: Sync + Send + Debug {
     async fn send_transaction(
         &self,
         tx: TransactionRequest,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<PendingTransaction<'_, Self::Provider>, Self::Error> {
         self.inner()
             .send_transaction(tx, block)
@@ -233,7 +233,7 @@ pub trait Middleware: Sync + Send + Debug {
     async fn get_transaction_count<T: Into<NameOrAddress> + Send + Sync>(
         &self,
         from: T,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<U256, Self::Error> {
         self.inner()
             .get_transaction_count(from, block)
@@ -248,7 +248,7 @@ pub trait Middleware: Sync + Send + Debug {
     async fn call(
         &self,
         tx: &TransactionRequest,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<Bytes, Self::Error> {
         self.inner().call(tx, block).await.map_err(FromErr::from)
     }
@@ -260,7 +260,7 @@ pub trait Middleware: Sync + Send + Debug {
     async fn get_balance<T: Into<NameOrAddress> + Send + Sync>(
         &self,
         from: T,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<U256, Self::Error> {
         self.inner()
             .get_balance(from, block)
@@ -375,7 +375,7 @@ pub trait Middleware: Sync + Send + Debug {
     async fn get_code<T: Into<NameOrAddress> + Send + Sync>(
         &self,
         at: T,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<Bytes, Self::Error> {
         self.inner()
             .get_code(at, block)
@@ -387,7 +387,7 @@ pub trait Middleware: Sync + Send + Debug {
         &self,
         from: T,
         location: H256,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<H256, Self::Error> {
         self.inner()
             .get_storage_at(from, location, block)

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -229,7 +229,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         };
 
         let from = utils::serialize(&from);
-        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest.into()));
+        let block = utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
         self.request("eth_getTransactionCount", [from, block]).await
     }
 
@@ -245,7 +245,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         };
 
         let from = utils::serialize(&from);
-        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest.into()));
+        let block = utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
         self.request("eth_getBalance", [from, block]).await
     }
 
@@ -267,7 +267,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         block: Option<BlockId>,
     ) -> Result<Bytes, ProviderError> {
         let tx = utils::serialize(tx);
-        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest.into()));
+        let block = utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
         self.request("eth_call", [tx, block]).await
     }
 
@@ -435,7 +435,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
 
         let from = utils::serialize(&from);
         let location = utils::serialize(&location);
-        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest.into()));
+        let block = utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
 
         // get the hex encoded value.
         let value: String = self
@@ -458,7 +458,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         };
 
         let at = utils::serialize(&at);
-        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest.into()));
+        let block = utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
         self.request("eth_getCode", [at, block]).await
     }
 

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -221,7 +221,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
     async fn get_transaction_count<T: Into<NameOrAddress> + Send + Sync>(
         &self,
         from: T,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<U256, ProviderError> {
         let from = match from.into() {
             NameOrAddress::Name(ens_name) => self.resolve_name(&ens_name).await?,
@@ -229,7 +229,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         };
 
         let from = utils::serialize(&from);
-        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest));
+        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest.into()));
         self.request("eth_getTransactionCount", [from, block]).await
     }
 
@@ -237,7 +237,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
     async fn get_balance<T: Into<NameOrAddress> + Send + Sync>(
         &self,
         from: T,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<U256, ProviderError> {
         let from = match from.into() {
             NameOrAddress::Name(ens_name) => self.resolve_name(&ens_name).await?,
@@ -245,7 +245,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         };
 
         let from = utils::serialize(&from);
-        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest));
+        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest.into()));
         self.request("eth_getBalance", [from, block]).await
     }
 
@@ -264,10 +264,10 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
     async fn call(
         &self,
         tx: &TransactionRequest,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<Bytes, ProviderError> {
         let tx = utils::serialize(tx);
-        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest));
+        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest.into()));
         self.request("eth_call", [tx, block]).await
     }
 
@@ -283,7 +283,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
     async fn send_transaction(
         &self,
         mut tx: TransactionRequest,
-        _: Option<BlockNumber>,
+        _: Option<BlockId>,
     ) -> Result<PendingTransaction<'_, P>, ProviderError> {
         if tx.from.is_none() {
             tx.from = self.3;
@@ -426,7 +426,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         &self,
         from: T,
         location: H256,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<H256, ProviderError> {
         let from = match from.into() {
             NameOrAddress::Name(ens_name) => self.resolve_name(&ens_name).await?,
@@ -435,7 +435,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
 
         let from = utils::serialize(&from);
         let location = utils::serialize(&location);
-        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest));
+        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest.into()));
 
         // get the hex encoded value.
         let value: String = self
@@ -450,7 +450,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
     async fn get_code<T: Into<NameOrAddress> + Send + Sync>(
         &self,
         at: T,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<Bytes, ProviderError> {
         let at = match at.into() {
             NameOrAddress::Name(ens_name) => self.resolve_name(&ens_name).await?,
@@ -458,7 +458,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         };
 
         let at = utils::serialize(&at);
-        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest));
+        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest.into()));
         self.request("eth_getCode", [at, block]).await
     }
 

--- a/ethers/examples/transfer_eth.rs
+++ b/ethers/examples/transfer_eth.rs
@@ -23,11 +23,11 @@ async fn main() -> Result<()> {
     println!("{}", serde_json::to_string(&tx)?);
 
     let nonce1 = provider
-        .get_transaction_count(from, Some(BlockNumber::Latest))
+        .get_transaction_count(from, Some(BlockNumber::Latest.into()))
         .await?;
 
     let nonce2 = provider
-        .get_transaction_count(from, Some(BlockNumber::Number(0.into())))
+        .get_transaction_count(from, Some(BlockNumber::Number(0.into()).into()))
         .await?;
 
     assert!(nonce2 < nonce1);


### PR DESCRIPTION
Related issue: #230

## Motivation

These two EIPs are closely related, and allow for querying the blockchain's state at a specified block hash. Which is quite useful when dealing chain reorgs and allows for more robust clients.

## Solution

For EIP-234, add method `at_block_hash` for `Event` and `Filter`.

For EIP-1898, modify `Middleware` functions affected by the EIP (that is, most that receive a `BlockNumber`), changing their signatures to receive a `BlockId` instead. Also, change the method `ContractCall::block` to receive a `BlockId`, instead of a `BlockNumber`.