### PR TITLE
feat: detect ethers crate paths in derive macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c297bd3135f558552f99a0daa180876984ea2c4ffa7470314540dff8c654109a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,8 +839,10 @@ version = "0.4.0"
 dependencies = [
  "Inflector",
  "anyhow",
+ "cargo_metadata",
  "ethers-core",
  "hex",
+ "once_cell",
  "proc-macro2",
  "quote",
  "reqwest",
@@ -2307,6 +2340,9 @@ name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"

--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -21,6 +21,8 @@ url = "2.1"
 serde_json = "1.0.61"
 hex = { version = "0.4.2", default-features = false, features = ["std"] }
 reqwest = { version = "0.11.3", features = ["blocking"] }
+once_cell = { version = "1.8.0", default-features = false }
+cargo_metadata = "0.14.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ethers-contract/ethers-contract-abigen/src/lib.rs
+++ b/ethers-contract/ethers-contract-abigen/src/lib.rs
@@ -21,7 +21,7 @@ mod util;
 
 pub use ethers_core::types::Address;
 pub use source::Source;
-pub use util::parse_address;
+pub use util::{ethers_crate, parse_address};
 
 use anyhow::Result;
 use proc_macro2::TokenStream;

--- a/ethers-contract/ethers-contract-abigen/src/lib.rs
+++ b/ethers-contract/ethers-contract-abigen/src/lib.rs
@@ -21,7 +21,7 @@ mod util;
 
 pub use ethers_core::types::Address;
 pub use source::Source;
-pub use util::{ethers_crate, parse_address};
+pub use util::{ethers_contract_crate, ethers_core_crate, parse_address};
 
 use anyhow::Result;
 use proc_macro2::TokenStream;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
- The `EthEvent` and `EthAbiType` derive macros are usable with `ethers_contract` and `ethers_core` only, therefore it depends on `ethers_core` which requires `use ethers::core as ethers_core;` alias to compile.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- parse the project's `Cargo.toml` and check the dependencies for `ethers` dependency, if the dependency is present then `EthEvent` relies on `ethers::core`.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
