### PR TITLE
Add xDai multicall contract address

### DIFF
--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -38,6 +38,11 @@ pub static ADDRESS_BOOK: Lazy<HashMap<U256, Address>> = Lazy::new(|| {
     let addr =
         Address::from_str("2cc8688c5f75e365aaeeb4ea8d6a480405a48d2a").expect("Decoding failed");
     m.insert(U256::from(42u8), addr);
+    
+    // xdai
+    let addr =
+        Address::from_str("b5b692a88bdfc81ca69dcb1d924f59f0413a602a").expect("Decoding failed");
+    m.insert(U256::from(100u8), addr);
 
     m
 });


### PR DESCRIPTION
Adds the address of the multicall address on xDai, taken from [makerdao/multicall](https://github.com/makerdao/multicall).

## Motivation

I deploy stuff on xDai and I want to lower friction of using the multicall contract on xDai with this crate.