### PR TITLE
feat: add async setup utility functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,6 +693,7 @@ dependencies = [
  "ethereum-types",
  "ethers",
  "funty",
+ "futures-util",
  "generic-array",
  "glob",
  "hex",
@@ -704,6 +705,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tiny-keccak",
+ "tokio",
 ]
 
 [[package]]

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -36,6 +36,9 @@ hex = { version = "0.4.3", default-features = false, features = ["std"] }
 # https://github.com/bitvecto-rs/bitvec/issues/105#issuecomment-778570981
 funty = "=1.1.0"
 
+# async
+tokio = { version = "1.2", default-features = false, optional = true}
+futures-util = { version = "0.3.13", default-features = false, optional = true}
 
 [dev-dependencies]
 ethers = { version = "0.2", path = "../ethers" }
@@ -47,6 +50,7 @@ once_cell = { version = "1.7.2" }
 
 [features]
 celo = [] # celo support extends the transaction format with extra fields
+setup = ["tokio", "futures-util"] # async support for concurrent setup
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -17,6 +17,12 @@ mod solc;
 #[cfg(not(target_arch = "wasm32"))]
 pub use solc::{CompiledContract, Solc};
 
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "setup")]
+mod setup;
+#[cfg(feature = "setup")]
+pub use setup::*;
+
 mod hash;
 pub use hash::{hash_message, id, keccak256, serialize};
 

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -20,6 +20,7 @@ pub use solc::{CompiledContract, Solc};
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg(feature = "setup")]
 mod setup;
+#[cfg(not(target_arch = "wasm32"))]
 #[cfg(feature = "setup")]
 pub use setup::*;
 

--- a/ethers-core/src/utils/setup.rs
+++ b/ethers-core/src/utils/setup.rs
@@ -1,0 +1,54 @@
+//! Setup utilities to start necessary infrastructure
+
+use crate::utils::solc::{CompiledContract, SolcError};
+use crate::utils::{Ganache, GanacheInstance, Geth, GethInstance, Solc};
+use std::collections::HashMap;
+
+/// Builds the contracts and returns a hashmap for each named contract
+///
+/// Same as [crate::utils::Solc::build] but async
+pub async fn compile(solc: Solc) -> Result<HashMap<String, CompiledContract>, SolcError> {
+    tokio::task::spawn_blocking(|| solc.build()).await.unwrap()
+}
+
+/// Launches a [crate::utils::GanacheInstance]
+///
+/// Same as [crate::utils::Ganache::spawn] but async
+pub async fn launch_ganache(ganache: Ganache) -> GanacheInstance {
+    tokio::task::spawn_blocking(|| ganache.spawn())
+        .await
+        .unwrap()
+}
+
+/// Compiles the contracts and launches a [crate::utils::GanacheInstance]
+///
+/// Same as [crate::utils::setup::compile] and [crate::utils::setup::launch_ganache]
+pub async fn compile_and_launch_ganache(
+    solc: Solc,
+    ganache: Ganache,
+) -> Result<(HashMap<String, CompiledContract>, GanacheInstance), SolcError> {
+    let solc_fut = compile(solc);
+    let ganache_fut = launch_ganache(ganache);
+    let (solc, ganache) = futures_util::join!(solc_fut, ganache_fut);
+    solc.map(|solc| (solc, ganache))
+}
+
+/// Launches a [crate::utils::GethInstance]
+///
+/// Same as [crate::utils::Geth::spawn] but async
+pub async fn launch_geth(geth: Geth) -> GethInstance {
+    tokio::task::spawn_blocking(|| geth.spawn()).await.unwrap()
+}
+
+/// Compiles the contracts and launches a [crate::utils::GethInstance]
+///
+/// Same as [crate::utils::setup::compile] and [crate::utils::setup::launch_geth]
+pub async fn compile_and_launch_geth(
+    solc: Solc,
+    geth: Geth,
+) -> Result<(HashMap<String, CompiledContract>, GethInstance), SolcError> {
+    let solc_fut = compile(solc);
+    let geth_fut = launch_geth(geth);
+    let (solc, geth) = futures_util::join!(solc_fut, geth_fut);
+    solc.map(|solc| (solc, geth))
+}

--- a/ethers/Cargo.toml
+++ b/ethers/Cargo.toml
@@ -35,7 +35,7 @@ abigen = ["ethers-contract/abigen"]
 
 [dependencies]
 ethers-contract = { version = "0.2.2", path = "../ethers-contract" }
-ethers-core = { version = "0.2.2", path = "../ethers-core" }
+ethers-core = { version = "0.2.2", path = "../ethers-core", features = ["setup"] }
 ethers-providers = { version = "0.2.2", path = "../ethers-providers" }
 ethers-signers = { version = "0.2.2", path = "../ethers-signers" }
 ethers-middleware = { version = "0.2.2", path = "../ethers-middleware" }

--- a/ethers/examples/contract_human_readable.rs
+++ b/ethers/examples/contract_human_readable.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use ethers::{
     prelude::*,
-    utils::{Ganache, Solc},
+    utils::{compile_and_launch_ganache, Ganache, Solc},
 };
 use std::{convert::TryFrom, sync::Arc, time::Duration};
 
