### PR TITLE
fix: event decoding for events with zero or one parameters

### DIFF
--- a/ethers-contract/tests/common/derive.rs
+++ b/ethers-contract/tests/common/derive.rs
@@ -268,3 +268,44 @@ fn can_decode_event_with_no_topics() {
     assert_eq!(event.seize_tokens, 5250648u64.into());
     assert_eq!(event.repay_amount, 653800000000000000u64.into());
 }
+
+#[test]
+fn can_decode_event_single_param() {
+    #[derive(Debug, PartialEq, EthEvent)]
+    pub struct OneParam {
+        #[ethevent(indexed)]
+        param1: U256,
+    }
+
+    let log = RawLog {
+        topics: vec![
+            "bd9bb67345a2fcc8ef3b0857e7e2901f5a0dcfc7fe5e3c10dc984f02842fb7ba"
+                .parse()
+                .unwrap(),
+            "000000000000000000000000000000000000000000000000000000000000007b"
+                .parse()
+                .unwrap(),
+        ],
+        data: vec![],
+    };
+
+    let event = <OneParam as EthLogDecode>::decode_log(&log).unwrap();
+    assert_eq!(event.param1, 123u64.into());
+}
+
+#[test]
+fn can_decode_event_with_no_params() {
+    #[derive(Debug, PartialEq, EthEvent)]
+    pub struct NoParam {}
+
+    let log = RawLog {
+        topics: vec![
+            "59a6f900daaeb7581ff830f3a97097fa6372db29b0b50c6d1818ede9d1daaa0c"
+                .parse()
+                .unwrap(),
+        ],
+        data: vec![],
+    };
+
+    let _ = <NoParam as EthLogDecode>::decode_log(&log).unwrap();
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
#298 happened because, the the generated `Tokenizable::from_token` always expected a `Tuple`, however that is not valid for events with a single parameter.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
To handle events with zero or one parameters correctly, the macro now checks how many fields the struct with the `EthEvent` derive actually has. 
The code path for a single param looks rather hacky, but holds. it piggybacks on the existing TokenStreams for len > 1.

For events with zero parameters there is a soundness issue with the mandatory `into_token` function. Because there is nothing to encode, I opted for an empty tuple instead of panicing, but maybe a `panic!` would be more appropriate here?

Tested with two new test cases.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Closes #298 