### PR TITLE
fix: use once_cell with feature=std in abigen

### DIFF
--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0.61"
 serde = { version = "1.0.124", features = ["derive"] }
 hex = { version = "0.4.2", default-features = false, features = ["std"] }
 reqwest = { version = "0.11.3", features = ["blocking"] }
-once_cell = { version = "1.8.0", default-features = false }
+once_cell = "1.8.0"
 cargo_metadata = "0.14.0"
 cfg-if = "1.0.0"
 


### PR DESCRIPTION
This PR fixes the `once_cell` dependency of `ethers-contract-abigen` which has a dependency on `once_cell::sync`, but doesn't pull in this mod due to the `std` feature being turned off. If this worked before, it's because all of the tests are run using Cargo with `resolver = 1`, which compiles one version of a dependency with all features enabled by all peer dependencies.