### PR TITLE
Replace println usage in ws provider

### DIFF
--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -25,7 +25,7 @@ use tokio_tungstenite::{
     connect_async,
     tungstenite::{self, protocol::Message},
 };
-use tracing::{warn, error};
+use tracing::{error, warn};
 
 /// A JSON-RPC Client over Websockets.
 ///

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -25,6 +25,7 @@ use tokio_tungstenite::{
     connect_async,
     tungstenite::{self, protocol::Message},
 };
+use tracing::{warn, error};
 
 /// A JSON-RPC Client over Websockets.
 ///
@@ -223,22 +224,22 @@ where
                 sender,
             } => {
                 if self.pending.insert(id, sender).is_some() {
-                    println!("Replacing a pending request with id {:?}", id);
+                    warn!("Replacing a pending request with id {:?}", id);
                 }
 
                 if let Err(e) = self.ws.send(Message::Text(request)).await {
-                    println!("WS connection error: {:?}", e);
+                    error!("WS connection error: {:?}", e);
                     self.pending.remove(&id);
                 }
             }
             TransportMessage::Subscribe { id, sink } => {
                 if self.subscriptions.insert(id, sink).is_some() {
-                    println!("Replacing already-registered subscription with id {:?}", id);
+                    warn!("Replacing already-registered subscription with id {:?}", id);
                 }
             }
             TransportMessage::Unsubscribe { id } => {
                 if self.subscriptions.remove(&id).is_none() {
-                    println!(
+                    warn!(
                         "Unsubscribing from non-existent subscription with id {:?}",
                         id
                     );


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

I guess it was just the ws provider which had prints, I should have looked deeper before opening #262, missed the tracing usages.

Closes #262

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
