### PR TITLE
feat: introduce tx stream

### DIFF
--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -76,7 +76,7 @@ pub use pending_transaction::PendingTransaction;
 
 mod stream;
 pub use futures_util::StreamExt;
-pub use stream::{interval, FilterWatcher, DEFAULT_POLL_INTERVAL};
+pub use stream::{interval, FilterWatcher, TransactionStream, DEFAULT_POLL_INTERVAL};
 
 mod pubsub;
 pub use pubsub::{PubsubClient, SubscriptionStream};

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -22,6 +22,12 @@ use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
 use url::{ParseError, Url};
 
+use futures_core::{Future, Stream};
+use futures_util::stream::FuturesUnordered;
+use futures_util::{FutureExt, StreamExt, TryFutureExt};
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::{convert::TryFrom, fmt::Debug, time::Duration};
 use tracing::trace;
 use tracing_futures::Instrument;
@@ -982,5 +988,56 @@ mod tests {
             .collect::<Vec<_>>()
             .await;
         assert_eq!(blocks, vec![1, 2, 3]);
+    }
+}
+
+type TransactionFut<'a> = Pin<Box<dyn Future<Output = Result<Transaction, ProviderError>> + 'a>>;
+
+struct TxStream<'a, P> {
+    pending: FuturesUnordered<TransactionFut<'a>>,
+    buffered: VecDeque<TxHash>,
+    provider: &'a Provider<P>,
+    watcher: FilterWatcher<'a, P, TxHash>,
+    max_concurrent: usize,
+}
+
+impl<'a, P: JsonRpcClient> Stream for TxStream<'a, P> {
+    type Item = Result<Transaction, ProviderError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        if let tx @ Poll::Ready(Some(_)) = this.pending.poll_next_unpin(cx) {
+            return tx;
+        }
+
+        while this.max_concurrent < this.max_concurrent {
+            if let Some(_) = this.buffered.pop_front() {
+                // TODO add get_tx again
+            } else {
+                break;
+            }
+        }
+
+        while let Poll::Ready(Some(tx)) = Stream::poll_next(Pin::new(&mut this.watcher), cx) {
+            if this.pending.len() < this.max_concurrent {
+                this.pending
+                    .push(Box::pin(this.provider.get_transaction(tx).and_then(
+                        |res| {
+                            if let Some(tx) = res {
+                                futures_util::future::ok(tx)
+                            } else {
+                                futures_util::future::err(ProviderError::CustomError(
+                                    "Not found".to_string(),
+                                ))
+                            }
+                        },
+                    )));
+            } else {
+                this.buffered.push_back(tx);
+            }
+        }
+
+        todo!()
     }
 }

--- a/ethers-providers/src/stream.rs
+++ b/ethers-providers/src/stream.rs
@@ -124,6 +124,20 @@ where
     }
 }
 
+impl<'a, P> FilterWatcher<'a, P, TxHash>
+where
+    P: JsonRpcClient,
+{
+    /// Returns a stream that yields the `Transaction`s for the transaction hashes this stream yields.
+    ///
+    /// This internally calls `Provider::get_transaction` with every new transaction.
+    /// No more than n futures will be buffered at any point in time, and less than n may also be
+    /// buffered depending on the state of each future.
+    pub fn transactions_unordered(self, n: usize) -> TransactionStream<'a, P, Self> {
+        TransactionStream::new(self.provider, self, n)
+    }
+}
+
 /// Errors `TransactionStream` can throw
 #[derive(Debug, thiserror::Error)]
 pub enum GetTransactionError {

--- a/ethers-providers/src/stream.rs
+++ b/ethers-providers/src/stream.rs
@@ -269,12 +269,6 @@ mod tests {
             .unwrap()
             .with_sender(ganache.addresses()[0]);
 
-        provider
-            .watch_pending_transactions()
-            .await
-            .unwrap()
-            .transactions_unordered(10);
-
         let accounts = provider.get_accounts().await.unwrap();
 
         let tx = TransactionRequest::new()

--- a/ethers-providers/src/stream.rs
+++ b/ethers-providers/src/stream.rs
@@ -144,7 +144,7 @@ pub enum GetTransactionError {
     #[error("Failed to get transaction `{0}`: {1}")]
     ProviderError(TxHash, ProviderError),
     /// `get_transaction` resulted in a `None`
-    #[error("Transaction `{0}` not found {0}")]
+    #[error("Transaction `{0}` not found")]
     NotFound(TxHash),
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Provides support to fetch the respective `transaction`s for all transaction hashes provided by a `Stream<Item=TxHash>`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Create a new `TransactionStream` type that takes a `Provider` and a `Stream<Item=TxHash>` as input as well as the number  of the maximum allowed active futures at the same time and returns their `Transaction`.

Added a `transactions_unordered` function for the `Filterwatcher<TxHash>` and `SubscriptionStream<TxHash>` types that is intended to be called like:

```rust
 provider.watch_pending_transactions().await.unwrap().transactions_unordered(10);
``` 

and 

```rust
 provider.subscribe_pending_txs().await.unwrap().transactions_unordered(10);
``` 


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
