### PR TITLE
fix: make event types thread safe

### DIFF
--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 
 /// A trait for implementing event bindings
-pub trait EthEvent: Detokenize {
+pub trait EthEvent: Detokenize + Send + Sync {
     /// The name of the event this type represents
     fn name() -> Cow<'static, str>;
 

--- a/ethers-contract/src/log.rs
+++ b/ethers-contract/src/log.rs
@@ -3,7 +3,7 @@ use ethers_core::abi::Error;
 use ethers_core::abi::RawLog;
 
 /// A trait for types (events) that can be decoded from a `RawLog`
-pub trait EthLogDecode {
+pub trait EthLogDecode: Send + Sync {
     /// decode from a `RawLog`
     fn decode_log(log: &RawLog) -> Result<Self, Error>
     where

--- a/ethers-contract/src/stream.rs
+++ b/ethers-contract/src/stream.rs
@@ -4,7 +4,7 @@ use pin_project::pin_project;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-type MapEvent<'a, R, E> = Box<dyn Fn(Log) -> Result<R, E> + 'a>;
+type MapEvent<'a, R, E> = Box<dyn Fn(Log) -> Result<R, E> + 'a + Send + Sync>;
 
 #[pin_project]
 /// Generic wrapper around Log streams, mapping their content to a specific


### PR DESCRIPTION
Fixes the repro shown [here](https://github.com/hiddenmemory/minimal-example/) by making the Event Types `Send + Sync`.

Previously, this would not work:

```rust
#[tokio::main]
async fn main() -> AnyError {
    tokio::task::spawn(async move {
        let ws = Ws::connect("wss://mainnet.infura.io/ws/v3/[API-KEY]").await.unwrap();
        let provider = Arc::new(Provider::new(ws).interval(Duration::from_millis(500)));
        let address = Address::from_str("0xdac17f958d2ee523a2206206994597c13d831ec7").unwrap();
        let contract = token_contract::TokenContract::new(address, provider);

        let filter = contract.transfer_filter();
        let mut stream = filter.stream().await.unwrap();

        while let Some(block) = stream.next().await {
            dbg!(block);
        }
    }).await;

    Ok(())
}
```