### PR TITLE
chore(clippy): update rename clippy lint

### DIFF
--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 //! # Clients for interacting with Ethereum nodes
 //!
 //! This crate provides asynchronous [Ethereum JSON-RPC](https://github.com/ethereum/wiki/wiki/JSON-RPC)

--- a/ethers/src/lib.rs
+++ b/ethers/src/lib.rs
@@ -4,7 +4,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Get rid of the clippy warning `lint broken_intra_doc_links has been removed: use rustdoc::broken_intra_doc_linksinstead`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
apply clippy suggestion
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

EDIT: apparently this appears to be a `nightly` only issue, and therefor can't be included for now
