### PR TITLE
fix(abigen): generate correct imports depending on ethers crate usage

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -77,6 +77,10 @@ impl Context {
         // 5. Declare the structs parsed from the human readable abi
         let abi_structs_decl = cx.abi_structs()?;
 
+        let ethers_core = util::ethers_core_crate();
+        let ethers_contract = util::ethers_contract_crate();
+        let ethers_providers = util::ethers_providers_crate();
+
         Ok(quote! {
             // export all the created data types
             pub use #name_mod::*;
@@ -86,12 +90,12 @@ impl Context {
                 #imports
                 #struct_decl
 
-                impl<'a, M: ethers_providers::Middleware> #name<M> {
+                impl<'a, M: #ethers_providers::Middleware> #name<M> {
                     /// Creates a new contract instance with the specified `ethers`
                     /// client at the given `Address`. The contract derefs to a `ethers::Contract`
                     /// object
-                    pub fn new<T: Into<ethers_core::types::Address>>(address: T, client: ::std::sync::Arc<M>) -> Self {
-                        let contract = ethers_contract::Contract::new(address.into(), #abi_name.clone(), client);
+                    pub fn new<T: Into<#ethers_core::types::Address>>(address: T, client: ::std::sync::Arc<M>) -> Self {
+                        let contract = #ethers_contract::Contract::new(address.into(), #abi_name.clone(), client);
                         Self(contract)
                     }
 

--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -105,7 +105,11 @@ impl Context {
         // TODO use structs
         let outputs = expand_fn_outputs(&function.outputs)?;
 
-        let result = quote! { ethers_contract::builders::ContractCall<M, #outputs> };
+        let ethers_core = util::ethers_core_crate();
+        let ethers_providers = util::ethers_providers_crate();
+        let ethers_contract = util::ethers_contract_crate();
+
+        let result = quote! { #ethers_contract::builders::ContractCall<M, #outputs> };
 
         let (input, arg) = self.expand_inputs_call_arg_with_structs(function)?;
 

--- a/ethers-contract/ethers-contract-abigen/src/contract/structs.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/structs.rs
@@ -104,9 +104,10 @@ impl Context {
         let derives = &self.event_derives;
         let derives = quote! {#(#derives),*};
 
+        let ethers_contract = util::ethers_contract_crate();
         Ok(quote! {
             #abi_signature_doc
-            #[derive(Clone, Debug, Default, Eq, PartialEq, ethers::contract::EthAbiType, #derives)]
+            #[derive(Clone, Debug, Default, Eq, PartialEq, #ethers_contract::EthAbiType, #derives)]
             pub struct #name {
                 #( #fields ),*
             }
@@ -173,9 +174,11 @@ impl Context {
             let derives = &self.event_derives;
             let derives = quote! {#(#derives),*};
 
+            let ethers_contract = util::ethers_contract_crate();
+
             structs.extend(quote! {
             #abi_signature_doc
-            #[derive(Clone, Debug, Default, Eq, PartialEq, ethers::contract::EthAbiType, #derives)]
+            #[derive(Clone, Debug, Default, Eq, PartialEq, #ethers_contract::EthAbiType, #derives)]
             pub struct #name {
                 #( #fields ),*
             }

--- a/ethers-contract/ethers-contract-abigen/src/contract/types.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/types.rs
@@ -3,9 +3,13 @@ use ethers_core::abi::ParamType;
 use proc_macro2::{Literal, TokenStream};
 use quote::quote;
 
+use super::util;
+
 pub(crate) fn expand(kind: &ParamType) -> Result<TokenStream> {
+    let ethers_core = util::ethers_core_crate();
+
     match kind {
-        ParamType::Address => Ok(quote! { ethers_core::types::Address }),
+        ParamType::Address => Ok(quote! { #ethers_core::types::Address }),
         ParamType::Bytes => Ok(quote! { Vec<u8> }),
         ParamType::Int(n) => match n / 8 {
             1 => Ok(quote! { i8 }),
@@ -22,7 +26,7 @@ pub(crate) fn expand(kind: &ParamType) -> Result<TokenStream> {
             3..=4 => Ok(quote! { u32 }),
             5..=8 => Ok(quote! { u64 }),
             9..=16 => Ok(quote! { u128 }),
-            17..=32 => Ok(quote! { ethers_core::types::U256 }),
+            17..=32 => Ok(quote! { #ethers_core::types::U256 }),
             _ => Err(anyhow!("unsupported solidity type uint{}", n)),
         },
         ParamType::Bool => Ok(quote! { bool }),

--- a/ethers-contract/ethers-contract-abigen/src/util.rs
+++ b/ethers-contract/ethers-contract-abigen/src/util.rs
@@ -12,7 +12,8 @@ use syn::{Ident as SynIdent, Path};
 /// See `determine_ethers_crates`
 ///
 /// This ensures that the `MetadataCommand` is only run once
-static ETHERS_CRATES: Lazy<(&'static str, &'static str)> = Lazy::new(determine_ethers_crates);
+static ETHERS_CRATES: Lazy<(&'static str, &'static str, &'static str)> =
+    Lazy::new(determine_ethers_crates);
 
 /// Convenience function to turn the `ethers_core` name in `ETHERS_CRATE` into a `Path`
 pub fn ethers_core_crate() -> Path {
@@ -21,6 +22,9 @@ pub fn ethers_core_crate() -> Path {
 /// Convenience function to turn the `ethers_contract` name in `ETHERS_CRATE` into an `Path`
 pub fn ethers_contract_crate() -> Path {
     syn::parse_str(ETHERS_CRATES.1).expect("valid path; qed")
+}
+pub fn ethers_providers_crate() -> Path {
+    syn::parse_str(ETHERS_CRATES.2).expect("valid path; qed")
 }
 
 /// The crates name to use when deriving macros: (`core`, `contract`)
@@ -34,8 +38,8 @@ pub fn ethers_contract_crate() -> Path {
 /// | ethers_contract`, we need to use the fitting crate ident when expand the
 /// macros This will attempt to parse the current `Cargo.toml` and check the
 /// ethers related dependencies.
-pub fn determine_ethers_crates() -> (&'static str, &'static str) {
-    MetadataCommand::new()
+pub fn determine_ethers_crates() -> (&'static str, &'static str, &'static str) {
+    let res = MetadataCommand::new()
         .manifest_path(&format!(
             "{}/Cargo.toml",
             std::env::var("CARGO_MANIFEST_DIR").expect("No Manifest found")
@@ -44,16 +48,17 @@ pub fn determine_ethers_crates() -> (&'static str, &'static str) {
         .exec()
         .ok()
         .and_then(|metadata| {
-            metadata.root_package().and_then(|pkg| {
-                pkg.dependencies
-                    .iter()
-                    .filter(|dep| dep.kind == DependencyKind::Normal)
-                    .find_map(|dep| {
-                        (dep.name == "ethers").then(|| ("ethers::core", "ethers::contract"))
-                    })
-            })
+            metadata.packages[0]
+                .dependencies
+                .iter()
+                .filter(|dep| dep.kind == DependencyKind::Normal)
+                .find_map(|dep| {
+                    (dep.name == "ethers")
+                        .then(|| ("ethers::core", "ethers::contract", "ethers::providers"))
+                })
         })
-        .unwrap_or(("ethers_core", "ethers_contract"))
+        .unwrap_or(("ethers_core", "ethers_contract", "ethers_providers"));
+    res
 }
 
 /// Expands a identifier string into an token.


### PR DESCRIPTION
finishes over https://github.com/gakonst/ethers-rs/pull/366 for the datatypes which were not adjusted to be imported with e.g. `ethers_core` instead of `ethers ::core`