### PR TITLE
chore: disable all ethers features by default and expose them individually

### DIFF
--- a/ethers/Cargo.toml
+++ b/ethers/Cargo.toml
@@ -29,21 +29,35 @@ celo = [
     "legacy"
 ]
 
-legacy = ["ethers-core/legacy", "ethers-contract/legacy"]
+legacy = [
+    "ethers-core/legacy",
+    "ethers-contract/legacy"
+]
+
+# individual features per sub-crate
+## core
+setup = ["ethers-core/setup"]
+## providers
+ws = ["ethers-providers/ws"]
+ipc = ["ethers-providers/ipc"]
+rustls = ["ethers-providers/rustls"]
+openssl = ["ethers-providers/openssl"]
+## signers
 ledger = ["ethers-signers/ledger"]
 yubi = ["ethers-signers/yubi"]
-ws = ["ethers-providers/ws"]
+## contracts
 abigen = ["ethers-contract/abigen"]
 
+
 [dependencies]
-ethers-contract = { version = "0.4.7", path = "../ethers-contract" }
-ethers-core = { version = "0.4.8", path = "../ethers-core", features = ["setup"] }
-ethers-providers = { version = "0.4.6", path = "../ethers-providers" }
-ethers-signers = { version = "0.4.6", path = "../ethers-signers" }
-ethers-middleware = { version = "0.4.8", path = "../ethers-middleware" }
+ethers-contract = { version = "0.4.7", default-features = false, path = "../ethers-contract" }
+ethers-core = { version = "0.4.8", default-features = false, path = "../ethers-core", features = ["setup"] }
+ethers-providers = { version = "0.4.6", default-features = false, path = "../ethers-providers" }
+ethers-signers = { version = "0.4.6", default-features = false, path = "../ethers-signers" }
+ethers-middleware = { version = "0.4.8", default-features = false, path = "../ethers-middleware" }
 
 [dev-dependencies]
-ethers-contract = { version = "0.4.7", path = "../ethers-contract", features = ["abigen"] }
+ethers-contract = { version = "0.4.7", default-features = false, path = "../ethers-contract", features = ["abigen"] }
 
 anyhow = "1.0.39"
 rand = "0.8.4"


### PR DESCRIPTION
Fixes #393 

# Problem

We were bundling deps with `default` features in the `ethers` crate. This meant that IPC was getting included, which does not exist in windows.

# Fix

We disable all default features by default in `ethers` and expose individual feature flags for each.