### PR TITLE
feat: fee estimation with custom/default fn

### DIFF
--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -399,6 +399,7 @@ mod eth_tests {
         let _receipt = contract
             .method::<_, H256>("setValue", "hi".to_owned())
             .unwrap()
+            .legacy()
             .send()
             .await
             .unwrap()

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -48,10 +48,18 @@ pub enum FormatBytes32StringError {
 /// 1 Ether = 1e18 Wei == 0x0de0b6b3a7640000 Wei
 pub const WEI_IN_ETHER: U256 = U256([0x0de0b6b3a7640000, 0x0, 0x0, 0x0]);
 
+/// The number of blocks from the past for which the fee rewards are fetched for fee estimation.
 pub const EIP1559_FEE_ESTIMATION_PAST_BLOCKS: u64 = 10;
+/// The default percentile of gas premiums that are fetched for fee estimation.
 pub const EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE: f64 = 5.0;
+/// The default max priority fee per gas, used in case the base fee is within a threshold.
 pub const EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE: u64 = 3_000_000_000;
+/// The threshold for base fee below which we use the default priority fee, and beyond which we
+/// estimate an appropriate value for priority fee.
 pub const EIP1559_FEE_ESTIMATION_PRIORITY_FEE_TRIGGER: u64 = 100_000_000_000;
+/// The threshold max change/difference (in %) at which we will ignore the fee history values
+/// under it.
+pub const EIP1559_FEE_ESTIMATION_THRESHOLD_MAX_CHANGE: i64 = 200;
 
 /// Format the output for the user which prefer to see values
 /// in ether (instead of wei)
@@ -193,6 +201,7 @@ pub fn parse_bytes32_string(bytes: &[u8; 32]) -> Result<&str, std::str::Utf8Erro
     std::str::from_utf8(&bytes[..length])
 }
 
+/// The default EIP-1559 fee estimator which is based on the work by [MyCrypto](https://github.com/MyCryptoHQ/MyCrypto/blob/master/src/services/ApiService/Gas/eip1559.ts)
 pub fn eip1559_default_estimator(base_fee_per_gas: U256, rewards: Vec<Vec<U256>>) -> (U256, U256) {
     let max_priority_fee_per_gas =
         if base_fee_per_gas < U256::from(EIP1559_FEE_ESTIMATION_PRIORITY_FEE_TRIGGER) {
@@ -224,9 +233,11 @@ fn estimate_priority_fee(rewards: Vec<Vec<U256>>) -> U256 {
     if rewards.len() == 1 {
         return rewards[0];
     }
+    // Sort the rewards as we will eventually take the median.
     rewards.sort();
-    dbg!(rewards.clone());
 
+    // A copy of the same vector is created for convenience to calculate percentage change
+    // between subsequent fee values.
     let mut rewards_copy = rewards.clone();
     rewards_copy.rotate_left(1);
 
@@ -234,8 +245,6 @@ fn estimate_priority_fee(rewards: Vec<Vec<U256>>) -> U256 {
         .iter()
         .zip(rewards_copy.iter())
         .map(|(a, b)| {
-            dbg!(a);
-            dbg!(b);
             if b > a {
                 ((b - a).low_u32() as i64 * 100) / (a.low_u32() as i64)
             } else {
@@ -245,19 +254,24 @@ fn estimate_priority_fee(rewards: Vec<Vec<U256>>) -> U256 {
         .collect();
     percentage_change.pop();
 
-    dbg!(percentage_change.clone());
+    // Fetch the max of the percentage change, and that element's index.
     let max_change = percentage_change.iter().max().unwrap();
     let max_change_index = percentage_change
         .iter()
         .position(|&c| c == *max_change)
         .unwrap();
 
-    let values = if *max_change >= 200 && (max_change_index >= (rewards.len() / 2)) {
+    // If we encountered a big change in fees at a certain position, then consider only
+    // the values >= it.
+    let values = if *max_change >= EIP1559_FEE_ESTIMATION_THRESHOLD_MAX_CHANGE
+        && (max_change_index >= (rewards.len() / 2))
+    {
         rewards[max_change_index..].to_vec()
     } else {
         rewards
     };
 
+    // Return the median.
     values[values.len() / 2]
 }
 

--- a/ethers-middleware/src/gas_oracle/eth_gas_station.rs
+++ b/ethers-middleware/src/gas_oracle/eth_gas_station.rs
@@ -71,4 +71,8 @@ impl GasOracle for EthGasStation {
 
         Ok(gas_price)
     }
+
+    async fn estimate_eip1559_fees(&self) -> Result<(U256, U256), GasOracleError> {
+        Err(GasOracleError::Eip1559EstimationNotSupported)
+    }
 }

--- a/ethers-middleware/src/gas_oracle/etherchain.rs
+++ b/ethers-middleware/src/gas_oracle/etherchain.rs
@@ -77,4 +77,8 @@ impl GasOracle for Etherchain {
 
         Ok(gas_price)
     }
+
+    async fn estimate_eip1559_fees(&self) -> Result<(U256, U256), GasOracleError> {
+        Err(GasOracleError::Eip1559EstimationNotSupported)
+    }
 }

--- a/ethers-middleware/src/gas_oracle/etherscan.rs
+++ b/ethers-middleware/src/gas_oracle/etherscan.rs
@@ -84,4 +84,8 @@ impl GasOracle for Etherscan {
             _ => Err(GasOracleError::GasCategoryNotSupported),
         }
     }
+
+    async fn estimate_eip1559_fees(&self) -> Result<(U256, U256), GasOracleError> {
+        Err(GasOracleError::Eip1559EstimationNotSupported)
+    }
 }

--- a/ethers-middleware/src/gas_oracle/gas_now.rs
+++ b/ethers-middleware/src/gas_oracle/gas_now.rs
@@ -77,4 +77,8 @@ impl GasOracle for GasNow {
 
         Ok(gas_price)
     }
+
+    async fn estimate_eip1559_fees(&self) -> Result<(U256, U256), GasOracleError> {
+        Err(GasOracleError::Eip1559EstimationNotSupported)
+    }
 }

--- a/ethers-middleware/src/gas_oracle/mod.rs
+++ b/ethers-middleware/src/gas_oracle/mod.rs
@@ -42,6 +42,9 @@ pub enum GasOracleError {
     /// supported by the gas oracle API
     #[error("gas category not supported")]
     GasCategoryNotSupported,
+
+    #[error("EIP-1559 gas estimation not supported")]
+    Eip1559EstimationNotSupported,
 }
 
 /// `GasOracle` is a trait that an underlying gas oracle needs to implement.
@@ -80,4 +83,6 @@ pub trait GasOracle: Send + Sync + std::fmt::Debug {
     /// # }
     /// ```
     async fn fetch(&self) -> Result<U256, GasOracleError>;
+
+    async fn estimate_eip1559_fees(&self) -> Result<(U256, U256), GasOracleError>;
 }

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -265,15 +265,18 @@ pub trait Middleware: Sync + Send + Debug {
                     inner.from = self.default_sender();
                 }
 
-                let (max_priority_fee_per_gas, max_fee_per_gas, gas) = futures_util::try_join!(
-                    // TODO: Replace with algorithms using eth_feeHistory
-                    maybe(inner.max_priority_fee_per_gas, self.get_gas_price()),
-                    maybe(inner.max_fee_per_gas, self.get_gas_price()),
-                    maybe(inner.gas, self.estimate_gas(&tx_clone)),
-                )?;
+                let gas = maybe(inner.gas, self.estimate_gas(&tx_clone)).await?;
                 inner.gas = Some(gas);
-                inner.max_fee_per_gas = Some(max_fee_per_gas);
-                inner.max_priority_fee_per_gas = Some(max_priority_fee_per_gas);
+
+                if inner.max_fee_per_gas.is_none() || inner.max_priority_fee_per_gas.is_none() {
+                    let (max_fee_per_gas, max_priority_fee_per_gas) = self.estimate_eip1559_fees(None).await?;
+                    if inner.max_fee_per_gas.is_none() {
+                        inner.max_fee_per_gas = Some(max_fee_per_gas);
+                    }
+                    if inner.max_priority_fee_per_gas.is_none() {
+                        inner.max_priority_fee_per_gas = Some(max_priority_fee_per_gas);
+                    }
+                }
             }
         };
 
@@ -399,6 +402,16 @@ pub trait Middleware: Sync + Send + Debug {
 
     async fn get_gas_price(&self) -> Result<U256, Self::Error> {
         self.inner().get_gas_price().await.map_err(FromErr::from)
+    }
+
+    async fn estimate_eip1559_fees(
+        &self,
+        estimator: Option<fn(U256, Vec<Vec<U256>>) -> (U256, U256)>,
+    ) -> Result<(U256, U256), Self::Error> {
+        self.inner()
+            .estimate_eip1559_fees(estimator)
+            .await
+            .map_err(FromErr::from)
     }
 
     async fn get_accounts(&self) -> Result<Vec<Address>, Self::Error> {

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -269,7 +269,8 @@ pub trait Middleware: Sync + Send + Debug {
                 inner.gas = Some(gas);
 
                 if inner.max_fee_per_gas.is_none() || inner.max_priority_fee_per_gas.is_none() {
-                    let (max_fee_per_gas, max_priority_fee_per_gas) = self.estimate_eip1559_fees(None).await?;
+                    let (max_fee_per_gas, max_priority_fee_per_gas) =
+                        self.estimate_eip1559_fees(None).await?;
                     if inner.max_fee_per_gas.is_none() {
                         inner.max_fee_per_gas = Some(max_fee_per_gas);
                     }

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -261,6 +261,35 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.request("eth_gasPrice", ()).await
     }
 
+    /// Gets a heuristic recommendation of max fee per gas and max priority fee per gas for
+    /// EIP-1559 compatible transactions.
+    async fn estimate_eip1559_fees(
+        &self,
+        estimator: Option<fn(U256, Vec<Vec<U256>>) -> (U256, U256)>,
+    ) -> Result<(U256, U256), Self::Error> {
+        let base_fee_per_gas = self
+            .get_block(BlockNumber::Latest)
+            .await?
+            .ok_or(ProviderError::CustomError("Latest block not found".into()))?
+            .base_fee_per_gas
+            .ok_or(ProviderError::CustomError("EIP-1559 not activated".into()))?;
+        let fee_history = self
+            .fee_history(
+                utils::EIP1559_FEE_ESTIMATION_PAST_BLOCKS,
+                BlockNumber::Latest,
+                &[utils::EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE],
+            )
+            .await?;
+
+        let (max_fee_per_gas, max_priority_fee_per_gas) = if estimator.is_some() {
+            estimator.unwrap()(base_fee_per_gas, fee_history.reward)
+        } else {
+            utils::eip1559_default_estimator(base_fee_per_gas, fee_history.reward)
+        };
+
+        Ok((max_fee_per_gas, max_priority_fee_per_gas))
+    }
+
     /// Gets the accounts on the node
     async fn get_accounts(&self) -> Result<Vec<Address>, ProviderError> {
         self.request("eth_accounts", ()).await

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -273,6 +273,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
             .ok_or_else(|| ProviderError::CustomError("Latest block not found".into()))?
             .base_fee_per_gas
             .ok_or_else(|| ProviderError::CustomError("EIP-1559 not activated".into()))?;
+
         let fee_history = self
             .fee_history(
                 utils::EIP1559_FEE_ESTIMATION_PAST_BLOCKS,

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -282,6 +282,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
             )
             .await?;
 
+        // use the provided fee estimator function, or fallback to the default implementation.
         let (max_fee_per_gas, max_priority_fee_per_gas) = if let Some(es) = estimator {
             es(base_fee_per_gas, fee_history.reward)
         } else {

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -199,6 +199,17 @@ mod eth_tests {
             .into();
         check_tx(&provider, tx, 2).await;
     }
+
+    #[tokio::test]
+    async fn eip1559_fee_estimation() {
+        let provider = Provider::<Http>::try_from(
+            "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27",
+        )
+        .unwrap();
+
+        let (_max_fee_per_gas, _max_priority_fee_per_gas) =
+            provider.estimate_eip1559_fees(None).await.unwrap();
+    }
 }
 
 #[cfg(feature = "celo")]

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -207,8 +207,10 @@ mod eth_tests {
         )
         .unwrap();
 
-        let (_max_fee_per_gas, _max_priority_fee_per_gas) =
+        let (max_fee_per_gas, max_priority_fee_per_gas) =
             provider.estimate_eip1559_fees(None).await.unwrap();
+        dbg!(max_fee_per_gas);
+        dbg!(max_priority_fee_per_gas);
     }
 }
 

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -207,10 +207,8 @@ mod eth_tests {
         )
         .unwrap();
 
-        let (max_fee_per_gas, max_priority_fee_per_gas) =
+        let (_max_fee_per_gas, _max_priority_fee_per_gas) =
             provider.estimate_eip1559_fees(None).await.unwrap();
-        dbg!(max_fee_per_gas);
-        dbg!(max_priority_fee_per_gas);
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fee estimation/recommendation not available for EIP-1559 type transactions

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Default estimator is a port of [this](https://github.com/MyCryptoHQ/MyCrypto/blob/master/src/services/ApiService/Gas/eip1559.ts)

* Add `estimate_eip1559_fees` method to `Middleware` and implement in the `JsonRpcProvider`
* I believe none of the Gas oracle APIs support EIP-1559 fee recommendation (so that's simply an Err at the moment)
* Ethers-rs users can even provide their own `fn` to estimate fees using the `base_fee_per_gas` and `fee_history.reward`