### PR TITLE
feat(abigen): extend ethevent trait methods and decoding

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -79,15 +79,14 @@ impl Context {
             #[allow(clippy::too_many_arguments)]
             mod #name_mod {
                 #imports
-
                 #struct_decl
 
-                impl<'a, M: Middleware> #name<M> {
+                impl<'a, M: ethers_providers::Middleware> #name<M> {
                     /// Creates a new contract instance with the specified `ethers`
                     /// client at the given `Address`. The contract derefs to a `ethers::Contract`
                     /// object
-                    pub fn new<T: Into<Address>>(address: T, client: Arc<M>) -> Self {
-                        let contract = Contract::new(address.into(), #abi_name.clone(), client);
+                    pub fn new<T: Into<ethers_core::types::Address>>(address: T, client: ::std::sync::Arc<M>) -> Self {
+                        let contract = ethers_contract::Contract::new(address.into(), #abi_name.clone(), client);
                         Self(contract)
                     }
 

--- a/ethers-contract/ethers-contract-abigen/src/contract/common.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/common.rs
@@ -15,11 +15,12 @@ pub(crate) fn imports(name: &str) -> TokenStream {
         use std::sync::Arc;
         use ethers::{
             core::{
+                self as ethers_core,
                 abi::{Abi, Token, Detokenize, InvalidOutputType, Tokenizable},
                 types::*, // import all the types so that we can codegen for everything
             },
-            contract::{Contract, builders::{ContractCall, Event}, Lazy},
-            providers::Middleware,
+            contract::{self as ethers_contract, Contract, builders::{ContractCall, Event}, Lazy},
+            providers::{self as ethers_providers,Middleware},
         };
     }
 }

--- a/ethers-contract/ethers-contract-abigen/src/contract/common.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/common.rs
@@ -31,12 +31,12 @@ pub(crate) fn struct_declaration(cx: &Context, abi_name: &proc_macro2::Ident) ->
 
     let abi_parse = if !cx.human_readable {
         quote! {
-            pub static #abi_name: Lazy<Abi> = Lazy::new(|| serde_json::from_str(#abi)
+            pub static #abi_name: ethers_contract::Lazy<ethers_core::abi::Abi> = ethers_contract::Lazy::new(|| serde_json::from_str(#abi)
                                               .expect("invalid abi"));
         }
     } else {
         quote! {
-            pub static #abi_name: Lazy<Abi> = Lazy::new(|| ethers::core::abi::parse_abi_str(#abi)
+            pub static #abi_name: ethers_contract::Lazy<ethers_core::abi::Abi> = ethers_contract::Lazy::new(|| ethers::core::abi::parse_abi_str(#abi)
                                                 .expect("invalid abi"));
         }
     };
@@ -47,17 +47,17 @@ pub(crate) fn struct_declaration(cx: &Context, abi_name: &proc_macro2::Ident) ->
 
         // Struct declaration
         #[derive(Clone)]
-        pub struct #name<M>(Contract<M>);
+        pub struct #name<M>(ethers_contract::Contract<M>);
 
 
         // Deref to the inner contract in order to access more specific functions functions
         impl<M> std::ops::Deref for #name<M> {
-            type Target = Contract<M>;
+            type Target = ethers_contract::Contract<M>;
 
             fn deref(&self) -> &Self::Target { &self.0 }
         }
 
