### PR TITLE
feat: improve gas oracles

### DIFF
--- a/ethers-middleware/src/gas_oracle/eth_gas_station.rs
+++ b/ethers-middleware/src/gas_oracle/eth_gas_station.rs
@@ -13,14 +13,14 @@ const ETH_GAS_STATION_URL_PREFIX: &str = "https://ethgasstation.info/api/ethgasA
 
 /// A client over HTTP for the [EthGasStation](https://ethgasstation.info/api/ethgasAPI.json) gas tracker API
 /// that implements the `GasOracle` trait
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct EthGasStation {
     client: Client,
     url: Url,
     gas_category: GasCategory,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 /// Eth Gas Station's response for the current recommended fast, standard and
 /// safe low gas prices on the Ethereum network, along with the current block

--- a/ethers-middleware/src/gas_oracle/eth_gas_station.rs
+++ b/ethers-middleware/src/gas_oracle/eth_gas_station.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use ethers_core::types::U256;
 
 use async_trait::async_trait;
@@ -18,13 +20,43 @@ pub struct EthGasStation {
     gas_category: GasCategory,
 }
 
-#[derive(Deserialize)]
-struct EthGasStationResponse {
-    #[serde(rename = "safeLow")]
-    safe_low: f64,
-    average: u64,
-    fast: u64,
-    fastest: u64,
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+/// Eth Gas Station's response for the current recommended fast, standard and
+/// safe low gas prices on the Ethereum network, along with the current block
+/// and wait times for each "speed".
+pub struct EthGasStationResponse {
+    /// Recommended safe(expected to be mined in < 30 minutes) gas price in
+    /// x10 Gwei (divide by 10 to convert it to gwei)
+    pub safe_low: f64,
+    /// Recommended average(expected to be mined in < 5 minutes) gas price in
+    /// x10 Gwei (divide by 10 to convert it to gwei)
+    pub average: u64,
+    /// Recommended fast(expected to be mined in < 2 minutes) gas price in
+    /// x10 Gwei (divide by 10 to convert it to gwei)
+    pub fast: u64,
+    /// Recommended fastest(expected to be mined in < 30 seconds) gas price
+    /// in x10 Gwei(divide by 10 to convert it to gwei)
+    pub fastest: u64,
+
+    // post eip-1559 fields
+    #[serde(rename = "block_time")] // inconsistent json response naming...
+    /// Average time(in seconds) to mine one single block
+    pub block_time: f64,
+    /// The latest block number
+    pub block_num: u64,
+    /// Smallest value of (gasUsed / gaslimit) from last 10 blocks
+    pub speed: f64,
+    /// Waiting time(in minutes) for the `safe_low` gas price
+    pub safe_low_wait: f64,
+    /// Waiting time(in minutes) for the `average` gas price
+    pub avg_wait: f64,
+    /// Waiting time(in minutes) for the `fast` gas price
+    pub fast_wait: f64,
+    /// Waiting time(in minutes) for the `fastest` gas price
+    pub fastest_wait: f64,
+    // What is this?
+    pub gas_price_range: HashMap<u64, f64>,
 }
 
 impl EthGasStation {

--- a/ethers-middleware/src/gas_oracle/etherchain.rs
+++ b/ethers-middleware/src/gas_oracle/etherchain.rs
@@ -3,7 +3,6 @@ use ethers_core::types::U256;
 use async_trait::async_trait;
 use reqwest::Client;
 use serde::Deserialize;
-use serde_aux::prelude::*;
 use url::Url;
 
 use crate::gas_oracle::{GasCategory, GasOracle, GasOracleError, GWEI_TO_WEI};
@@ -26,16 +25,14 @@ impl Default for Etherchain {
 }
 
 #[derive(Deserialize)]
-struct EtherchainResponse {
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    #[serde(rename = "safeLow")]
-    safe_low: f32,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    standard: f32,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    fast: f32,
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    fastest: f32,
+#[serde(rename_all = "camelCase")]
+pub struct EtherchainResponse {
+    pub safe_low: f32,
+    pub standard: f32,
+    pub fast: f32,
+    pub fastest: f32,
+    pub current_base_fee: f32,
+    pub recommended_base_fee: f32,
 }
 
 impl Etherchain {
@@ -55,19 +52,22 @@ impl Etherchain {
         self.gas_category = gas_category;
         self
     }
-}
 
-#[async_trait]
-impl GasOracle for Etherchain {
-    async fn fetch(&self) -> Result<U256, GasOracleError> {
-        let res = self
+    pub async fn query(&self) -> Result<EtherchainResponse, GasOracleError> {
+        Ok(self
             .client
             .get(self.url.as_ref())
             .send()
             .await?
             .json::<EtherchainResponse>()
-            .await?;
+            .await?)
+    }
+}
 
+#[async_trait]
+impl GasOracle for Etherchain {
+    async fn fetch(&self) -> Result<U256, GasOracleError> {
+        let res = self.query().await?;
         let gas_price = match self.gas_category {
             GasCategory::SafeLow => U256::from((res.safe_low as u64) * GWEI_TO_WEI),
             GasCategory::Standard => U256::from((res.standard as u64) * GWEI_TO_WEI),

--- a/ethers-middleware/src/gas_oracle/etherchain.rs
+++ b/ethers-middleware/src/gas_oracle/etherchain.rs
@@ -11,7 +11,7 @@ const ETHERCHAIN_URL: &str = "https://www.etherchain.org/api/gasPriceOracle";
 
 /// A client over HTTP for the [Etherchain](https://www.etherchain.org/api/gasPriceOracle) gas tracker API
 /// that implements the `GasOracle` trait
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Etherchain {
     client: Client,
     url: Url,
@@ -24,7 +24,7 @@ impl Default for Etherchain {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd)]
 #[serde(rename_all = "camelCase")]
 pub struct EtherchainResponse {
     pub safe_low: f32,

--- a/ethers-middleware/src/gas_oracle/etherscan.rs
+++ b/ethers-middleware/src/gas_oracle/etherscan.rs
@@ -13,7 +13,7 @@ const ETHERSCAN_URL_PREFIX: &str =
 
 /// A client over HTTP for the [Etherscan](https://api.etherscan.io/api?module=gastracker&action=gasoracle) gas tracker API
 /// that implements the `GasOracle` trait
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Etherscan {
     client: Client,
     url: Url,
@@ -25,7 +25,7 @@ struct EtherscanResponseWrapper {
     result: EtherscanResponse,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd)]
 #[serde(rename_all = "PascalCase")]
 pub struct EtherscanResponse {
     #[serde(deserialize_with = "deserialize_number_from_string")]

--- a/ethers-middleware/src/gas_oracle/etherscan.rs
+++ b/ethers-middleware/src/gas_oracle/etherscan.rs
@@ -21,21 +21,40 @@ pub struct Etherscan {
 }
 
 #[derive(Deserialize)]
-struct EtherscanResponse {
-    result: EtherscanResponseInner,
+struct EtherscanResponseWrapper {
+    result: EtherscanResponse,
 }
 
 #[derive(Deserialize)]
-struct EtherscanResponseInner {
+#[serde(rename_all = "PascalCase")]
+pub struct EtherscanResponse {
     #[serde(deserialize_with = "deserialize_number_from_string")]
-    #[serde(rename = "SafeGasPrice")]
-    safe_gas_price: u64,
+    pub safe_gas_price: u64,
     #[serde(deserialize_with = "deserialize_number_from_string")]
-    #[serde(rename = "ProposeGasPrice")]
-    propose_gas_price: u64,
+    pub propose_gas_price: u64,
     #[serde(deserialize_with = "deserialize_number_from_string")]
-    #[serde(rename = "FastGasPrice")]
-    fast_gas_price: u64,
+    pub fast_gas_price: u64,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub last_block: u64,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    #[serde(rename = "suggestBaseFee")]
+    pub suggested_base_fee: f64,
+    #[serde(deserialize_with = "deserialize_f64_vec")]
+    #[serde(rename = "gasUsedRatio")]
+    pub gas_used_ratio: Vec<f64>,
+}
+
+use serde::de;
+use std::str::FromStr;
+fn deserialize_f64_vec<'de, D>(deserializer: D) -> Result<Vec<f64>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    let str_sequence = String::deserialize(deserializer)?;
+    str_sequence
+        .split(',')
+        .map(|item| f64::from_str(item).map_err(|err| de::Error::custom(err.to_string())))
+        .collect()
 }
 
 impl Etherscan {
@@ -60,6 +79,17 @@ impl Etherscan {
         self.gas_category = gas_category;
         self
     }
+
+    pub async fn query(&self) -> Result<EtherscanResponse, GasOracleError> {
+        let res = self
+            .client
+            .get(self.url.as_ref())
+            .send()
+            .await?
+            .json::<EtherscanResponseWrapper>()
+            .await?;
+        Ok(res.result)
+    }
 }
 
 #[async_trait]
@@ -69,18 +99,12 @@ impl GasOracle for Etherscan {
             return Err(GasOracleError::GasCategoryNotSupported);
         }
 
-        let res = self
-            .client
-            .get(self.url.as_ref())
-            .send()
-            .await?
-            .json::<EtherscanResponse>()
-            .await?;
+        let res = self.query().await?;
 
         match self.gas_category {
-            GasCategory::SafeLow => Ok(U256::from(res.result.safe_gas_price * GWEI_TO_WEI)),
-            GasCategory::Standard => Ok(U256::from(res.result.propose_gas_price * GWEI_TO_WEI)),
-            GasCategory::Fast => Ok(U256::from(res.result.fast_gas_price * GWEI_TO_WEI)),
+            GasCategory::SafeLow => Ok(U256::from(res.safe_gas_price * GWEI_TO_WEI)),
+            GasCategory::Standard => Ok(U256::from(res.propose_gas_price * GWEI_TO_WEI)),
+            GasCategory::Fast => Ok(U256::from(res.fast_gas_price * GWEI_TO_WEI)),
             _ => Err(GasOracleError::GasCategoryNotSupported),
         }
     }

--- a/ethers-middleware/tests/gas_oracle.rs
+++ b/ethers-middleware/tests/gas_oracle.rs
@@ -32,7 +32,6 @@ async fn using_gas_oracle() {
 }
 
 #[tokio::test]
-#[ignore]
 // TODO: Re-enable, EthGasStation changed its response api @ https://ethgasstation.info/api/ethgasAPI.json
 async fn eth_gas_station() {
     // initialize and fetch gas estimates from EthGasStation

--- a/ethers-middleware/tests/gas_oracle.rs
+++ b/ethers-middleware/tests/gas_oracle.rs
@@ -32,7 +32,6 @@ async fn using_gas_oracle() {
 }
 
 #[tokio::test]
-// TODO: Re-enable, EthGasStation changed its response api @ https://ethgasstation.info/api/ethgasAPI.json
 async fn eth_gas_station() {
     // initialize and fetch gas estimates from EthGasStation
     let eth_gas_station_oracle = EthGasStation::new(None);
@@ -59,9 +58,6 @@ async fn etherscan() {
 }
 
 #[tokio::test]
-#[ignore]
-// TODO: Etherchain has Cloudflare DDOS protection which makes the request fail
-// https://twitter.com/gakonst/status/1421796226316578816
 async fn etherchain() {
     // initialize and fetch gas estimates from Etherchain
     let etherchain_oracle = Etherchain::new().category(GasCategory::Fast);


### PR DESCRIPTION
A bunch of fields have been added to gas oracles since EIP-1559. This PR introduces them, as well as re-enables any of the previously ignored tests.