### PR TITLE
fix: change the type of block number and pub key

### DIFF
--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -565,12 +565,12 @@ pub trait Middleware: Sync + Send + Debug {
 #[cfg(feature = "celo")]
 #[async_trait]
 pub trait CeloMiddleware: Middleware {
-    async fn get_validators_bls_public_keys(
+    async fn get_validators_bls_public_keys<T: Into<BlockId> + Send + Sync>(
         &self,
-        block: Option<BlockId>,
-    ) -> Result<Vec<Vec<u8>>, ProviderError> {
+        block_id: T,
+    ) -> Result<Vec<String>, ProviderError> {
         self.provider()
-            .get_validators_bls_public_keys(block)
+            .get_validators_bls_public_keys(block_id)
             .await
             .map_err(FromErr::from)
     }

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -155,12 +155,12 @@ impl<P: JsonRpcClient> Provider<P> {
 #[cfg(feature = "celo")]
 #[async_trait]
 impl<P: JsonRpcClient> CeloMiddleware for Provider<P> {
-    async fn get_validators_bls_public_keys(
+    async fn get_validators_bls_public_keys<T: Into<BlockId> + Send + Sync>(
         &self,
-        block: Option<BlockId>,
-    ) -> Result<Vec<Vec<u8>>, ProviderError> {
-        let block = utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
-        self.request("istanbul_getValidatorsBLSPublicKeys", [block])
+        block_id: T,
+    ) -> Result<Vec<String>, ProviderError> {
+        let block_id = utils::serialize(&block_id.into());
+        self.request("istanbul_getValidatorsBLSPublicKeys", [block_id])
             .await
     }
 }


### PR DESCRIPTION
A follow up on #314, changed the type of block number to the generic `Into<BlockId>` so that the client can query with the input of type `u64` other than converting `u64` to `BlockId` manually. 

Changed the type of returned public key to `String` since the client cannot deserialize the response data otherwise.