-        impl<M: Middleware> std::fmt::Debug for #name<M> {
+        impl<M: ethers_providers::Middleware> std::fmt::Debug for #name<M> {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
                 f.debug_tuple(stringify!(#name))
                     .field(&self.address())

--- a/ethers-contract/ethers-contract-abigen/src/contract/events.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/events.rs
@@ -384,10 +384,8 @@ mod tests {
         let cx = test_context();
         assert_quote!(cx.expand_filter(&event), {
             #[doc = "Gets the contract's `Transfer` event"]
-            pub fn transfer_filter(&self) -> Event<M, TransferFilter> {
-                self.0
-                    .event("Transfer")
-                    .expect("event not found (this should never happen)")
+            pub fn transfer_filter(&self) -> ethers_contract::builders::Event<M, TransferFilter> {
+                self.0.event()
             }
         });
     }
@@ -419,7 +417,7 @@ mod tests {
         assert_quote!(definition, {
             struct FooFilter {
                 pub a: bool,
-                pub p1: Address,
+                pub p1: ethers_core::types::Address,
             }
         });
     }
@@ -446,10 +444,10 @@ mod tests {
         let cx = test_context();
         let params = cx.expand_params(&event).unwrap();
         let name = expand_struct_name(&event);
-        let definition = expand_data_tuple(name, &params);
+        let definition = expand_data_tuple(&name, &params);
 
         assert_quote!(definition, {
-            struct FooFilter(pub bool, pub Address);
+            struct FooFilter(pub bool, pub ethers_core::types::Address);
         });
     }
 

--- a/ethers-contract/ethers-contract-abigen/src/contract/events.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/events.rs
@@ -63,19 +63,19 @@ impl Context {
                 #(#variants(#variants)),*
             }
 
-             impl ethers::abi::Tokenizable for #enum_name {
+             impl ethers_core::abi::Tokenizable for #enum_name {
 
-                 fn from_token(token: ethers::abi::Token) -> Result<Self, ethers::abi::InvalidOutputType> where
+                 fn from_token(token: ethers_core::abi::Token) -> Result<Self, ethers_core::abi::InvalidOutputType> where
                      Self: Sized {
                     #(
                         if let Ok(decoded) = #variants::from_token(token.clone()) {
                             return Ok(#enum_name::#variants(decoded))
                         }
                     )*
-                    Err(ethers::abi::InvalidOutputType("Failed to decode all event variants".to_string()))
+                    Err(ethers_core::abi::InvalidOutputType("Failed to decode all event variants".to_string()))
                 }
 
-                fn into_token(self) -> ethers::abi::Token {
+                fn into_token(self) -> ethers_core::abi::Token {
                     match self {
                         #(
                             #enum_name::#variants(element) => element.into_token()
@@ -83,10 +83,10 @@ impl Context {
                     }
                 }
              }
-             impl ethers::abi::TokenizableItem for #enum_name { }
+             impl ethers_core::abi::TokenizableItem for #enum_name { }
 
-             impl ethers::contract::EthLogDecode for #enum_name {
-                fn decode_log(log: &ethers::abi::RawLog) -> Result<Self, ethers::abi::Error>
+             impl ethers_contract::EthLogDecode for #enum_name {
+                fn decode_log(log: &ethers_core::abi::RawLog) -> Result<Self, ethers_core::abi::Error>
                 where
                     Self: Sized,
                 {
@@ -95,7 +95,7 @@ impl Context {
                             return Ok(#enum_name::#variants(decoded))
                         }
                     )*
-                    Err(ethers::abi::Error::InvalidData)
+                    Err(ethers_core::abi::Error::InvalidData)
                 }
             }
         }
@@ -146,7 +146,7 @@ impl Context {
                         return Ok(quote! {::std::vec::Vec<#ty>});
                     }
                 }
-                quote! { H256 }
+                quote! { ethers_core::types::H256 }
             }
             (ParamType::FixedArray(ty, size), true) => {
                 if let ParamType::Tuple(..) = **ty {
@@ -162,7 +162,7 @@ impl Context {
                         return Ok(quote! {[#ty; #size]});
                     }
                 }
-                quote! { H256 }
+                quote! { ethers_core::types::H256 }
             }
             (ParamType::Tuple(..), true) => {
                 // represents an struct
@@ -175,11 +175,11 @@ impl Context {
                 {
                     quote! {#ty}
                 } else {
-                    quote! { H256 }
+                    quote! { ethers_core::types::H256 }
                 }
             }
             (ParamType::Bytes, true) | (ParamType::String, true) => {
-                quote! { H256 }
+                quote! { ethers_core::types::H256 }
             }
             (kind, _) => types::expand(kind)?,
         })
@@ -213,7 +213,7 @@ impl Context {
         let doc = util::expand_doc(&format!("Gets the contract's `{}` event", event.name));
         quote! {
             #doc
-            pub fn #name(&self) -> Event<M, #result> {
+            pub fn #name(&self) -> ethers_contract::builders::Event<M, #result> {
                 self.0.event(#ev_name).expect("event not found (this should never happen)")
             }
         }
@@ -239,7 +239,7 @@ impl Context {
         let event_abi_name = &event.name;
 
         Ok(quote! {
-            #[derive(Clone, Debug, Default, Eq, PartialEq, ethers::contract::EthEvent, #derives)]
+            #[derive(Clone, Debug, Default, Eq, PartialEq, ethers_contract::EthEvent, #derives)]
             #[ethevent( name = #event_abi_name, abi = #abi_signature )]
             pub #data_type_definition
         })
@@ -335,7 +335,7 @@ fn expand_hash(hash: Hash) -> TokenStream {
     let bytes = hash.as_bytes().iter().copied().map(Literal::u8_unsuffixed);
 
     quote! {
-        H256([#( #bytes ),*])
+        ethers_core::types::H256([#( #bytes ),*])
     }
 }
 
@@ -452,7 +452,7 @@ mod tests {
                 "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".parse().unwrap()
             ),
             {
-                H256([
+                ethers_core::types::H256([
                     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
                     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
                 ])

--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -179,7 +179,7 @@ mod tests {
                 ],
             )
             .unwrap(),
-            { , a: bool, b: Address },
+            { , a: bool, b: ethers_core::types::Address },
         );
     }
 
@@ -214,7 +214,7 @@ mod tests {
                 },
             ],)
             .unwrap(),
-            { (bool, Address) },
+            { (bool, ethers_core::types::Address) },
         );
     }
 }

--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -39,7 +39,7 @@ fn expand_function(function: &Function, alias: Option<Ident>) -> Result<TokenStr
 
     let outputs = expand_fn_outputs(&function.outputs)?;
 
-    let result = quote! { ContractCall<M, #outputs> };
+    let result = quote! { ethers_contract::builders::ContractCall<M, #outputs> };
 
     let arg = expand_inputs_call_arg(&function.inputs);
     let doc = util::expand_doc(&format!(

--- a/ethers-contract/ethers-contract-abigen/src/contract/types.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/types.rs
@@ -5,7 +5,7 @@ use quote::quote;
 
 pub(crate) fn expand(kind: &ParamType) -> Result<TokenStream> {
     match kind {
-        ParamType::Address => Ok(quote! { Address }),
+        ParamType::Address => Ok(quote! { ethers_core::types::Address }),
         ParamType::Bytes => Ok(quote! { Vec<u8> }),
         ParamType::Int(n) => match n / 8 {
             1 => Ok(quote! { i8 }),
@@ -22,7 +22,7 @@ pub(crate) fn expand(kind: &ParamType) -> Result<TokenStream> {
             3..=4 => Ok(quote! { u32 }),
             5..=8 => Ok(quote! { u64 }),
             9..=16 => Ok(quote! { u128 }),
-            17..=32 => Ok(quote! { U256 }),
+            17..=32 => Ok(quote! { ethers_core::types::U256 }),
             _ => Err(anyhow!("unsupported solidity type uint{}", n)),
         },
         ParamType::Bool => Ok(quote! { bool }),

--- a/ethers-contract/ethers-contract-derive/src/lib.rs
+++ b/ethers-contract/ethers-contract-derive/src/lib.rs
@@ -96,7 +96,7 @@ pub fn abigen(input: TokenStream) -> TokenStream {
 /// - `name`: override the name of an indexed event input, default is the rust field name
 ///
 /// # Example
-/// ```no_run
+/// ```ignore
 /// # use ethers_core::types::Address;
 ///
 /// #[derive(Debug, EthAbiType)]

--- a/ethers-contract/ethers-contract-derive/src/lib.rs
+++ b/ethers-contract/ethers-contract-derive/src/lib.rs
@@ -8,8 +8,8 @@ use proc_macro2::{Literal, Span};
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned as _;
 use syn::{
-    parse::Error, parse_macro_input, AttrStyle, Data, DeriveInput, Expr, Fields, GenericArgument,
-    Lit, Meta, NestedMeta, PathArguments, Type,
+    parse::Error, parse_macro_input, AttrStyle, Data, DeriveInput, Expr, Field, Fields,
+    GenericArgument, Lit, Meta, NestedMeta, PathArguments, Type,
 };
 
 use abigen::{expand, ContractArgs};
@@ -113,14 +113,13 @@ pub fn derive_abi_event(input: TokenStream) -> TokenStream {
 
     let event_name = attributes
         .name
-        .map(|(n, _)| n)
+        .map(|(s, _)| s)
         .unwrap_or_else(|| input.ident.to_string());
 
-    let (abi, hash) = if let Some((src, span)) = attributes.abi {
+    let mut event = if let Some((src, span)) = attributes.abi {
         // try to parse as solidity event
-        if let Ok(mut event) = parse_event(&src) {
-            event.name = event_name.clone();
-            (event.abi_signature(), event.signature())
+        if let Ok(event) = parse_event(&src) {
+            event
         } else {
             // try as tuple
             if let Some(inputs) = Reader::read(
@@ -142,12 +141,11 @@ pub fn derive_abi_event(input: TokenStream) -> TokenStream {
                 ),
                 _ => None,
             }) {
-                let event = Event {
+                Event {
                     name: event_name.clone(),
                     inputs,
                     anonymous: false,
-                };
-                (event.abi_signature(), event.signature())
+                }
             } else {
                 match src.parse::<Source>().and_then(|s| s.get()) {
                     Ok(abi) => {
@@ -157,10 +155,7 @@ pub fn derive_abi_event(input: TokenStream) -> TokenStream {
                         //  this could be mitigated by getting the ABI of each non elementary type at runtime
                         //  and computing the the signature as `static Lazy::...`
                         match parse_event(&abi) {
-                            Ok(mut event) => {
-                                event.name = event_name.clone();
-                                (event.abi_signature(), event.signature())
-                            }
+                            Ok(event) => event,
                             Err(err) => {
                                 return TokenStream::from(Error::new(span, err).to_compile_error())
                             }
@@ -173,13 +168,22 @@ pub fn derive_abi_event(input: TokenStream) -> TokenStream {
     } else {
         // try to determine the abi from the fields
         match derive_abi_event_from_fields(&input) {
-            Ok(mut event) => {
-                event.name = event_name.clone();
-                (event.abi_signature(), event.signature())
-            }
+            Ok(event) => event,
             Err(err) => return TokenStream::from(err.to_compile_error()),
         }
     };
+
+    event.name = event_name.clone();
+    if let Some((anon, _)) = attributes.anonymous.as_ref() {
+        event.anonymous = *anon;
+    }
+
+    let decode_log_impl = match derive_decode_from_log_impl(&input, &event) {
+        Ok(log) => log,
+        Err(err) => return TokenStream::from(err.to_compile_error()),
+    };
+
+    let (abi, hash) = (event.abi_signature(), event.signature());
 
     let signature = if let Some((hash, _)) = attributes.signature_hash {
         signature(&hash)
@@ -201,6 +205,11 @@ pub fn derive_abi_event(input: TokenStream) -> TokenStream {
             fn abi_signature() -> ::std::borrow::Cow<'static, str> {
                 #abi.into()
             }
+
+            fn decode_log(log: ethers::abi::RawLog) -> Result<Self, ethers::abi::Error> where Self: Sized {
+                #decode_log_impl
+            }
+
         }
     };
 
@@ -213,11 +222,268 @@ pub fn derive_abi_event(input: TokenStream) -> TokenStream {
     })
 }
 
-fn derive_abi_event_from_fields(input: &DeriveInput) -> Result<Event, Error> {
-    let types: Vec<_> = match input.data {
+struct EventField {
+    topic_name: Option<String>,
+    index: usize,
+    param: EventParam,
+}
+
+impl EventField {
+    fn is_indexed(&self) -> bool {
+        self.topic_name.is_some()
+    }
+}
+
+// Converts param types for indexed parameters to bytes32 where appropriate
+// This applies to strings, arrays, structs and bytes to follow the encoding of
+// these indexed param types according to
+// https://solidity.readthedocs.io/en/develop/abi-spec.html#encoding-of-indexed-event-parameters
+fn topic_param_type_quote(kind: &ParamType) -> proc_macro2::TokenStream {
+    match kind {
+        ParamType::String
+        | ParamType::Bytes
+        | ParamType::Array(_)
+        | ParamType::FixedArray(_, _)
+        | ParamType::Tuple(_) => quote! {ethers::abi::ParamType::FixedBytes(32)},
+        ty => param_type_quote(ty),
+    }
+}
+
+fn param_type_quote(kind: &ParamType) -> proc_macro2::TokenStream {
+    match kind {
+        ParamType::Address => {
+            quote! {ethers::abi::ParamType::Address}
+        }
+        ParamType::Bytes => {
+            quote! {ethers::abi::ParamType::Bytes}
+        }
+        ParamType::Int(size) => {
+            let size = Literal::usize_suffixed(*size);
+            quote! {ethers::abi::ParamType::Int(#size)}
+        }
+        ParamType::Uint(size) => {
+            let size = Literal::usize_suffixed(*size);
+            quote! {ethers::abi::ParamType::Uint(#size)}
+        }
+        ParamType::Bool => {
+            quote! {ethers::abi::ParamType::Bool}
+        }
+        ParamType::String => {
+            quote! {ethers::abi::ParamType::String}
+        }
+        ParamType::Array(ty) => {
+            let ty = param_type_quote(&*ty);
+            quote! {ethers::abi::ParamType::Array(Box::new(#ty))}
+        }
+        ParamType::FixedBytes(size) => {
+            let size = Literal::usize_suffixed(*size);
+            quote! {ethers::abi::ParamType::FixedBytes(#size)}
+        }
+        ParamType::FixedArray(ty, size) => {
+            let ty = param_type_quote(&*ty);
+            let size = Literal::usize_suffixed(*size);
+            quote! {ethers::abi::ParamType::FixedArray(Box::new(#ty),#size)}
+        }
+        ParamType::Tuple(tuple) => {
+            let elements = tuple.iter().map(param_type_quote);
+            quote! {
+                ethers::abi::ParamType::Tuple(
+                    vec![
+                        #( #elements ),*
+                    ]
+                )
+            }
+        }
+    }
+}
+
+fn derive_decode_from_log_impl(
+    input: &DeriveInput,
+    event: &Event,
+) -> Result<proc_macro2::TokenStream, Error> {
+    let fields: Vec<_> = match input.data {
         Data::Struct(ref data) => match data.fields {
-            Fields::Named(ref fields) => fields.named.iter().map(|f| &f.ty).collect(),
-            Fields::Unnamed(ref fields) => fields.unnamed.iter().map(|f| &f.ty).collect(),
+            Fields::Named(ref fields) => {
+                if fields.named.len() != event.inputs.len() {
+                    return Err(Error::new(
+                        fields.span(),
+                        format!(
+                            "EthEvent {}'s fields length don't match with signature inputs {}",
+                            event.name,
+                            event.abi_signature()
+                        ),
+                    ));
+                }
+                fields.named.iter().collect()
+            }
+            Fields::Unnamed(ref fields) => {
+                if fields.unnamed.len() != event.inputs.len() {
+                    return Err(Error::new(
+                        fields.span(),
+                        format!(
+                            "EthEvent {}'s fields length don't match with signature inputs {}",
+                            event.name,
+                            event.abi_signature()
+                        ),
+                    ));
+                }
+                fields.unnamed.iter().collect()
+            }
+            Fields::Unit => {
+                return Err(Error::new(
+                    input.span(),
+                    "EthEvent cannot be derived for empty structs and unit",
+                ));
+            }
+        },
+        Data::Enum(_) => {
+            return Err(Error::new(
+                input.span(),
+                "EthEvent cannot be derived for enums",
+            ));
+        }
+        Data::Union(_) => {
+            return Err(Error::new(
+                input.span(),
+                "EthEvent cannot be derived for unions",
+            ));
+        }
+    };
+
+    let mut event_fields = Vec::with_capacity(fields.len());
+    for (index, field) in fields.iter().enumerate() {
+        let mut param = event.inputs[index].clone();
+
+        let (topic_name, indexed) = parse_field_attributes(field)?;
+        if indexed {
+            param.indexed = true;
+        }
+        let topic_name = if param.indexed {
+            if topic_name.is_none() {
+                Some(param.name.clone())
+            } else {
+                topic_name
+            }
+        } else {
+            None
+        };
+
+        if param.indexed {
+            if let Some(name) = topic_name.as_ref() {
+                if name.is_empty() {
+                    return Err(Error::new(field.span(), "EthEvent field requires a name"));
+                }
+            }
+        }
+
+        event_fields.push(EventField {
+            topic_name,
+            index,
+            param,
+        });
+    }
+
+    // convert fields to params list
+    let topic_types = event_fields
+        .iter()
+        .filter(|f| f.is_indexed())
+        .map(|f| topic_param_type_quote(&f.param.kind));
+
+    let topic_types_init = quote! {let topic_types = vec![#( #topic_types ),*];};
+
+    let data_types = event_fields
+        .iter()
+        .filter(|f| !f.is_indexed())
+        .map(|f| param_type_quote(&f.param.kind));
+
+    let data_types_init = quote! {let data_types = vec![#( #data_types ),*];};
+
+    // decode
+    let (signature_check, flat_topics_init, topic_tokens_len_check) = if event.anonymous {
+        (
+            quote! {},
+            quote! {
+                  let flat_topics = topics.into_iter().flat_map(|t| t.as_ref().to_vec()).collect::<Vec<u8>>();
+            },
+            quote! {
+                if topic_tokens.len() != topics_len {
+                    return Err(ethers::abi::Error::InvalidData);
+                }
+            },
+        )
+    } else {
+        (
+            quote! {
+                let event_signature = topics.get(0).ok_or(ethers::abi::Error::InvalidData)?;
+                if event_signature != &Self::signature() {
+                    return Err(ethers::abi::Error::InvalidData);
+                }
+            },
+            quote! {
+                let flat_topics = topics.into_iter().skip(1).flat_map(|t| t.as_ref().to_vec()).collect::<Vec<u8>>();
+            },
+            quote! {
+                if topic_tokens.is_empty() || topic_tokens.len() != topics_len - 1 {
+                    return Err(ethers::abi::Error::InvalidData);
+                }
+            },
+        )
+    };
+
+    // check if indexed are sorted
+    let tokens_init = if event_fields
+        .iter()
+        .filter(|f| f.is_indexed())
+        .enumerate()
+        .all(|(idx, f)| f.index == idx)
+    {
+        quote! {
+            let topic_tokens = ethers::abi::decode(&topic_types, &flat_topics)?;
+            #topic_tokens_len_check
+            let data_tokens = ethers::abi::decode(&data_types, &data)?;
+            let tokens:Vec<_> = topic_tokens.into_iter().chain(data_tokens.into_iter()).collect();
+        }
+    } else {
+        let swap_tokens = event_fields.iter().map(|field| {
+            if field.is_indexed() {
+                quote! { topic_tokens.remove(0) }
+            } else {
+                quote! { data_tokens.remove(0) }
+            }
+        });
+
+        quote! {
+            let mut topic_tokens = ethers::abi::decode(&topic_types, &flat_topics)?;
+            #topic_tokens_len_check
+            let mut data_tokens = ethers::abi::decode(&data_types, &data)?;
+            let mut tokens = Vec::with_capacity(topics_len + data_tokens.len());
+            #( tokens.push(#swap_tokens); )*
+        }
+    };
+
+    Ok(quote! {
+
+        let ethers::abi::RawLog {data, topics} = log;
+        let topics_len = topics.len();
+
+        #signature_check
+
+        #topic_types_init
+        #data_types_init
+
+        #flat_topics_init
+
+        #tokens_init
+
+        ethers::abi::Detokenize::from_tokens(tokens).map_err(|_|ethers::abi::Error::InvalidData)
+    })
+}
+
+fn derive_abi_event_from_fields(input: &DeriveInput) -> Result<Event, Error> {
+    let fields: Vec<_> = match input.data {
+        Data::Struct(ref data) => match data.fields {
+            Fields::Named(ref fields) => fields.named.iter().collect(),
+            Fields::Unnamed(ref fields) => fields.unnamed.iter().collect(),
             Fields::Unit => {
                 return Err(Error::new(
                     input.span(),
@@ -239,17 +505,24 @@ fn derive_abi_event_from_fields(input: &DeriveInput) -> Result<Event, Error> {
         }
     };
 
-    let inputs = types
+    let inputs = fields
         .iter()
-        .map(|ty| find_parameter_type(ty))
+        .map(|f| {
+            let name = f
+                .ident
+                .as_ref()
+                .map(|name| name.to_string())
+                .unwrap_or_else(|| "".to_string());
+            find_parameter_type(&f.ty).map(|ty| (name, ty))
+        })
         .collect::<Result<Vec<_>, _>>()?;
 
     let event = Event {
         name: "".to_string(),
         inputs: inputs
             .into_iter()
-            .map(|kind| EventParam {
-                name: "".to_string(),
+            .map(|(name, kind)| EventParam {
+                name,
                 kind,
                 indexed: false,
             })
@@ -257,6 +530,55 @@ fn derive_abi_event_from_fields(input: &DeriveInput) -> Result<Event, Error> {
         anonymous: false,
     };
     Ok(event)
+}
+
+fn parse_field_attributes(field: &Field) -> Result<(Option<String>, bool), Error> {
+    let mut indexed = false;
+    let mut topic_name = None;
+    for a in field.attrs.iter() {
+        if let AttrStyle::Outer = a.style {
+            if let Ok(Meta::List(meta)) = a.parse_meta() {
+                if meta.path.is_ident("ethevent") {
+                    for n in meta.nested.iter() {
+                        if let NestedMeta::Meta(meta) = n {
+                            match meta {
+                                Meta::Path(path) => {
+                                    if path.is_ident("indexed") {
+                                        indexed = true;
+                                    } else {
+                                        return Err(Error::new(
+                                            path.span(),
+                                            "unrecognized ethevent parameter",
+                                        ));
+                                    }
+                                }
+                                Meta::List(meta) => {
+                                    return Err(Error::new(
+                                        meta.path.span(),
+                                        "unrecognized ethevent parameter",
+                                    ));
+                                }
+                                Meta::NameValue(meta) => {
+                                    if meta.path.is_ident("name") {
+                                        if let Lit::Str(ref lit_str) = meta.lit {
+                                            topic_name = Some(lit_str.value());
+                                        } else {
+                                            return Err(Error::new(
+                                                meta.span(),
+                                                "name attribute must be a string",
+                                            ));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok((topic_name, indexed))
 }
 
 fn find_parameter_type(ty: &Type) -> Result<ParamType, Error> {
@@ -315,13 +637,10 @@ fn find_parameter_type(ty: &Type) -> Result<ParamType, Error> {
                 .collect::<Result<Vec<_>, _>>()?;
             Ok(ParamType::Tuple(params))
         }
-        _ => {
-            eprintln!("Found other types");
-            Err(Error::new(
-                ty.span(),
-                "Failed to derive proper ABI from fields",
-            ))
-        }
+        _ => Err(Error::new(
+            ty.span(),
+            "Failed to derive proper ABI from fields",
+        )),
     }
 }
 
@@ -496,23 +815,21 @@ fn derive_tokenizeable_impl(input: &DeriveInput) -> proc_macro2::TokenStream {
                 )
              }
          }
+
+        impl<#generic_params> ethers_core::abi::TokenizableItem for #name<#generic_args>
+         where
+             #generic_predicates
+             #tokenize_predicates
+         { }
     }
 }
 
+#[derive(Default)]
 struct Attributes {
     name: Option<(String, Span)>,
     abi: Option<(String, Span)>,
     signature_hash: Option<(Vec<u8>, Span)>,
-}
-
-impl Default for Attributes {
-    fn default() -> Self {
-        Self {
-            name: None,
-            abi: None,
-            signature_hash: None,
-        }
-    }
+    anonymous: Option<(bool, Span)>,
 }
 
 fn parse_attributes(input: &DeriveInput) -> Result<Attributes, proc_macro2::TokenStream> {
@@ -525,6 +842,20 @@ fn parse_attributes(input: &DeriveInput) -> Result<Attributes, proc_macro2::Toke
                         if let NestedMeta::Meta(meta) = n {
                             match meta {
                                 Meta::Path(path) => {
+                                    if let Some(name) = path.get_ident() {
+                                        if *name.to_string() == "anonymous" {
+                                            if result.anonymous.is_none() {
+                                                result.anonymous = Some((true, name.span()));
+                                                continue;
+                                            } else {
+                                                return Err(Error::new(
+                                                    name.span(),
+                                                    "anonymous already specified",
+                                                )
+                                                .to_compile_error());
+                                            }
+                                        }
+                                    }
                                     return Err(Error::new(
                                         path.span(),
                                         "unrecognized ethevent parameter",
@@ -532,7 +863,6 @@ fn parse_attributes(input: &DeriveInput) -> Result<Attributes, proc_macro2::Toke
                                     .to_compile_error());
                                 }
                                 Meta::List(meta) => {
-                                    // TODO support raw list
                                     return Err(Error::new(
                                         meta.path.span(),
                                         "unrecognized ethevent parameter",
@@ -540,7 +870,26 @@ fn parse_attributes(input: &DeriveInput) -> Result<Attributes, proc_macro2::Toke
                                     .to_compile_error());
                                 }
                                 Meta::NameValue(meta) => {
-                                    if meta.path.is_ident("name") {
+                                    if meta.path.is_ident("anonymous") {
+                                        if let Lit::Bool(ref bool_lit) = meta.lit {
+                                            if result.anonymous.is_none() {
+                                                result.anonymous =
+                                                    Some((bool_lit.value, bool_lit.span()));
+                                            } else {
+                                                return Err(Error::new(
+                                                    meta.span(),
+                                                    "anonymous already specified",
+                                                )
+                                                .to_compile_error());
+                                            }
+                                        } else {
+                                            return Err(Error::new(
+                                                meta.span(),
+                                                "name must be a string",
+                                            )
+                                            .to_compile_error());
+                                        }
+                                    } else if meta.path.is_ident("name") {
                                         if let Lit::Str(ref lit_str) = meta.lit {
                                             if result.name.is_none() {
                                                 result.name =

--- a/ethers-contract/ethers-contract-derive/src/lib.rs
+++ b/ethers-contract/ethers-contract-derive/src/lib.rs
@@ -385,14 +385,6 @@ fn derive_decode_from_log_impl(
             None
         };
 
-        if param.indexed {
-            if let Some(name) = topic_name.as_ref() {
-                if name.is_empty() {
-                    return Err(Error::new(field.span(), "EthEvent field requires a name"));
-                }
-            }
-        }
-
         event_fields.push(EventField {
             topic_name,
             index,

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -178,7 +178,7 @@ impl<M: Middleware> Contract<M> {
     }
 
     /// Returns an [`Event`](crate::builders::Event) builder with the provided name.
-    pub fn event_by_name<D: EthLogDecode>(&self, name: &str) -> Result<Event<M, D>, Error> {
+    pub fn event_for_name<D: EthLogDecode>(&self, name: &str) -> Result<Event<M, D>, Error> {
         // get the event's full name
         let event = self.base_contract.abi.event(name)?;
         Ok(self.event_with_filter(Filter::new().event(&event.abi_signature())))

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -180,6 +180,7 @@ impl<M: Middleware> Contract<M> {
     }
 
     /// Returns an [`Event`](crate::builders::Event) builder for the provided event name.
+    /// TODO(mattsse) keep this but remove event
     pub fn event<D: Detokenize>(&self, name: &str) -> Result<Event<M, D>, Error> {
         // get the event's full name
         let event = self.base_contract.abi.event(name)?;

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -109,7 +109,7 @@ use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 /// ```no_run
 /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
 /// use ethers_core::{abi::Abi, types::Address};
-/// use ethers_contract::Contract;
+/// use ethers_contract::{Contract, EthEvent};
 /// use ethers_providers::{Provider, Http, Middleware};
 /// use ethers_signers::Wallet;
 /// use std::convert::TryFrom;
@@ -120,7 +120,7 @@ use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 /// # let client = Provider::<Http>::try_from("http://localhost:8545").unwrap();
 /// # let contract = Contract::new(address, abi, client);
 ///
-/// #[derive(Clone, Debug)]
+/// #[derive(Clone, Debug, EthEvent)]
 /// struct ValueChanged {
 ///     old_author: Address,
 ///     new_author: Address,
@@ -128,25 +128,8 @@ use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 ///     new_value: String,
 /// }
 ///
-/// impl Detokenize for ValueChanged {
-///     fn from_tokens(tokens: Vec<Token>) -> Result<ValueChanged, InvalidOutputType> {
-///         let old_author: Address = tokens[1].clone().into_address().unwrap();
-///         let new_author: Address = tokens[1].clone().into_address().unwrap();
-///         let old_value = tokens[2].clone().into_string().unwrap();
-///         let new_value = tokens[3].clone().into_string().unwrap();
-///
-///         Ok(Self {
-///             old_author,
-///             new_author,
-///             old_value,
-///             new_value,
-///         })
-///     }
-/// }
-///
-///
 /// let logs: Vec<ValueChanged> = contract
-///     .event("ValueChanged")?
+///     .event()
 ///     .from_block(0u64)
 ///     .query()
 ///     .await?;

--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -23,9 +23,13 @@ pub trait EthEvent: Detokenize {
     fn abi_signature() -> Cow<'static, str>;
 
     /// Decodes an Ethereum `RawLog` into an instance of the type.
-    fn decode_log(log: RawLog) -> Result<Self, ethers_core::abi::Error>
+    fn decode_log(log: &RawLog) -> Result<Self, ethers_core::abi::Error>
     where
         Self: Sized;
+
+    /// Returns true if this is an anonymous event
+    fn is_anonymous() -> bool;
+
 }
 
 /// Helper for managing the event filter before querying or streaming its logs

--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -1,7 +1,7 @@
 use crate::{base::decode_event, stream::EventStream, ContractError};
 
 use ethers_core::{
-    abi::{Detokenize, Event as AbiEvent},
+    abi::{Detokenize, Event as AbiEvent, RawLog},
     types::{BlockNumber, Filter, Log, TxHash, ValueOrArray, H256, U64},
 };
 use ethers_providers::{FilterWatcher, Middleware, PubsubClient, SubscriptionStream};
@@ -21,6 +21,11 @@ pub trait EthEvent: Detokenize {
     /// Retrieves the ABI signature for the event this data corresponds
     /// to.
     fn abi_signature() -> Cow<'static, str>;
+
+    /// Decodes an Ethereum `RawLog` into an instance of the type.
+    fn decode_log(log: RawLog) -> Result<Self, ethers_core::abi::Error>
+    where
+        Self: Sized;
 }
 
 /// Helper for managing the event filter before querying or streaming its logs

--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -1,4 +1,4 @@
-use crate::{base::decode_event, stream::EventStream, ContractError};
+use crate::{base::decode_event, stream::EventStream, ContractError, EthLogDecode};
 
 use ethers_core::{
     abi::{Detokenize, Event as AbiEvent, RawLog},
@@ -29,7 +29,16 @@ pub trait EthEvent: Detokenize {
 
     /// Returns true if this is an anonymous event
     fn is_anonymous() -> bool;
+}
 
+// Convenience implementation
+impl<T: EthEvent> EthLogDecode for T {
+    fn decode_log(log: &RawLog) -> Result<Self, ethers_core::abi::Error>
+    where
+        Self: Sized,
+    {
+        T::decode_log(log)
+    }
 }
 
 /// Helper for managing the event filter before querying or streaming its logs

--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -29,6 +29,19 @@ pub trait EthEvent: Detokenize {
 
     /// Returns true if this is an anonymous event
     fn is_anonymous() -> bool;
+
+    /// Returns an Event builder for the ethereum event represented by this types ABI signature.
+    fn new<M: Middleware>(filter: Filter, provider: &M) -> Event2<M, Self>
+    where
+        Self: Sized,
+    {
+        let filter = filter.event(&Self::abi_signature());
+        Event2 {
+            filter,
+            provider,
+            datatype: PhantomData,
+        }
+    }
 }
 
 // Convenience implementation
@@ -38,6 +51,167 @@ impl<T: EthEvent> EthLogDecode for T {
         Self: Sized,
     {
         T::decode_log(log)
+    }
+}
+
+/// Helper for managing the event filter before querying or streaming its logs
+#[derive(Debug)]
+#[must_use = "event filters do nothing unless you `query` or `stream` them"]
+pub struct Event2<'a, M, D> {
+    /// The event filter's state
+    pub filter: Filter,
+    pub(crate) provider: &'a M,
+    /// Stores the event datatype
+    pub(crate) datatype: PhantomData<D>,
+}
+
+// TODO: Improve these functions
+impl<M, D: EthLogDecode> Event2<'_, M, D> {
+    /// Sets the filter's `from` block
+    #[allow(clippy::wrong_self_convention)]
+    pub fn from_block<T: Into<BlockNumber>>(mut self, block: T) -> Self {
+        self.filter = self.filter.from_block(block);
+        self
+    }
+
+    /// Sets the filter's `to` block
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_block<T: Into<BlockNumber>>(mut self, block: T) -> Self {
+        self.filter = self.filter.to_block(block);
+        self
+    }
+
+    /// Sets the filter's `blockHash`. Setting this will override previously
+    /// set `from_block` and `to_block` fields.
+    #[allow(clippy::wrong_self_convention)]
+    pub fn at_block_hash<T: Into<H256>>(mut self, hash: T) -> Self {
+        self.filter = self.filter.at_block_hash(hash);
+        self
+    }
+
+    /// Sets the filter's 0th topic (typically the event name for non-anonymous events)
+    pub fn topic0<T: Into<ValueOrArray<H256>>>(mut self, topic: T) -> Self {
+        self.filter.topics[0] = Some(topic.into());
+        self
+    }
+
+    /// Sets the filter's 1st topic
+    pub fn topic1<T: Into<ValueOrArray<H256>>>(mut self, topic: T) -> Self {
+        self.filter.topics[1] = Some(topic.into());
+        self
+    }
+
+    /// Sets the filter's 2nd topic
+    pub fn topic2<T: Into<ValueOrArray<H256>>>(mut self, topic: T) -> Self {
+        self.filter.topics[2] = Some(topic.into());
+        self
+    }
+
+    /// Sets the filter's 3rd topic
+    pub fn topic3<T: Into<ValueOrArray<H256>>>(mut self, topic: T) -> Self {
+        self.filter.topics[3] = Some(topic.into());
+        self
+    }
+}
+
+impl<'a, M, D> Event2<'a, M, D>
+where
+    M: Middleware,
+    D: EthLogDecode,
+{
+    /// Returns a stream for the event
+    pub async fn stream(
+        &'a self,
+    ) -> Result<
+        // Wraps the FilterWatcher with a mapping to the event
+        EventStream<'a, FilterWatcher<'a, M::Provider, Log>, D, ContractError<M>>,
+        ContractError<M>,
+    > {
+        let filter = self
+            .provider
+            .watch(&self.filter)
+            .await
+            .map_err(ContractError::MiddlewareError)?;
+        Ok(EventStream::new(
+            filter.id,
+            filter,
+            Box::new(move |log| self.parse_log(log)),
+        ))
+    }
+}
+
+impl<'a, M, D> Event2<'a, M, D>
+where
+    M: Middleware,
+    <M as Middleware>::Provider: PubsubClient,
+    D: EthLogDecode,
+{
+    /// Returns a subscription for the event
+    pub async fn subscribe(
+        &'a self,
+    ) -> Result<
+        // Wraps the SubscriptionStream with a mapping to the event
+        EventStream<'a, SubscriptionStream<'a, M::Provider, Log>, D, ContractError<M>>,
+        ContractError<M>,
+    > {
+        let filter = self
+            .provider
+            .subscribe_logs(&self.filter)
+            .await
+            .map_err(ContractError::MiddlewareError)?;
+        Ok(EventStream::new(
+            filter.id,
+            filter,
+            Box::new(move |log| self.parse_log(log)),
+        ))
+    }
+}
+
+impl<M, D> Event2<'_, M, D>
+where
+    M: Middleware,
+    D: EthLogDecode,
+{
+    /// Queries the blockchain for the selected filter and returns a vector of matching
+    /// event logs
+    pub async fn query(&self) -> Result<Vec<D>, ContractError<M>> {
+        let logs = self
+            .provider
+            .get_logs(&self.filter)
+            .await
+            .map_err(ContractError::MiddlewareError)?;
+        let events = logs
+            .into_iter()
+            .map(|log| self.parse_log(log))
+            .collect::<Result<Vec<_>, ContractError<M>>>()?;
+        Ok(events)
+    }
+
+    /// Queries the blockchain for the selected filter and returns a vector of logs
+    /// along with their metadata
+    pub async fn query_with_meta(&self) -> Result<Vec<(D, LogMeta)>, ContractError<M>> {
+        let logs = self
+            .provider
+            .get_logs(&self.filter)
+            .await
+            .map_err(ContractError::MiddlewareError)?;
+        let events = logs
+            .into_iter()
+            .map(|log| {
+                let meta = LogMeta::from(&log);
+                let event = self.parse_log(log)?;
+                Ok((event, meta))
+            })
+            .collect::<Result<_, ContractError<M>>>()?;
+        Ok(events)
+    }
+
+    fn parse_log(&self, log: Log) -> Result<D, ContractError<M>> {
+        D::decode_log(&RawLog {
+            topics: log.topics,
+            data: log.data.to_vec(),
+        })
+        .map_err(From::from)
     }
 }
 

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -28,6 +28,9 @@ pub use factory::ContractFactory;
 mod event;
 pub use event::EthEvent;
 
+mod log;
+pub use log::{decode_logs, EthLogDecode};
+
 mod stream;
 
 mod multicall;

--- a/ethers-contract/src/log.rs
+++ b/ethers-contract/src/log.rs
@@ -12,5 +12,5 @@ pub trait EthLogDecode {
 
 /// Decodes a series of logs into a vector
 pub fn decode_logs<T: EthLogDecode>(logs: &[RawLog]) -> Result<Vec<T>, Error> {
-    logs.into_iter().map(T::decode_log).collect()
+    logs.iter().map(T::decode_log).collect()
 }

--- a/ethers-contract/src/log.rs
+++ b/ethers-contract/src/log.rs
@@ -1,0 +1,14 @@
+//! Mod of types for ethereum logs
+use ethers_core::abi::Error;
+use ethers_core::abi::RawLog;
+
+/// A trait for types (events) that can be decoded from a `RawLog`
+pub trait EthLogDecode {
+    /// decode from a `RawLog`
+    fn decode_log(log: &RawLog) -> Result<Self, Error> where Self: Sized;
+}
+
+/// Decodes a series of logs into a vector
+pub fn decode_logs<T: EthLogDecode>(logs: &[RawLog]) -> Result<Vec<T>, Error> {
+    logs.into_iter().map(T::decode_log).collect()
+}

--- a/ethers-contract/src/log.rs
+++ b/ethers-contract/src/log.rs
@@ -5,7 +5,9 @@ use ethers_core::abi::RawLog;
 /// A trait for types (events) that can be decoded from a `RawLog`
 pub trait EthLogDecode {
     /// decode from a `RawLog`
-    fn decode_log(log: &RawLog) -> Result<Self, Error> where Self: Sized;
+    fn decode_log(log: &RawLog) -> Result<Self, Error>
+    where
+        Self: Sized;
 }
 
 /// Decodes a series of logs into a vector

--- a/ethers-contract/tests/common/derive.rs
+++ b/ethers-contract/tests/common/derive.rs
@@ -1,5 +1,5 @@
 use ethers::core::types::{H160, H256, I256, U128, U256};
-use ethers_contract::{EthAbiType, EthEvent};
+use ethers_contract::{abigen, EthAbiType, EthEvent};
 use ethers_core::abi::Tokenizable;
 use ethers_core::types::Address;
 
@@ -211,5 +211,28 @@ fn can_derive_indexed_and_anonymous_attribute() {
     assert_eq!(
         "ValueChangedEvent(address,address,string,string) anonymous",
         ValueChangedEvent::abi_signature()
+    );
+}
+
+#[test]
+fn can_generate_ethevent_from_json() {
+    abigen!(DsProxyFactory,
+        "ethers-middleware/contracts/DsProxyFactory.json",
+        methods {
+            build(address) as build_with_owner;
+        }
+    );
+
+    assert_eq!(
+        "Created(address,address,address,address)",
+        CreatedFilter::abi_signature()
+    );
+
+    assert_eq!(
+        H256([
+            37, 155, 48, 202, 57, 136, 92, 109, 128, 26, 11, 93, 188, 152, 134, 64, 243, 194, 94,
+            47, 55, 83, 31, 225, 56, 197, 197, 175, 137, 85, 212, 27,
+        ]),
+        CreatedFilter::signature()
     );
 }

--- a/ethers-contract/tests/common/derive.rs
+++ b/ethers-contract/tests/common/derive.rs
@@ -195,3 +195,21 @@ fn can_set_eth_abi_attribute() {
         ValueChangedEvent2::abi_signature()
     );
 }
+
+#[test]
+fn can_derive_indexed_and_anonymous_attribute() {
+    #[derive(Debug, PartialEq, EthEvent)]
+    #[ethevent(anonymous)]
+    struct ValueChangedEvent {
+        old_author: Address,
+        #[ethevent(indexed, name = "newAuthor")]
+        new_author: Address,
+        old_value: String,
+        new_value: String,
+    }
+
+    assert_eq!(
+        "ValueChangedEvent(address,address,string,string) anonymous",
+        ValueChangedEvent::abi_signature()
+    );
+}

--- a/ethers-contract/tests/common/mod.rs
+++ b/ethers-contract/tests/common/mod.rs
@@ -11,11 +11,13 @@ use ethers_providers::{Http, Middleware, Provider};
 use ethers_signers::LocalWallet;
 use std::{convert::TryFrom, sync::Arc, time::Duration};
 
-// Note: The `EthAbiType` derive macro implements the necessary conversion between `Tokens` and
+// Note: The `EthEvent` derive macro implements the necessary conversion between `Tokens` and
 // the struct
 #[derive(Clone, Debug, EthEvent)]
 pub struct ValueChanged {
+    #[ethevent(indexed)]
     pub old_author: Address,
+    #[ethevent(indexed)]
     pub new_author: Address,
     pub old_value: String,
     pub new_value: String,

--- a/ethers-contract/tests/common/mod.rs
+++ b/ethers-contract/tests/common/mod.rs
@@ -4,7 +4,7 @@ use ethers_core::{
     types::{Address, Bytes},
 };
 
-use ethers_contract::{Contract, ContractFactory, EthAbiType};
+use ethers_contract::{Contract, ContractFactory, EthEvent};
 use ethers_core::utils::{GanacheInstance, Solc};
 use ethers_middleware::signer::SignerMiddleware;
 use ethers_providers::{Http, Middleware, Provider};
@@ -13,7 +13,7 @@ use std::{convert::TryFrom, sync::Arc, time::Duration};
 
 // Note: The `EthAbiType` derive macro implements the necessary conversion between `Tokens` and
 // the struct
-#[derive(Clone, Debug, EthAbiType)]
+#[derive(Clone, Debug, EthEvent)]
 pub struct ValueChanged {
     pub old_author: Address,
     pub new_author: Address,

--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -109,8 +109,7 @@ mod eth_tests {
 
         // and we can fetch the events
         let logs: Vec<ValueChanged> = contract
-            .event("ValueChanged")
-            .unwrap()
+            .event()
             .from_block(0u64)
             .topic1(client.address()) // Corresponds to the first indexed parameter
             .query()
@@ -123,8 +122,7 @@ mod eth_tests {
         // and we can fetch the events at a block hash
         let hash = client.get_block(1).await.unwrap().unwrap().hash.unwrap();
         let logs: Vec<ValueChanged> = contract
-            .event("ValueChanged")
-            .unwrap()
+            .event()
             .at_block_hash(hash)
             .topic1(client.address()) // Corresponds to the first indexed parameter
             .query()
@@ -256,14 +254,14 @@ mod eth_tests {
         let contract = deploy(client, abi.clone(), bytecode).await;
 
         // We spawn the event listener:
-        let event = contract.event::<ValueChanged>("ValueChanged").unwrap();
+        let event = contract.event::<ValueChanged>();
         let mut stream = event.stream().await.unwrap();
         assert_eq!(stream.id, 1.into());
 
         // Also set up a subscription for the same thing
         let ws = Provider::connect(ganache.ws_endpoint()).await.unwrap();
         let contract2 = ethers_contract::Contract::new(contract.address(), abi, ws);
-        let event2 = contract2.event::<ValueChanged>("ValueChanged").unwrap();
+        let event2 = contract2.event::<ValueChanged>();
         let mut subscription = event2.subscribe().await.unwrap();
         assert_eq!(subscription.id, 2.into());
 

--- a/ethers-contract/tests/decode_logs2.rs
+++ b/ethers-contract/tests/decode_logs2.rs
@@ -1,9 +1,0 @@
-use ethers_contract::{abigen, EthEvent};
-// use ethers_core::abi::Tokenizable;
-//
-abigen!(DsProxyFactory,
-    "ethers-middleware/contracts/DsProxyFactory.json",
-    methods {
-        build(address) as build_with_owner;
-    }
-);

--- a/ethers-contract/tests/decode_logs2.rs
+++ b/ethers-contract/tests/decode_logs2.rs
@@ -1,0 +1,9 @@
+use ethers_contract::{abigen, EthEvent};
+// use ethers_core::abi::Tokenizable;
+//
+abigen!(DsProxyFactory,
+    "ethers-middleware/contracts/DsProxyFactory.json",
+    methods {
+        build(address) as build_with_owner;
+    }
+);

--- a/ethers-middleware/contracts/DsProxyFactory.json
+++ b/ethers-middleware/contracts/DsProxyFactory.json
@@ -1,0 +1,95 @@
+[
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isProxy",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "cache",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "build",
+    "outputs": [
+      {
+        "name": "proxy",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "build",
+    "outputs": [
+      {
+        "name": "proxy",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "proxy",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "cache",
+        "type": "address"
+      }
+    ],
+    "name": "Created",
+    "type": "event"
+  }
+]

--- a/ethers-middleware/src/transformer/ds_proxy/factory.rs
+++ b/ethers-middleware/src/transformer/ds_proxy/factory.rs
@@ -110,7 +110,7 @@ mod dsproxyfactory_mod {
         }
     }
     #[derive(Clone, Debug, Default, Eq, PartialEq, EthEvent)]
-    #[ethevent(abi = "Created(address,address,address,address)", name = "Created")]
+    #[ethevent(abi = "Created(address,address,address,address)")]
     pub struct CreatedFilter {
         #[ethevent(indexed)]
         pub sender: Address,

--- a/ethers-middleware/src/transformer/ds_proxy/factory.rs
+++ b/ethers-middleware/src/transformer/ds_proxy/factory.rs
@@ -110,7 +110,7 @@ mod dsproxyfactory_mod {
         }
     }
     #[derive(Clone, Debug, Default, Eq, PartialEq, EthEvent)]
-    #[ethevent(abi = "Created(address,address,address,address)")]
+    #[ethevent(abi = "Created(address,address,address,address)", name = "Created")]
     pub struct CreatedFilter {
         pub sender: Address,
         pub owner: Address,

--- a/ethers-middleware/src/transformer/ds_proxy/factory.rs
+++ b/ethers-middleware/src/transformer/ds_proxy/factory.rs
@@ -17,7 +17,7 @@ pub static ADDRESS_BOOK: Lazy<HashMap<U256, Address>> = Lazy::new(|| {
 
 ///
 /// Generated with
-/// ```no_run
+/// ```ignore
 /// # use ethers_contract::abigen;
 /// abigen!(DsProxyFactory,
 ///         "ethers-middleware/contracts/DsProxyFactory.json",

--- a/ethers-middleware/src/transformer/ds_proxy/factory.rs
+++ b/ethers-middleware/src/transformer/ds_proxy/factory.rs
@@ -110,6 +110,7 @@ mod dsproxyfactory_mod {
         }
     }
     #[derive(Clone, Debug, Default, Eq, PartialEq, EthEvent)]
+    #[ethevent(name = "Created")]
     pub struct CreatedFilter {
         #[ethevent(indexed)]
         pub sender: Address,

--- a/ethers-middleware/src/transformer/ds_proxy/factory.rs
+++ b/ethers-middleware/src/transformer/ds_proxy/factory.rs
@@ -110,7 +110,6 @@ mod dsproxyfactory_mod {
         }
     }
     #[derive(Clone, Debug, Default, Eq, PartialEq, EthEvent)]
-    #[ethevent(abi = "Created(address,address,address,address)")]
     pub struct CreatedFilter {
         #[ethevent(indexed)]
         pub sender: Address,

--- a/ethers-middleware/src/transformer/ds_proxy/factory.rs
+++ b/ethers-middleware/src/transformer/ds_proxy/factory.rs
@@ -112,7 +112,9 @@ mod dsproxyfactory_mod {
     #[derive(Clone, Debug, Default, Eq, PartialEq, EthEvent)]
     #[ethevent(abi = "Created(address,address,address,address)", name = "Created")]
     pub struct CreatedFilter {
+        #[ethevent(indexed)]
         pub sender: Address,
+        #[ethevent(indexed)]
         pub owner: Address,
         pub proxy: Address,
         pub cache: Address,

--- a/ethers-middleware/src/transformer/ds_proxy/factory.rs
+++ b/ethers-middleware/src/transformer/ds_proxy/factory.rs
@@ -15,6 +15,18 @@ pub static ADDRESS_BOOK: Lazy<HashMap<U256, Address>> = Lazy::new(|| {
     m
 });
 
+///
+/// Generated with
+/// ```no_run
+/// # use ethers_contract::abigen;
+/// abigen!(DsProxyFactory,
+///         "ethers-middleware/contracts/DsProxyFactory.json",
+///         methods {
+///             build() as build_with_sender;
+///         }
+///     );
+/// ```
+///
 // Auto-generated type-safe bindings
 pub use dsproxyfactory_mod::*;
 #[allow(clippy::too_many_arguments)]
@@ -23,7 +35,7 @@ mod dsproxyfactory_mod {
     #![allow(unused_imports)]
     use ethers_contract::{
         builders::{ContractCall, Event},
-        Contract, Lazy,
+        Contract, EthEvent, Lazy,
     };
     use ethers_core::{
         abi::{parse_abi, Abi, Detokenize, InvalidOutputType, Token, Tokenizable},
@@ -64,8 +76,19 @@ mod dsproxyfactory_mod {
                 .method_hash([41, 113, 3, 136], p0)
                 .expect("method not found (this should never happen)")
         }
-        #[doc = "Calls the contract's `build` (0xf3701da2) function"]
-        pub fn build(&self, owner: Address) -> ContractCall<M, Address> {
+        ///Calls the contract's `build` (0x8e1a55fc) function
+        pub fn build_with_sender(
+            &self,
+        ) -> ethers_contract::builders::ContractCall<M, ethers_core::types::Address> {
+            self.0
+                .method_hash([142, 26, 85, 252], ())
+                .expect("method not found (this should never happen)")
+        }
+        ///Calls the contract's `build` (0xf3701da2) function
+        pub fn build(
+            &self,
+            owner: ethers_core::types::Address,
+        ) -> ethers_contract::builders::ContractCall<M, ethers_core::types::Address> {
             self.0
                 .method_hash([243, 112, 29, 162], owner)
                 .expect("method not found (this should never happen)")
@@ -76,60 +99,22 @@ mod dsproxyfactory_mod {
                 .method_hash([96, 199, 210, 149], ())
                 .expect("method not found (this should never happen)")
         }
-        #[doc = "Gets the contract's `Created` event"]
-        pub fn created_filter(&self) -> Event<M, CreatedFilter> {
-            self.0
-                .event("Created")
-                .expect("event not found (this should never happen)")
+        ///Gets the contract's `Created` event
+        pub fn created_filter(&self) -> ethers_contract::builders::Event<M, CreatedFilter> {
+            self.0.event()
+        }
+
+        /// Returns an [`Event`](ethers_contract::builders::Event) builder for all events of this contract
+        pub fn events(&self) -> ethers_contract::builders::Event<M, CreatedFilter> {
+            self.0.event_with_filter(Default::default())
         }
     }
-    #[derive(Clone, Debug, Default, Eq, PartialEq)]
+    #[derive(Clone, Debug, Default, Eq, PartialEq, EthEvent)]
+    #[ethevent(abi = "Created(address,address,address,address)")]
     pub struct CreatedFilter {
         pub sender: Address,
         pub owner: Address,
         pub proxy: Address,
         pub cache: Address,
-    }
-    impl CreatedFilter {
-        #[doc = r" Retrieves the signature for the event this data corresponds to."]
-        #[doc = r" This signature is the Keccak-256 hash of the ABI signature of"]
-        #[doc = r" this event."]
-        pub const fn signature() -> H256 {
-            H256([
-                37, 155, 48, 202, 57, 136, 92, 109, 128, 26, 11, 93, 188, 152, 134, 64, 243, 194,
-                94, 47, 55, 83, 31, 225, 56, 197, 197, 175, 137, 85, 212, 27,
-            ])
-        }
-        #[doc = r" Retrieves the ABI signature for the event this data corresponds"]
-        #[doc = r" to. For this event the value should always be:"]
-        #[doc = r""]
-        #[doc = "`Created(address,address,address,address)`"]
-        pub const fn abi_signature() -> &'static str {
-            "Created(address,address,address,address)"
-        }
-    }
-    impl Detokenize for CreatedFilter {
-        fn from_tokens(tokens: Vec<Token>) -> Result<Self, InvalidOutputType> {
-            if tokens.len() != 4 {
-                return Err(InvalidOutputType(format!(
-                    "Expected {} tokens, got {}: {:?}",
-                    4,
-                    tokens.len(),
-                    tokens
-                )));
-            }
-            #[allow(unused_mut)]
-            let mut tokens = tokens.into_iter();
-            let sender = Tokenizable::from_token(tokens.next().expect("this should never happen"))?;
-            let owner = Tokenizable::from_token(tokens.next().expect("this should never happen"))?;
-            let proxy = Tokenizable::from_token(tokens.next().expect("this should never happen"))?;
-            let cache = Tokenizable::from_token(tokens.next().expect("this should never happen"))?;
-            Ok(CreatedFilter {
-                sender,
-                owner,
-                proxy,
-                cache,
-            })
-        }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
This follows up on #234 and also provides a solution for #98
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
The `EthEvent` trait is extended with a method to create an `Event` builder directly (closes #234).
The `EthEvent` proc macro now derives a `decode_log(log: &RawLog)` that parses the log message into an instance of the type it's derived on.
This introduces another trait `EthLogDecode` which only purpose is to create a common `RawLog -> Self` interface for all the generated `EthEvent`s of a contract and the generated enum wrapper that is generated for events that have more than 1 event in their abi (closes #98)

### Example
if a contract is created as follows

```rust
abigen!(
    SimpleContract,
    r#"[
    event ValueChanged(address indexed author, string oldValue, string newValue)
    event OwnerChanged(address indexed author, address indexed author)
    event Log(string msg)
]"#
);
```
an enum 

```
pub enum SimpleContractEvents {
    LogFilter(LogFilter),
    OwnerChangedFilter(OwnerChangedFilter),
    ValueChangedFilter(ValueChangedFilter),
}
```

is created. 
In addition, if the abi has at least one event the generated contract gets a new method `events(&self) -> Event<M,  Events>`, where `Events` is either the sole event for contracts with only a single event or the generated enum for contracts with more than one event. 
In the latter case, the protocol decoding works in such a way that all variants are tried to be decoded one after the other and the first successful attempt is returned

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Breaking changes
* Renamed the `Contract::event(&self, &str) -> Result<Event<_>,Error>` to `event_for_name` and introduced `Contract::event<T:EthEvent>(&self) -> Event<_>` + another convenience function