### PR TITLE
bugfix: disable type serialization when legacy feature is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "arrayvec 0.7.1",
  "bincode",

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ethers-core"
 license = "MIT OR Apache-2.0"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"
 description = "Core structures for the ethers-rs crate"

--- a/ethers-core/src/types/transaction/eip2718.rs
+++ b/ethers-core/src/types/transaction/eip2718.rs
@@ -5,8 +5,21 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
+/// The TypedTransaction enum represents all Ethereum transaction types.
+///
+/// Its variants correspond to specific allowed transactions:
+/// 1. Legacy (pre-EIP2718) [`TransactionRequest`]
+/// 2. EIP2930 (state access lists) [`Eip2930TransactionRequest`]
+/// 3. EIP1559 [`Eip1559TransactionRequest`]
+///
+/// To support Kovan and other non-London-compatbile networks, please enable
+/// the `legacy` crate feature. This will disable the `type` flag in the
+/// serialized transaction, and cause contract calls and other common actions
+/// to default to using the legacy transaction type.
+///
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
-#[serde(tag = "type")]
+#[cfg_attr(not(feature = "legacy"), serde(tag = "type"))]
+#[cfg_attr(feature = "legacy", serde(untagged))]
 pub enum TypedTransaction {
     // 0x00
     #[serde(rename = "0x00")]


### PR DESCRIPTION
- Updated the `TypedTransaction` serde flags to skip serializing the tx type if the `legacy` feature is set
- bumps `ethers-core` to 0.4.7
- adds rustdoc to `TypedTransaction`

this _should_ fix recent problems with view calls and gas estimations on kovan