### PR TITLE
fix: remove ethers celo feature and ignore celo test

### DIFF
--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -49,6 +49,6 @@ tempfile = "3.2.0"
 
 [features]
 default = ["ws", "ipc"]
-celo = ["ethers-core/celo", "ethers/celo"]
+celo = ["ethers-core/celo"]
 ws = ["tokio", "tokio-tungstenite"]
 ipc = ["tokio", "tokio/io-util", "tokio-util", "bytes"]

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -875,6 +875,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(feature = "celo", ignore)]
     async fn test_is_signer() {
         use ethers_core::utils::Ganache;
         use std::str::FromStr;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
This removes the `ethers/celo` feature enabled for `celo` which prevent `ethers-providers` to be used as standalone dep. and ignores the celo dependend test by default.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
