### PR TITLE
fix: always treat abi type structs as tuples

### DIFF
--- a/ethers-contract/ethers-contract-derive/src/lib.rs
+++ b/ethers-contract/ethers-contract-derive/src/lib.rs
@@ -808,26 +808,6 @@ fn derive_tokenizeable_impl(input: &DeriveInput) -> proc_macro2::TokenStream {
                 #core_crate::abi::Token::Tuple(Vec::new())
             },
         ),
-        1 => {
-            // This is a hacky solution in order to keep the same tokenstream as for tuples
-            let from_token = quote! {
-                let mut iter = Some(token).into_iter();
-                Ok(#init_struct_impl)
-            };
-
-            // This is a hack to get rid of the trailing comma introduced in the macro that concatenates all the fields
-            if let Ok(into_token) = into_token_impl
-                .to_string()
-                .as_str()
-                .trim_end_matches(',')
-                .parse()
-            {
-                (from_token, into_token)
-            } else {
-                return Error::new(input.span(), "Failed to derive Tokenizeable implementation")
-                    .to_compile_error();
-            }
-        }
         _ => {
             let from_token = quote! {
                 if let #core_crate::abi::Token::Tuple(tokens) = token {

--- a/ethers-contract/ethers-contract-derive/src/lib.rs
+++ b/ethers-contract/ethers-contract-derive/src/lib.rs
@@ -808,6 +808,22 @@ fn derive_tokenizeable_impl(input: &DeriveInput) -> proc_macro2::TokenStream {
                 #core_crate::abi::Token::Tuple(Vec::new())
             },
         ),
+        1 => {
+            // This is a hacky solution in order to keep the same tokenstream as for tuples
+            let from_token = quote! {
+                let mut iter = Some(token).into_iter();
+                Ok(#init_struct_impl)
+            };
+
+            let into_token = quote! {
+                #core_crate::abi::Token::Tuple(
+                    ::std::vec![
+                        #into_token_impl
+                    ]
+                )
+            };
+            (from_token, into_token)
+        }
         _ => {
             let from_token = quote! {
                 if let #core_crate::abi::Token::Tuple(tokens) = token {

--- a/ethers-contract/tests/common/derive.rs
+++ b/ethers-contract/tests/common/derive.rs
@@ -23,6 +23,11 @@ struct ValueChangedTuple(Address, Address, String, String);
 #[derive(Debug, Clone, PartialEq, EthAbiType)]
 struct ValueChangedTupleWrapper(ValueChangedTuple, String);
 
+#[derive(Debug, Clone, PartialEq, EthAbiType)]
+struct ValueChangedVecWrapper {
+    inner: Vec<ValueChanged>,
+}
+
 #[test]
 fn can_detokenize_struct() {
     let value = ValueChanged {
@@ -79,6 +84,26 @@ fn can_detokenize_nested_tuple_struct() {
 
     let token = value.clone().into_token();
     assert_eq!(value, ValueChangedTupleWrapper::from_token(token).unwrap());
+}
+
+#[test]
+fn can_detokenize_single_field() {
+    let value = ValueChangedVecWrapper { inner: vec![] };
+
+    let token = value.clone().into_token();
+    assert_eq!(value, ValueChangedVecWrapper::from_token(token).unwrap());
+
+    let value = ValueChangedVecWrapper {
+        inner: vec![ValueChanged {
+            old_author: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".parse().unwrap(),
+            new_author: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse().unwrap(),
+            old_value: "50".to_string(),
+            new_value: "100".to_string(),
+        }],
+    };
+
+    let token = value.clone().into_token();
+    assert_eq!(value, ValueChangedVecWrapper::from_token(token).unwrap());
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
structs with a single field weren't properly endcoded into a `Token::Tuple`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- always treat `EthAbiType` as tuples 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Closes #416 