### PR TITLE
fix: signature fields should be U256 instead of H256

### DIFF
--- a/ethers-signers/src/aws/utils.rs
+++ b/ethers-signers/src/aws/utils.rs
@@ -13,7 +13,7 @@ use ethers_core::{
         elliptic_curve::sec1::ToEncodedPoint,
         FieldBytes,
     },
-    types::{Address, Signature as EthSig, H256},
+    types::{Address, Signature as EthSig, U256},
     utils::keccak256,
 };
 use rusoto_kms::{GetPublicKeyResponse, SignResponse};
@@ -26,8 +26,8 @@ pub(super) fn rsig_to_ethsig(sig: &RSig) -> EthSig {
     let v = (v + 27) as u64;
     let r_bytes: FieldBytes = sig.r().into();
     let s_bytes: FieldBytes = sig.s().into();
-    let r = H256::from_slice(&r_bytes.as_slice());
-    let s = H256::from_slice(&s_bytes.as_slice());
+    let r = U256::from_big_endian(&r_bytes.as_slice());
+    let s = U256::from_big_endian(&s_bytes.as_slice());
     EthSig { r, s, v }
 }
 

--- a/ethers-signers/src/ledger/app.rs
+++ b/ethers-signers/src/ledger/app.rs
@@ -170,8 +170,8 @@ impl LedgerEthereum {
         }
 
         let v = result[0] as u64;
-        let r = H256::from_slice(&result[1..33]);
-        let s = H256::from_slice(&result[33..]);
+        let r = U256::from_big_endian(&result[1..33]);
+        let s = U256::from_big_endian(&result[33..]);
         Ok(Signature { r, s, v })
     }
 

--- a/ethers-signers/src/wallet/mod.rs
+++ b/ethers-signers/src/wallet/mod.rs
@@ -16,7 +16,7 @@ use ethers_core::{
         elliptic_curve::FieldBytes,
         Secp256k1,
     },
-    types::{transaction::eip2718::TypedTransaction, Address, Signature, H256},
+    types::{transaction::eip2718::TypedTransaction, Address, Signature, H256, U256},
     utils::hash_message,
 };
 use hash::Sha256Proxy;
@@ -116,8 +116,8 @@ impl<D: DigestSigner<Sha256Proxy, RecoverableSignature>> Wallet<D> {
 
         let r_bytes: FieldBytes<Secp256k1> = recoverable_sig.r().into();
         let s_bytes: FieldBytes<Secp256k1> = recoverable_sig.s().into();
-        let r = H256::from_slice(r_bytes.as_slice());
-        let s = H256::from_slice(s_bytes.as_slice());
+        let r = U256::from_big_endian(r_bytes.as_slice());
+        let s = U256::from_big_endian(s_bytes.as_slice());
 
         Signature { r, s, v }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

PR to fix #377 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

`r` and `s` fields in `Signature` changed from `H256` to `U256`