### PR TITLE
bug: log streams properly end when internal stream closes

### DIFF
--- a/ethers-contract/src/stream.rs
+++ b/ethers-contract/src/stream.rs
@@ -65,7 +65,7 @@ where
                 let res = res.map(|inner| (inner, meta));
                 Poll::Ready(Some(res))
             }
-            None => Poll::Pending,
+            None => Poll::Ready(None),
         }
     }
 }


### PR DESCRIPTION
Changes `<EventStream as Stream>::poll_next` to properly end the stream when the internal stream ends

Need to consider, how do we pass permanent/temporary failures from `Provider` -> `FilterWatcher` -> `EventStream`