### PR TITLE
feat: stream_with_meta

### DIFF
--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -1,8 +1,8 @@
-use crate::{stream::EventStream, ContractError, EthLogDecode};
+use crate::{log::LogMeta, stream::EventStream, ContractError, EthLogDecode};
 
 use ethers_core::{
     abi::{Detokenize, RawLog},
-    types::{Address, BlockNumber, Filter, Log, TxHash, ValueOrArray, H256, U256, U64},
+    types::{BlockNumber, Filter, Log, ValueOrArray, H256},
 };
 use ethers_providers::{FilterWatcher, Middleware, PubsubClient, SubscriptionStream};
 use std::borrow::Cow;
@@ -212,40 +212,5 @@ where
             data: log.data.to_vec(),
         })
         .map_err(From::from)
-    }
-}
-
-/// Metadata inside a log
-#[derive(Clone, Debug, PartialEq)]
-pub struct LogMeta {
-    /// Address from which this log originated
-    pub address: Address,
-
-    /// The block in which the log was emitted
-    pub block_number: U64,
-
-    /// The block hash in which the log was emitted
-    pub block_hash: H256,
-
-    /// The transaction hash in which the log was emitted
-    pub transaction_hash: TxHash,
-
-    /// Transactions index position log was created from
-    pub transaction_index: U64,
-
-    /// Log index position in the block
-    pub log_index: U256,
-}
-
-impl From<&Log> for LogMeta {
-    fn from(src: &Log) -> Self {
-        LogMeta {
-            address: src.address,
-            block_number: src.block_number.expect("should have a block number"),
-            block_hash: src.block_hash.expect("should have a block hash"),
-            transaction_hash: src.transaction_hash.expect("should have a tx hash"),
-            transaction_index: src.transaction_index.expect("should have a tx index"),
-            log_index: src.log_index.expect("should have a log index"),
-        }
     }
 }

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -26,10 +26,10 @@ mod factory;
 pub use factory::ContractFactory;
 
 mod event;
-pub use event::{EthEvent, LogMeta};
+pub use event::EthEvent;
 
 mod log;
-pub use log::{decode_logs, EthLogDecode};
+pub use log::{decode_logs, EthLogDecode, LogMeta};
 
 mod stream;
 

--- a/ethers-contract/src/log.rs
+++ b/ethers-contract/src/log.rs
@@ -1,6 +1,7 @@
 //! Mod of types for ethereum logs
 use ethers_core::abi::Error;
 use ethers_core::abi::RawLog;
+use ethers_core::types::{Address, Log, TxHash, H256, U256, U64};
 
 /// A trait for types (events) that can be decoded from a `RawLog`
 pub trait EthLogDecode: Send + Sync {
@@ -13,4 +14,39 @@ pub trait EthLogDecode: Send + Sync {
 /// Decodes a series of logs into a vector
 pub fn decode_logs<T: EthLogDecode>(logs: &[RawLog]) -> Result<Vec<T>, Error> {
     logs.iter().map(T::decode_log).collect()
+}
+
+/// Metadata inside a log
+#[derive(Clone, Debug, PartialEq)]
+pub struct LogMeta {
+    /// Address from which this log originated
+    pub address: Address,
+
+    /// The block in which the log was emitted
+    pub block_number: U64,
+
+    /// The block hash in which the log was emitted
+    pub block_hash: H256,
+
+    /// The transaction hash in which the log was emitted
+    pub transaction_hash: TxHash,
+
+    /// Transactions index position log was created from
+    pub transaction_index: U64,
+
+    /// Log index position in the block
+    pub log_index: U256,
+}
+
+impl From<&Log> for LogMeta {
+    fn from(src: &Log) -> Self {
+        LogMeta {
+            address: src.address,
+            block_number: src.block_number.expect("should have a block number"),
+            block_hash: src.block_hash.expect("should have a block hash"),
+            transaction_hash: src.transaction_hash.expect("should have a tx hash"),
+            transaction_index: src.transaction_index.expect("should have a tx index"),
+            log_index: src.log_index.expect("should have a log index"),
+        }
+    }
 }

--- a/ethers-contract/src/stream.rs
+++ b/ethers-contract/src/stream.rs
@@ -1,3 +1,4 @@
+use crate::LogMeta;
 use ethers_core::types::{Log, U256};
 use futures_util::stream::{Stream, StreamExt};
 use pin_project::pin_project;
@@ -20,6 +21,12 @@ pub struct EventStream<'a, T, R, E> {
 }
 
 impl<'a, T, R, E> EventStream<'a, T, R, E> {
+    pub fn with_meta(self) -> EventStreamMeta<'a, T, R, E> {
+        EventStreamMeta(self)
+    }
+}
+
+impl<'a, T, R, E> EventStream<'a, T, R, E> {
     pub fn new(id: U256, stream: T, parse: MapEvent<'a, R, E>) -> Self {
         Self { id, stream, parse }
     }
@@ -35,6 +42,29 @@ where
         let mut this = self.project();
         match futures_util::ready!(this.stream.poll_next_unpin(ctx)) {
             Some(item) => Poll::Ready(Some((this.parse)(item))),
+            None => Poll::Pending,
+        }
+    }
+}
+
+#[pin_project]
+pub struct EventStreamMeta<'a, T, R, E>(pub EventStream<'a, T, R, E>);
+
+impl<'a, T, R, E> Stream for EventStreamMeta<'a, T, R, E>
+where
+    T: Stream<Item = Log> + Unpin,
+{
+    type Item = Result<(R, LogMeta), E>;
+
+    fn poll_next(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        match futures_util::ready!(this.0.stream.poll_next_unpin(ctx)) {
+            Some(item) => {
+                let meta = LogMeta::from(&item);
+                let res = (this.0.parse)(item);
+                let res = res.map(|inner| (inner, meta));
+                Poll::Ready(Some(res))
+            }
             None => Poll::Pending,
         }
     }


### PR DESCRIPTION
As title, allows one to stream logs with metadata, by calling `with_meta` on the stream before polling it.