### PR TITLE
feature: Signature derives Copy trait

### DIFF
--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -494,7 +494,8 @@ mod celo_tests {
         // Funded with https://celo.org/developers/faucet
         let wallet = "d652abb81e8c686edba621a895531b1f291289b63b5ef09a94f686a5ecdd5db1"
             .parse::<LocalWallet>()
-            .unwrap();
+            .unwrap()
+            .set_chain_id(44787u64);
 
         let client = SignerMiddleware::new(provider, wallet);
         let client = Arc::new(client);

--- a/ethers-core/src/types/signature.rs
+++ b/ethers-core/src/types/signature.rs
@@ -51,7 +51,7 @@ pub enum RecoveryMessage {
     Hash(H256),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Copy)]
 /// An ECDSA signature
 pub struct Signature {
     /// R value

--- a/ethers-middleware/tests/signer.rs
+++ b/ethers-middleware/tests/signer.rs
@@ -53,7 +53,8 @@ async fn test_send_transaction() {
     // Please do not drain this account :)
     let wallet = "d652abb81e8c686edba621a895531b1f291289b63b5ef09a94f686a5ecdd5db1"
         .parse::<LocalWallet>()
-        .unwrap();
+        .unwrap()
+        .set_chain_id(44787u64);
     let client = SignerMiddleware::new(provider, wallet);
 
     let balance_before = client.get_balance(client.address(), None).await.unwrap();


### PR DESCRIPTION
derives `Copy` on `Signature`

## Motivation

I'd like `Signature` to be `Copy`

## Solution

Derive `Copy`

## Drive-by change

Set network ID in signer in Celo tests