### PR TITLE
add impl_fixed_types!(18) (fixes opensea abigen)

### DIFF
--- a/ethers-core/src/abi/tokens.rs
+++ b/ethers-core/src/abi/tokens.rs
@@ -463,6 +463,7 @@ impl_fixed_types!(13);
 impl_fixed_types!(14);
 impl_fixed_types!(15);
 impl_fixed_types!(16);
+impl_fixed_types!(18);
 impl_fixed_types!(32);
 impl_fixed_types!(64);
 impl_fixed_types!(128);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
crash when abigen for opensea contract- 

```
3 | abigen!(WyvernExchange, "etherscan:0x7be8076f4ea4a4ad08075c2508e481d6c946d12b");
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tokenizable` is not implemented for `[U256; 18]
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
add `impl_fixed_types!(18)`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
