### PR TITLE
feat: make I256::from_raw() as const

### DIFF
--- a/ethers-core/src/types/i256.rs
+++ b/ethers-core/src/types/i256.rs
@@ -168,7 +168,7 @@ impl I256 {
     /// Coerces an unsigned integer into a signed one. If the unsigned integer
     /// is greater than the greater than or equal to `1 << 255`, then the result
     /// will overflow into a negative value.
-    pub fn from_raw(raw: U256) -> Self {
+    pub const fn from_raw(raw: U256) -> Self {
         I256(raw)
     }
 
@@ -1263,6 +1263,9 @@ mod tests {
 
     #[test]
     fn identities() {
+        const ONE: I256 = I256::from_raw(U256([1, 0, 0, 0]));
+        assert_eq!(ONE, I256::one());
+
         assert_eq!(I256::zero().to_string(), "0");
         assert_eq!(I256::one().to_string(), "1");
         assert_eq!(I256::minus_one().to_string(), "-1");

--- a/ethers/examples/sign.rs
+++ b/ethers/examples/sign.rs
@@ -10,7 +10,7 @@ use ethers_signers::{LocalWallet, Signer};
 async fn main() -> Result<()> {
     // Generate a random wallet
     let wallet = LocalWallet::new(&mut thread_rng());
-    
+
     // Declare the message you want to sign.
     let message = "Some data";
 


### PR DESCRIPTION
I'd like to make from_raw() a const fn.