### PR TITLE
fix: skip 2930 tests in legacy mode / skip aws test if no id

### DIFF
--- a/ethers-core/src/types/transaction/eip2930.rs
+++ b/ethers-core/src/types/transaction/eip2930.rs
@@ -127,6 +127,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "legacy", ignore)]
     fn serde_eip2930_tx() {
         let access_list = vec![AccessListItem {
             address: Address::zero(),

--- a/ethers-signers/src/aws/mod.rs
+++ b/ethers-signers/src/aws/mod.rs
@@ -301,7 +301,10 @@ mod tests {
     #[tokio::test]
     async fn it_signs_messages() {
         let chain_id = 1;
-        let key_id = std::env::var("AWS_KEY_ID").expect("no key id");
+        let key_id = match std::env::var("AWS_KEY_ID") {
+            Ok(id) => id,
+            _ => return,
+        };
         setup_tracing();
         let client = env_client();
         let signer = AwsSigner::new(&client, key_id, chain_id).await.unwrap();


### PR DESCRIPTION
The latest legacy compat PRs #384 #383 somehow got the `--all-features` CI workflow working again. Attempt at fixing one of its falling tests.