### PR TITLE
fix: off by one error during log topic decoding

### DIFF
--- a/ethers-contract/ethers-contract-derive/src/lib.rs
+++ b/ethers-contract/ethers-contract-derive/src/lib.rs
@@ -432,7 +432,7 @@ fn derive_decode_from_log_impl(
                 let flat_topics = topics.iter().skip(1).flat_map(|t| t.as_ref().to_vec()).collect::<Vec<u8>>();
             },
             quote! {
-                if topic_tokens.is_empty() || topic_tokens.len() != topics.len() - 1 {
+                if topic_tokens.len() != topics.len() - 1 {
                     return Err(ethers_core::abi::Error::InvalidData);
                 }
             },


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Fixes a bug, that is essentially an off by one error, that resulted in errors when decoding events with no indexed entries. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Remove the bad `is_empty` requirement and test against real log.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
