### PR TITLE
fix: backwards compatibility for eth_feeHistory

### DIFF
--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -84,8 +84,8 @@ pub use pubsub::{PubsubClient, SubscriptionStream};
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use ethers_core::types::transaction::{eip2718::TypedTransaction, eip2930::AccessListWithGasUsed};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{error::Error, fmt::Debug, future::Future, pin::Pin};
+use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
+use std::{error::Error, fmt::Debug, future::Future, pin::Pin, str::FromStr};
 
 pub use provider::{FilterKind, Provider, ProviderError};
 
@@ -706,7 +706,7 @@ pub trait Middleware: Sync + Send + Debug {
 
     async fn fee_history(
         &self,
-        block_count: u64,
+        block_count: U256,
         last_block: BlockNumber,
         reward_percentiles: &[f64],
     ) -> Result<FeeHistory, Self::Error> {
@@ -733,8 +733,29 @@ pub trait Middleware: Sync + Send + Debug {
 pub struct FeeHistory {
     pub base_fee_per_gas: Vec<U256>,
     pub gas_used_ratio: Vec<f64>,
-    pub oldest_block: u64,
+    #[serde(deserialize_with = "from_int_or_hex")]
+    /// oldestBlock is returned as an unsigned integer up to geth v1.10.6. From
+    /// geth v1.10.7, this has been updated to return in the hex encoded form.
+    /// The custom deserializer allows backward compatibility for those clients
+    /// not running v1.10.7 yet.
+    pub oldest_block: U256,
     pub reward: Vec<Vec<U256>>,
+}
+
+fn from_int_or_hex<'de, D>(deserializer: D) -> Result<U256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum IntOrHex {
+        Int(u64),
+        Hex(String),
+    }
+    match IntOrHex::deserialize(deserializer)? {
+        IntOrHex::Int(n) => Ok(U256::from(n)),
+        IntOrHex::Hex(s) => U256::from_str(s.as_str()).map_err(serde::de::Error::custom),
+    }
 }
 
 #[cfg(feature = "celo")]

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -704,9 +704,9 @@ pub trait Middleware: Sync + Send + Debug {
             .map_err(FromErr::from)
     }
 
-    async fn fee_history(
+    async fn fee_history<T: Into<U256> + serde::Serialize + Send + Sync>(
         &self,
-        block_count: U256,
+        block_count: T,
         last_block: BlockNumber,
         reward_percentiles: &[f64],
     ) -> Result<FeeHistory, Self::Error> {

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -317,7 +317,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
 
         let fee_history = self
             .fee_history(
-                utils::EIP1559_FEE_ESTIMATION_PAST_BLOCKS,
+                U256::from(utils::EIP1559_FEE_ESTIMATION_PAST_BLOCKS),
                 BlockNumber::Latest,
                 &[utils::EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE],
             )
@@ -771,18 +771,35 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
 
     async fn fee_history(
         &self,
-        block_count: u64,
+        block_count: U256,
         last_block: BlockNumber,
         reward_percentiles: &[f64],
     ) -> Result<FeeHistory, Self::Error> {
-        let block_count = utils::serialize(&block_count);
         let last_block = utils::serialize(&last_block);
         let reward_percentiles = utils::serialize(&reward_percentiles);
+
+        // The blockCount param is expected to be an unsigned integer up to geth v1.10.6.
+        // Geth v1.10.7 onwards, this has been updated to a hex encoded form. Failure to
+        // decode the param from client side would fallback to the old API spec.
         self.request(
             "eth_feeHistory",
-            [block_count, last_block, reward_percentiles],
+            [
+                utils::serialize(&block_count),
+                last_block.clone(),
+                reward_percentiles.clone(),
+            ],
         )
         .await
+        .or(self
+            .request(
+                "eth_feeHistory",
+                [
+                    utils::serialize(&block_count.as_u64()),
+                    last_block,
+                    reward_percentiles,
+                ],
+            )
+            .await)
     }
 }
 
@@ -1123,7 +1140,7 @@ mod tests {
         .unwrap();
 
         let history = provider
-            .fee_history(10, BlockNumber::Latest, &[10.0, 40.0])
+            .fee_history(10u64.into(), BlockNumber::Latest, &[10.0, 40.0])
             .await
             .unwrap();
         dbg!(&history);

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -317,7 +317,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
 
         let fee_history = self
             .fee_history(
-                U256::from(utils::EIP1559_FEE_ESTIMATION_PAST_BLOCKS),
+                utils::EIP1559_FEE_ESTIMATION_PAST_BLOCKS,
                 BlockNumber::Latest,
                 &[utils::EIP1559_FEE_ESTIMATION_REWARD_PERCENTILE],
             )
@@ -769,9 +769,9 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.subscribe([logs, filter]).await
     }
 
-    async fn fee_history(
+    async fn fee_history<T: Into<U256> + serde::Serialize + Send + Sync>(
         &self,
-        block_count: U256,
+        block_count: T,
         last_block: BlockNumber,
         reward_percentiles: &[f64],
     ) -> Result<FeeHistory, Self::Error> {
@@ -794,7 +794,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
             .request(
                 "eth_feeHistory",
                 [
-                    utils::serialize(&block_count.as_u64()),
+                    utils::serialize(&block_count.into().as_u64()),
                     last_block,
                     reward_percentiles,
                 ],
@@ -1140,7 +1140,7 @@ mod tests {
         .unwrap();
 
         let history = provider
-            .fee_history(10u64.into(), BlockNumber::Latest, &[10.0, 40.0])
+            .fee_history(10u64, BlockNumber::Latest, &[10.0, 40.0])
             .await
             .unwrap();
         dbg!(&history);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Geth v1.10.6 expects `blockCount` parameter in the RPC call to `eth_feeHistory` to be an unsigned integer, whereas since v1.10.7 it allows both unsigned integer as well as hex encoded uint. Hardhat allows only hex encoded uint.

The response format has also changed in Geth v1.10.7, whereby the field `oldestBlock` is now a hex-encoded uint.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Deserialisation of the `FeeHistory` struct is made backwards-compatible with Geth v1.10.6 as well, and in case the call to Hardhat (or any other client only supporting hex-encoded form for `blockCount` ) fails, we fallback to the unsigned integer serialiastion while making the RPC call.

Note: This is for convenience for more users since a few networks (at this point in time Infura) are running Geth v1.10.6, while others may have upgraded. We don't want the `eth_feeHistory` to fail, since the EIP-1559 fee estimator makes use of this RPC method.