### PR TITLE
feat: extend Middleware trait customized for celo

### DIFF
--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -561,3 +561,17 @@ pub trait Middleware: Sync + Send + Debug {
             .map_err(FromErr::from)
     }
 }
+
+#[cfg(feature = "celo")]
+#[async_trait]
+pub trait CeloMiddleware: Middleware {
+    async fn get_validators_bls_public_keys(
+        &self,
+        block_number: String,
+    ) -> Result<Vec<String>, ProviderError> {
+        self.provider()
+            .get_validators_bls_public_keys(block_number)
+            .await
+            .map_err(FromErr::from)
+    }
+}

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -567,10 +567,10 @@ pub trait Middleware: Sync + Send + Debug {
 pub trait CeloMiddleware: Middleware {
     async fn get_validators_bls_public_keys(
         &self,
-        block_number: String,
-    ) -> Result<Vec<String>, ProviderError> {
+        block: Option<BlockId>,
+    ) -> Result<Vec<Vec<u8>>, ProviderError> {
         self.provider()
-            .get_validators_bls_public_keys(block_number)
+            .get_validators_bls_public_keys(block)
             .await
             .map_err(FromErr::from)
     }

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -157,9 +157,10 @@ impl<P: JsonRpcClient> Provider<P> {
 impl<P: JsonRpcClient> CeloMiddleware for Provider<P> {
     async fn get_validators_bls_public_keys(
         &self,
-        block_number: String,
-    ) -> Result<Vec<String>, ProviderError> {
-        self.request("istanbul_getValidatorsBLSPublicKeys", [block_number])
+        block: Option<BlockId>,
+    ) -> Result<Vec<Vec<u8>>, ProviderError> {
+        let block = utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
+        self.request("istanbul_getValidatorsBLSPublicKeys", [block])
             .await
     }
 }

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -15,6 +15,8 @@ use ethers_core::{
     utils,
 };
 
+#[cfg(feature = "celo")]
+use crate::CeloMiddleware;
 use crate::Middleware;
 use async_trait::async_trait;
 use hex::FromHex;
@@ -147,6 +149,18 @@ impl<P: JsonRpcClient> Provider<P> {
                     .await?
             }
         })
+    }
+}
+
+#[cfg(feature = "celo")]
+#[async_trait]
+impl<P: JsonRpcClient> CeloMiddleware for Provider<P> {
+    async fn get_validators_bls_public_keys(
+        &self,
+        block_number: String,
+    ) -> Result<Vec<String>, ProviderError> {
+        self.request("istanbul_getValidatorsBLSPublicKeys", [block_number])
+            .await
     }
 }
 


### PR DESCRIPTION
## Motivation
We would like to have a customized `provider` for Celo so as to add more functions exclusively provided by Celo blockchain.

## Solution
A new trait `CeloMiddleware` is added to extend the `Middleware` for provider, so that functions in `Middleware` will query APIs compatible with Ethereum while functions in `CeloMiddleware` will query those exclusively in Celo.

The method `get_validators_bls_public_keys()` is added as an example.