### PR TITLE
Event aliasing for contract bindings

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -46,6 +46,9 @@ pub(crate) struct Context {
 
     /// Derives added to event structs and enums.
     event_derives: Vec<Path>,
+
+    /// Manually specified event aliases.
+    event_aliases: BTreeMap<String, Ident>,
 }
 
 impl Context {
@@ -151,6 +154,17 @@ impl Context {
             }
         }
 
+        let mut event_aliases = BTreeMap::new();
+        for (signature, alias) in args.event_aliases.into_iter() {
+            let alias = syn::parse_str(&alias)?;
+            if event_aliases.insert(signature.clone(), alias).is_some() {
+                return Err(anyhow!(
+                    "duplicate method signature '{}' in method aliases",
+                    signature,
+                ));
+            }
+        }
+
         let event_derives = args
             .event_derives
             .iter()
@@ -167,6 +181,7 @@ impl Context {
             contract_name,
             method_aliases,
             event_derives,
+            event_aliases,
         })
     }
 }

--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -157,12 +157,7 @@ impl Context {
         let mut event_aliases = BTreeMap::new();
         for (signature, alias) in args.event_aliases.into_iter() {
             let alias = syn::parse_str(&alias)?;
-            if event_aliases.insert(signature.clone(), alias).is_some() {
-                return Err(anyhow!(
-                    "duplicate method signature '{}' in method aliases",
-                    signature,
-                ));
-            }
+            event_aliases.insert(signature.clone(), alias);
         }
 
         let event_derives = args

--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -157,7 +157,7 @@ impl Context {
         let mut event_aliases = BTreeMap::new();
         for (signature, alias) in args.event_aliases.into_iter() {
             let alias = syn::parse_str(&alias)?;
-            event_aliases.insert(signature.clone(), alias);
+            event_aliases.insert(signature, alias);
         }
 
         let event_derives = args

--- a/ethers-contract/ethers-contract-abigen/src/contract/events.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/events.rs
@@ -226,18 +226,17 @@ impl Context {
     fn expand_filter(&self, event: &Event) -> TokenStream {
         let ethers_contract = util::ethers_contract_crate();
         let alias = self.event_aliases.clone().remove(&event.abi_signature());
-        let mut name;
+        let name;
         if let Some(id) = alias {
             name = util::safe_ident(&format!("{}_filter", id.to_string().to_snake_case()));
         } else {
             name = util::safe_ident(&format!("{}_filter", event.name.to_snake_case()));
         }
 
-
         // append `filter` to disambiguate with potentially conflicting
         // function names
 
-         let result = util::ident(&name.to_string().to_pascal_case());
+        let result = util::ident(&name.to_string().to_pascal_case());
         //let result = expand_struct_name(event);
 
         let doc = util::expand_doc(&format!("Gets the contract's `{}` event", event.name));
@@ -252,17 +251,18 @@ impl Context {
     /// Expands an ABI event into a single event data type. This can expand either
     /// into a structure or a tuple in the case where all event parameters (topics
     /// and data) are anonymous.
-    fn expand_event(&self, event: &Event, sig: Option<Ident> ) -> Result<TokenStream> {
+    fn expand_event(&self, event: &Event, sig: Option<Ident>) -> Result<TokenStream> {
         let mut event = event.clone();
         let abi_signature = event.abi_signature();
         let event_abi_name = event.name.clone();
-        let alias = sig.clone().unwrap_or_else(|| util::safe_ident(&event_abi_name.to_snake_case()));
+        let alias = sig
+            .clone()
+            .unwrap_or_else(|| util::safe_ident(&event_abi_name.to_snake_case()));
         event = Event {
             name: alias.to_string(),
             inputs: event.inputs.clone(),
-            anonymous: event.anonymous
+            anonymous: event.anonymous,
         };
-
 
         let event_name = expand_struct_name(&event, sig);
 
@@ -276,8 +276,6 @@ impl Context {
         };
 
         let derives = expand_derives(&self.event_derives);
-
-
 
         let ethers_contract = util::ethers_contract_crate();
 
@@ -406,6 +404,49 @@ mod tests {
         Context::from_abigen(Abigen::new("TestToken", "[]").unwrap()).unwrap()
     }
 
+    fn test_context_with_alias(sig: &str, alias: &str) -> Context {
+        Context::from_abigen(
+            Abigen::new("TestToken", "[]")
+                .unwrap()
+                .add_event_alias(sig, alias),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn expand_transfer_filter_with_alias() {
+        let event = Event {
+            name: "Transfer".into(),
+            inputs: vec![
+                EventParam {
+                    name: "from".into(),
+                    kind: ParamType::Address,
+                    indexed: true,
+                },
+                EventParam {
+                    name: "to".into(),
+                    kind: ParamType::Address,
+                    indexed: true,
+                },
+                EventParam {
+                    name: "amount".into(),
+                    kind: ParamType::Uint(256),
+                    indexed: false,
+                },
+            ],
+            anonymous: false,
+        };
+        let sig = "Transfer(address,address,uint256)";
+        let cx = test_context_with_alias(sig, "TransferEvent");
+        assert_quote!(cx.expand_filter(&event), {
+            #[doc = "Gets the contract's `Transfer` event"]
+            pub fn transfer_event_filter(
+                &self,
+            ) -> ethers_contract::builders::Event<M, TransferEventFilter> {
+                self.0.event()
+            }
+        });
+    }
     #[test]
     fn expand_transfer_filter() {
         let event = Event {
@@ -471,6 +512,39 @@ mod tests {
     }
 
     #[test]
+    fn expand_data_struct_with_alias() {
+        let event = Event {
+            name: "Foo".into(),
+            inputs: vec![
+                EventParam {
+                    name: "a".into(),
+                    kind: ParamType::Bool,
+                    indexed: false,
+                },
+                EventParam {
+                    name: String::new(),
+                    kind: ParamType::Address,
+                    indexed: false,
+                },
+            ],
+            anonymous: false,
+        };
+
+        let cx = test_context_with_alias("Foo(bool,address)", "FooAliased");
+        let params = cx.expand_params(&event).unwrap();
+        let alias = Some(util::ident("FooAliased"));
+        let name = expand_struct_name(&event, alias);
+        let definition = expand_data_struct(&name, &params);
+
+        assert_quote!(definition, {
+            struct FooAliasedFilter {
+                pub a: bool,
+                pub p1: ethers_core::types::Address,
+            }
+        });
+    }
+
+    #[test]
     fn expand_data_tuple_value() {
         let event = Event {
             name: "Foo".into(),
@@ -496,6 +570,36 @@ mod tests {
 
         assert_quote!(definition, {
             struct FooFilter(pub bool, pub ethers_core::types::Address);
+        });
+    }
+
+    #[test]
+    fn expand_data_tuple_value_with_alias() {
+        let event = Event {
+            name: "Foo".into(),
+            inputs: vec![
+                EventParam {
+                    name: String::new(),
+                    kind: ParamType::Bool,
+                    indexed: false,
+                },
+                EventParam {
+                    name: String::new(),
+                    kind: ParamType::Address,
+                    indexed: false,
+                },
+            ],
+            anonymous: false,
+        };
+
+        let cx = test_context_with_alias("Foo(bool,address)", "FooAliased");
+        let params = cx.expand_params(&event).unwrap();
+        let alias = Some(util::ident("FooAliased"));
+        let name = expand_struct_name(&event, alias);
+        let definition = expand_data_tuple(&name, &params);
+
+        assert_quote!(definition, {
+            struct FooAliasedFilter(pub bool, pub ethers_core::types::Address);
         });
     }
 

--- a/ethers-contract/ethers-contract-abigen/src/contract/events.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/events.rs
@@ -253,9 +253,9 @@ impl Context {
         let abi_signature = event.abi_signature();
         let event_abi_name = event.name.clone();
 
-        let event_name = expand_struct_name(&event, sig);
+        let event_name = expand_struct_name(event, sig);
 
-        let params = self.expand_params(&event)?;
+        let params = self.expand_params(event)?;
         // expand as a tuple if all fields are anonymous
         let all_anonymous_fields = event.inputs.iter().all(|input| input.name.is_empty());
         let data_type_definition = if all_anonymous_fields {

--- a/ethers-contract/ethers-contract-abigen/src/lib.rs
+++ b/ethers-contract/ethers-contract-abigen/src/lib.rs
@@ -61,6 +61,9 @@ pub struct Abigen {
 
     /// Format the code using a locally installed copy of `rustfmt`.
     rustfmt: bool,
+
+    /// Manually specified event name aliases.
+    event_aliases: HashMap<String, String>,
 }
 
 impl Abigen {
@@ -72,8 +75,20 @@ impl Abigen {
             contract_name: contract_name.to_owned(),
             method_aliases: HashMap::new(),
             event_derives: Vec::new(),
+            event_aliases: HashMap::new(),
             rustfmt: true,
         })
+    }
+
+    /// Manually adds a solidity event alias to specify what the event struct
+    /// and function name will be in Rust.
+    pub fn add_event_alias<S1, S2>(mut self, signature: S1, alias: S2) -> Self
+    where
+        S1: Into<String>,
+        S2: Into<String>,
+    {
+        self.event_aliases.insert(signature.into(), alias.into());
+        self
     }
 
     /// Manually adds a solidity method alias to specify what the method name


### PR DESCRIPTION

## Motivation

Smart contracts written in Solidity can include methods *and* events with the same name, so long as their signatures are different. 

The `contract` crate provides utilities for generating bindings to a contract's ABI. Because Rust does not support function overloading, these utilities enable the user to add `method_alias`es, which changes the function's name in the generated contract bindings.

The crate did not provide aliasing capabilities for event definitions.

## Solution

The associated function `add_event_alias` was added to the `Abigen` struct within `ethers-contract::ethers-contract-abigen`.

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
- [ ] Updated the changelog
