### PR TITLE
feat: add basic policy middleware

### DIFF
--- a/ethers-middleware/src/lib.rs
+++ b/ethers-middleware/src/lib.rs
@@ -78,3 +78,8 @@ pub mod transformer;
 /// instead of using eth_sendTransaction and eth_sign
 pub mod signer;
 pub use signer::SignerMiddleware;
+
+/// The [Policy](crate::PolicyMiddleware) is used to ensure transactions comply with the rules
+/// configured in the `PolicyMiddleware` before sending them.
+pub mod policy;
+pub use policy::PolicyMiddleware;

--- a/ethers-middleware/src/policy.rs
+++ b/ethers-middleware/src/policy.rs
@@ -1,0 +1,93 @@
+use ethers_core::types::{transaction::eip2718::TypedTransaction, BlockId};
+use ethers_providers::{FromErr, Middleware, PendingTransaction};
+
+use async_trait::async_trait;
+use std::fmt::Debug;
+use thiserror::Error;
+
+#[async_trait]
+pub trait Policy: Sync + Send + Debug {
+    type Error: Sync + Send + Debug;
+
+    async fn ensure_can_send(&self, tx: TypedTransaction) -> Result<TypedTransaction, Self::Error>;
+}
+
+/// A policy that does not restrict anything.
+#[derive(Debug, Clone, Copy)]
+pub struct AllowEverything;
+
+#[async_trait]
+impl Policy for AllowEverything {
+    type Error = ();
+
+    async fn ensure_can_send(&self, tx: TypedTransaction) -> Result<TypedTransaction, Self::Error> {
+        Ok(tx)
+    }
+}
+
+/// A policy that rejects all transactions.
+#[derive(Debug, Clone, Copy)]
+pub struct RejectAll;
+
+#[async_trait]
+impl Policy for RejectAll {
+    type Error = ();
+
+    async fn ensure_can_send(&self, _: TypedTransaction) -> Result<TypedTransaction, Self::Error> {
+        Err(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PolicyMiddleware<M, P> {
+    pub(crate) inner: M,
+    pub(crate) policy: P,
+}
+
+impl<M: Middleware, P: Policy> FromErr<M::Error> for PolicyMiddlewareError<M, P> {
+    fn from(src: M::Error) -> PolicyMiddlewareError<M, P> {
+        PolicyMiddlewareError::MiddlewareError(src)
+    }
+}
+
+#[derive(Error, Debug)]
+/// Error thrown when the client interacts with the blockchain
+pub enum PolicyMiddlewareError<M: Middleware, P: Policy> {
+    /// Thrown when the internal policy errors
+    #[error("{0:?}")]
+    PolicyError(P::Error),
+    /// Thrown when an internal middleware errors
+    #[error(transparent)]
+    MiddlewareError(M::Error),
+}
+
+#[async_trait]
+impl<M, P> Middleware for PolicyMiddleware<M, P>
+where
+    M: Middleware,
+    P: Policy,
+{
+    type Error = PolicyMiddlewareError<M, P>;
+    type Provider = M::Provider;
+    type Inner = M;
+
+    fn inner(&self) -> &M {
+        &self.inner
+    }
+
+    async fn send_transaction<T: Into<TypedTransaction> + Send + Sync>(
+        &self,
+        tx: T,
+        block: Option<BlockId>,
+    ) -> Result<PendingTransaction<'_, Self::Provider>, Self::Error> {
+        let tx = self
+            .policy
+            .ensure_can_send(tx.into())
+            .await
+            .map_err(PolicyMiddlewareError::PolicyError)?;
+        self.inner
+            .send_transaction(tx, block)
+            .await
+            .map_err(PolicyMiddlewareError::MiddlewareError)
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Support a way to enforce certain rules for transactions

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add a new `PolicyMiddleware` type which wrapps a middleware and includes an instance of the new `Policy` trait, which is a single function to ensure a transaction is in compliance with this policy.

### Further work
common use cases could be to look up the receiver in a database and check if its address is whitelisted. Not sure yet what the most flexible implementation would be since a DB adapter is database specific and also how to check for a whitelisted address may be database model specific. So we could abstract basic use cases via some kind of `PolicyBackend` trait or smth which implements common functions for checking `is_whitelist(&self, recv: Address)` and also for checking the calldata maybe. We could also add a default persistent implementation of that (postgres for example) and a `HashSet` based one and feature gate this.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
