### PR TITLE
Fix RLP encoding of gas price

### DIFF
--- a/ethers-core/src/types/transaction/response.rs
+++ b/ethers-core/src/types/transaction/response.rs
@@ -143,7 +143,7 @@ impl Transaction {
         let mut rlp = RlpStream::new();
         rlp.begin_list(NUM_TX_FIELDS);
         rlp.append(&self.nonce);
-        rlp.append(&self.gas_price);
+        rlp_opt(&mut rlp, &self.gas_price);
         rlp.append(&self.gas);
 
         #[cfg(feature = "celo")]


### PR DESCRIPTION
## Motivation

The gas price is an `Option` because of EIP-1559, and this encodes gas price as a list, leading to invalid RLP, see https://github.com/onbjerg/ethers-flashbots/issues/11

## Solution

Use `rlp_opt` to correctly encode the gas price if it is set. I'm not sure if this is the best way to go about it since not setting a gas price by this point would then result in an empty field, but I guess it is also a logic error to arrive to this point without having the gas price set?