### PR TITLE
fix: only wrap single struct param in a tuple

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -80,7 +80,11 @@ pub(crate) fn expand_inputs_call_arg(inputs: &[Param]) -> TokenStream {
         .map(|(i, param)| {
             let name = util::expand_input_name(i, &param.name);
             match param.kind {
-                ParamType::Tuple(_) => {
+                // this is awkward edge case where the function inputs are a single struct
+                // we need to force this argument into a tuple so it gets expanded to `((#name,))`
+                // this is currently necessary because internally `flatten_tokens` is called which removes the outermost `tuple` level
+                // and since `((#name))` is not a rust tuple it doesn't get wrapped into another tuple that will be peeled off by `flatten_tokens`
+                ParamType::Tuple(_) if inputs.len() == 1 => {
                     // make sure the tuple gets converted to `Token::Tuple`
                     quote! {(#name,)}
                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
This is a follow up for #363 which introduced invalid encoding if the function has *not* a single struct parameter.
The reason why this is a bit error prone is due the token flattening that takes place during encoding of the input params where the outmost `Tuple` layer gets removed. This is intentionally because all function arguments are passed to the `method_hash` function as tuple which adds the `Tuple` layer in the first place.
However, if the function input is a single struct, prior to #363 the param would be `((input))` which is not a rust tuple but `input` itself is, so `flatten_tokens` would later strip away the outmost `Tuple` layer of the input itself, instead of the additional `Tuple` layer that would have been added if `((input))` where a rust tuple.

So in #363 I attempted to fix this by enforcing tuple encoding`((input))` if the param is a tuple, however I did not understand that this was the entire edge case so #363 results in invalid encoding for multiple params (which enforce tuple encoding)
 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Since the edge case is:
* struct input
* len(input) == 1
we can add this condition in to the match arm
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
