### PR TITLE
Support multiple addresses in filters

### DIFF
--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use ethers_core::{
     abi::{Abi, Detokenize, Error, EventExt, Function, Tokenize},
-    types::{Address, Filter, NameOrAddress, Selector},
+    types::{Address, Filter, ValueOrArray, NameOrAddress, Selector},
 };
 
 #[cfg(not(feature = "legacy"))]
@@ -178,7 +178,7 @@ impl<M: Middleware> Contract<M> {
     pub fn event_with_filter<D: EthLogDecode>(&self, filter: Filter) -> Event<M, D> {
         Event {
             provider: &self.client,
-            filter: filter.address(self.address),
+            filter: filter.address(ValueOrArray::Value(self.address)),
             datatype: PhantomData,
         }
     }

--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -1,4 +1,4 @@
-use ethers::{contract::ContractFactory, types::H256};
+use ethers::{contract::ContractFactory, types::{H256, ValueOrArray, Filter}};
 
 mod common;
 pub use common::*;
@@ -336,6 +336,38 @@ mod eth_tests {
                 .unwrap();
             assert_eq!(meta.block_hash, hash);
         }
+    }
+
+    #[tokio::test]
+    async fn watch_subscription_events_multiple_addresses() {
+        let (abi, bytecode) = compile_contract("SimpleStorage", "SimpleStorage.sol");
+        let ganache = Ganache::new().spawn();
+        let client = connect(&ganache, 0);
+        let contract_1 = deploy(client.clone(), abi.clone(), bytecode.clone()).await;
+        let contract_2 = deploy(client.clone(), abi.clone(), bytecode).await;
+
+        let ws = Provider::connect(ganache.ws_endpoint()).await.unwrap();
+        let filter = Filter::new().address(ValueOrArray::Array(vec!(contract_1.address(), contract_2.address())));
+        let mut stream = ws.subscribe_logs(&filter).await.unwrap();
+    
+        // and we make a few calls
+        let call = contract_1
+            .method::<_, H256>("setValue", "1".to_string())
+            .unwrap();
+        let pending_tx = call.send().await.unwrap();
+        let _receipt = pending_tx.await.unwrap();
+
+        let call = contract_2
+            .method::<_, H256>("setValue", "2".to_string())
+            .unwrap();
+        let pending_tx = call.send().await.unwrap();
+        let _receipt = pending_tx.await.unwrap();
+
+        // unwrap the option of the stream, then unwrap the decoding result
+        let log_1 = stream.next().await.unwrap();
+        let log_2 = stream.next().await.unwrap();
+        assert_eq!(log_1.address, contract_1.address());
+        assert_eq!(log_2.address, contract_2.address());
     }
 
     #[tokio::test]

--- a/ethers-core/src/types/log.rs
+++ b/ethers-core/src/types/log.rs
@@ -181,9 +181,7 @@ pub struct Filter {
     pub block_option: FilterBlockOption,
 
     /// Address
-    // TODO: The spec says that this can also be an array, do we really want to
-    // monitor for the same event for multiple contracts?
-    address: Option<Address>,
+    address: Option<ValueOrArray<Address>>,
 
     /// Topics
     // TODO: We could improve the low level API here by using ethabi's RawTopicFilter
@@ -331,7 +329,7 @@ impl Filter {
         self
     }
 
-    pub fn address<T: Into<Address>>(mut self, address: T) -> Self {
+    pub fn address<T: Into<ValueOrArray<Address>>>(mut self, address: T) -> Self {
         self.address = Some(address.into());
         self
     }
@@ -449,7 +447,7 @@ mod tests {
         let ser = serialize(&filter);
         assert_eq!(ser, json!({ "topics": [] }));
 
-        let filter = filter.address(addr);
+        let filter = filter.address(ValueOrArray::Value(addr));
 
         let ser = serialize(&filter);
         assert_eq!(ser, json!({"address" : addr, "topics": []}));


### PR DESCRIPTION
## Motivation

According to the [ETH Wiki](https://eth.wiki/json-rpc/API#eth_newfilter) a filter should be able to define a contract address or a list of addresses from which logs should originate. The current state allows to define only one single address. 

## Solution

I added the `ValueOrArray` enum to the Log types and refactored some `ethers-contract` code with the mentioned enum.
To check the replacements there is also a new integration test in the `ethers-contract` package, that will deploy multiple contracts and check if the logs that originate are from the corresponding addresses.
