### PR TITLE
style: remove token instead of cloning them

### DIFF
--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -307,11 +307,11 @@ impl<M: Middleware> Multicall<M> {
             .iter()
             .zip(&return_data)
             .map(|(call, bytes)| {
-                let tokens: Vec<Token> = call.function.decode_output(&bytes)?;
+                let mut tokens: Vec<Token> = call.function.decode_output(&bytes)?;
 
                 Ok(match tokens.len() {
                     0 => Token::Tuple(vec![]),
-                    1 => tokens[0].clone(),
+                    1 => tokens.remove(0),
                     _ => Token::Tuple(tokens),
                 })
             })

--- a/ethers-core/src/abi/tokens.rs
+++ b/ethers-core/src/abi/tokens.rs
@@ -31,10 +31,10 @@ impl Detokenize for () {
 }
 
 impl<T: Tokenizable> Detokenize for T {
-    fn from_tokens(tokens: Vec<Token>) -> Result<Self, InvalidOutputType> {
+    fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, InvalidOutputType> {
         let token = match tokens.len() {
             0 => Token::Tuple(vec![]),
-            1 => tokens[0].clone(),
+            1 => tokens.remove(0),
             _ => Token::Tuple(tokens),
         };
 
@@ -473,11 +473,11 @@ impl_fixed_types!(1024);
 /// Helper for flattening non-nested tokens into their inner
 /// types, e.g. (A, B, C ) would get tokenized to Tuple([A, B, C])
 /// when in fact we need [A, B, C].
-fn flatten_tokens(tokens: Vec<Token>) -> Vec<Token> {
+fn flatten_tokens(mut tokens: Vec<Token>) -> Vec<Token> {
     if tokens.len() == 1 {
         // flatten the tokens if required
         // and there is no nesting
-        match tokens[0].clone() {
+        match tokens.remove(0) {
             Token::Tuple(inner) => inner,
             other => vec![other],
         }


### PR DESCRIPTION
By using `remove(0)` on a `Vec<Token>` with len == 1 we don't need to clone