@@ -19,54 +19,52 @@ abigen!(
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // 1. compile the contract (note this requires that you are inside the `ethers/examples` directory)
-    let compiled = Solc::new("**/contract.sol").build()?;
+    // 1. compile the contract (note this requires that you are inside the `ethers/examples` directory) and launch ganache
+    let (compiled, ganache) =
+        compile_and_launch_ganache(Solc::new("**/contract.sol"), Ganache::new()).await?;
     let contract = compiled
         .get("SimpleStorage")
         .expect("could not find contract");
 
-    // 2. launch ganache
-    let ganache = Ganache::new().spawn();
-
-    // 3. instantiate our wallet
+    // 2. instantiate our wallet
     let wallet: LocalWallet = ganache.keys()[0].clone().into();
 
-    // 4. connect to the network
+    // 3. connect to the network
     let provider =
         Provider::<Http>::try_from(ganache.endpoint())?.interval(Duration::from_millis(10u64));
 
-    // 5. instantiate the client with the wallet
+    // 4. instantiate the client with the wallet
     let client = SignerMiddleware::new(provider, wallet);
     let client = Arc::new(client);
 
-    // 6. create a factory which will be used to deploy instances of the contract
+    // 5. create a factory which will be used to deploy instances of the contract
     let factory = ContractFactory::new(
         contract.abi.clone(),
         contract.bytecode.clone(),
         client.clone(),
     );
 
-    // 7. deploy it with the constructor arguments
+    // 6. deploy it with the constructor arguments
     let contract = factory.deploy("initial value".to_string())?.send().await?;
 
-    // 8. get the contract's address
+    // 7. get the contract's address
     let addr = contract.address();
 
-    // 9. instantiate the contract
+    // 8. instantiate the contract
     let contract = SimpleContract::new(addr, client.clone());
 
-    // 10. call the `setValue` method
+    // 9. call the `setValue` method
     // (first `await` returns a PendingTransaction, second one waits for it to be mined)
     let _receipt = contract.set_value("hi".to_owned()).send().await?.await?;
 
-    // 11. get all events
+    // 10. get all events
     let logs = contract
         .value_changed_filter()
         .from_block(0u64)
         .query()
         .await?;
 
-    // 12. get the new value
+    // 11. get the new value
     let value = contract.get_value().call().await?;
 
     println!("Value: {}. Logs: {}", value, serde_json::to_string(&logs)?);

--- a/ethers/examples/contract_with_abi.rs
+++ b/ethers/examples/contract_with_abi.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use ethers::{
     prelude::*,
-    utils::{Ganache, Solc},
+    utils::{compile_and_launch_ganache, Ganache, Solc},
 };
 use std::{convert::TryFrom, sync::Arc, time::Duration};
 
@@ -15,55 +15,54 @@ abigen!(
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // 1. compile the contract (note this requires that you are inside the `ethers/examples` directory)
-    let compiled = Solc::new("**/contract.sol").build()?;
+    // 1. compile the contract (note this requires that you are inside the `ethers/examples` directory) and launch ganache
+    let (compiled, ganache) =
+        compile_and_launch_ganache(Solc::new("**/contract.sol"), Ganache::new()).await?;
+
     let contract = compiled
         .get("SimpleStorage")
         .expect("could not find contract");
     dbg!("OK");
 
-    // 2. launch ganache
-    let ganache = Ganache::new().spawn();
-
-    // 3. instantiate our wallet
+    // 2. instantiate our wallet
     let wallet: LocalWallet = ganache.keys()[0].clone().into();
 
-    // 4. connect to the network
+    // 3. connect to the network
     let provider =
         Provider::<Http>::try_from(ganache.endpoint())?.interval(Duration::from_millis(10u64));
 
-    // 5. instantiate the client with the wallet
+    // 4. instantiate the client with the wallet
     let client = SignerMiddleware::new(provider, wallet);
     let client = Arc::new(client);
 
-    // 6. create a factory which will be used to deploy instances of the contract
+    // 5. create a factory which will be used to deploy instances of the contract
     let factory = ContractFactory::new(
         contract.abi.clone(),
         contract.bytecode.clone(),
         client.clone(),
     );
 
-    // 7. deploy it with the constructor arguments
+    // 6. deploy it with the constructor arguments
     let contract = factory.deploy("initial value".to_string())?.send().await?;
 
-    // 8. get the contract's address
+    // 7. get the contract's address
     let addr = contract.address();
 
-    // 9. instantiate the contract
+    // 8. instantiate the contract
     let contract = SimpleContract::new(addr, client.clone());
 
-    // 10. call the `setValue` method
+    // 9. call the `setValue` method
     // (first `await` returns a PendingTransaction, second one waits for it to be mined)
     let _receipt = contract.set_value("hi".to_owned()).send().await?.await?;
 
-    // 11. get all events
+    // 10. get all events
     let logs = contract
         .value_changed_filter()
         .from_block(0u64)
         .query()
         .await?;
 
-    // 12. get the new value
+    // 11. get the new value
     let value = contract.get_value().call().await?;
 
     println!("Value: {}. Logs: {}", value, serde_json::to_string(&logs)?);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
This adds async helper functions for compiling contracts and setting up `geth` or `ganache`.
Using the async `compile_and_launch_ganache` will only take as long as the longest running command (`solc`, `ganache-cli` ). 
This will shave off the solidity compile time for the updated examples, because this in those cases the compile time is very short. And it will shave off the `~1.8s` it takes to launch ganache for those cases where `solc` takes longer than that.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Feature gate a `setup` module in `ethers-core` that simply runs `tokio::task::blocking` for the commands (`solc`, `geth`, `ganache`) and join those task when using `compile_and_launch_ganache` or `compile_and_launch_geth`.
By default the `setup` feature of the `ethers-core` crate is enabled in `ethers` exposing those helper functions from the `ethers::util` module.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
