### PR TITLE
fix: make gasPrice optional (since Type 2 transactions)

### DIFF
--- a/ethers-core/src/types/transaction/response.rs
+++ b/ethers-core/src/types/transaction/response.rs
@@ -41,13 +41,9 @@ pub struct Transaction {
     /// Transfered value
     pub value: U256,
 
-    /// Gas Price
+    /// Gas Price, null for Type 2 transactions
     #[serde(rename = "gasPrice")]
-    // TODO: Should this be deprecated?
-    // https://twitter.com/TimBeiko/status/1413536062429794304
-    // If yes, how will we handle pre-calculating the transaction's hash keccak256(rlp(tx)),
-    // given that it contains the gas price?
-    pub gas_price: U256,
+    pub gas_price: Option<U256>,
 
     /// Gas amount
     pub gas: U256,
@@ -123,6 +119,9 @@ pub struct Transaction {
     /// Represents the maximum amount that a user is willing to pay for their tx (inclusive of baseFeePerGas and maxPriorityFeePerGas).
     /// The difference between maxFeePerGas and baseFeePerGas + maxPriorityFeePerGas is “refunded” to the user.
     pub max_fee_per_gas: Option<U256>,
+
+    #[serde(rename = "chainId", default, skip_serializing_if = "Option::is_none")]
+    pub chain_id: Option<U256>,
 }
 
 impl Transaction {

--- a/ethers-middleware/tests/gas_oracle.rs
+++ b/ethers-middleware/tests/gas_oracle.rs
@@ -28,7 +28,7 @@ async fn using_gas_oracle() {
     let tx_hash = provider.send_transaction(tx, None).await.unwrap();
 
     let tx = provider.get_transaction(*tx_hash).await.unwrap().unwrap();
-    assert_eq!(tx.gas_price, expected_gas_price);
+    assert_eq!(tx.gas_price, Some(expected_gas_price));
 }
 
 #[tokio::test]

--- a/ethers-middleware/tests/nonce_manager.rs
+++ b/ethers-middleware/tests/nonce_manager.rs
@@ -35,7 +35,10 @@ async fn nonce_manager() {
     let mut tx_hashes = Vec::new();
     for _ in 0..10 {
         let tx = provider
-            .send_transaction(TransactionRequest::pay(address, 100u64), None)
+            .send_transaction(
+                Eip1559TransactionRequest::new().to(address).value(100u64),
+                None,
+            )
             .await
             .unwrap();
         tx_hashes.push(*tx);

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -159,7 +159,7 @@ mod eth_tests {
         .unwrap();
 
         let chain_id = provider.get_chainid().await.unwrap();
-        let wallet = "59c37cb6b16fa2de30675f034c8008f890f4b2696c729d6267946d29736d73e4"
+        let wallet = "87203087aed9246e0b2417e248752a1a0df4fdaf65085c11a2b48087ba036b41"
             .parse::<LocalWallet>()
             .unwrap()
             .with_chain_id(chain_id.as_u64());


### PR DESCRIPTION
* Gas Price is now Optional for Type 2 transactions
* Adds `chain_id` to the `Transaction`