### PR TITLE
chore: use upstream ethabi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,10 +572,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethabi-next"
-version = "13.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317f1828c48834fbe40ed37b9267742d37392f6c1f7bedb9dec7f0c62d17601c"
+name = "ethabi"
+version = "13.0.0"
+source = "git+https://github.com/rust-ethereum/ethabi#a9126613ecd18295f48fa3222eabdc4b65c07392"
 dependencies = [
  "anyhow",
  "ethereum-types",
@@ -689,7 +688,7 @@ dependencies = [
  "bytes",
  "ecdsa",
  "elliptic-curve 0.9.5",
- "ethabi-next",
+ "ethabi",
  "ethereum-types",
  "ethers",
  "funty",

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["ethereum", "web3", "celo", "ethers"]
 # ethereum related
 ethereum-types = { version = "0.11.0", default-features = false }
 rlp = { version = "0.5.0", default-features = false }
-ethabi = { package = "ethabi-next", version = "13.3.0", default-features = false }
+ethabi = { git = "https://github.com/rust-ethereum/ethabi", version = "13.0.0", default-features = false }
 arrayvec = { version = "0.5.1", default-features = false }
 
 # crypto

--- a/ethers-core/src/types/trace/mod.rs
+++ b/ethers-core/src/types/trace/mod.rs
@@ -106,6 +106,7 @@ pub struct TransactionTrace {
 
 // ---------------- VmTrace ------------------------------
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+#[allow(clippy::upper_case_acronyms)]
 /// A record of a full VM trace for a CALL/CREATE.
 pub struct VMTrace {
     /// The code to be executed.
@@ -115,6 +116,7 @@ pub struct VMTrace {
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+#[allow(clippy::upper_case_acronyms)]
 /// A record of the execution of a single VM operation.
 pub struct VMOperation {
     /// The program counter.
@@ -129,6 +131,7 @@ pub struct VMOperation {
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+#[allow(clippy::upper_case_acronyms)]
 /// A record of an executed VM operation.
 pub struct VMExecutedOperation {
     /// The total gas used.
@@ -145,6 +148,7 @@ pub struct VMExecutedOperation {
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+#[allow(clippy::upper_case_acronyms)]
 /// A diff of some chunk of memory.
 pub struct MemoryDiff {
     /// Offset into memory the change begins.
@@ -154,6 +158,7 @@ pub struct MemoryDiff {
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Deserialize, Serialize)]
+#[allow(clippy::upper_case_acronyms)]
 /// A diff of some storage value.
 pub struct StorageDiff {
     /// Which key in storage is changed.


### PR DESCRIPTION
We maintained a fork of [ethabi](https://github.com/gakonst/ethabi/) since the package was missing a few critical features, but now that there's new maintainers, we can finally use upstream and get rid of the fork.

This is still WIP until there's a release with all the features we need.