### PR TITLE
fix: cleanup lock file after exec cargo metadata

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/util.rs
+++ b/ethers-contract/ethers-contract-abigen/src/util.rs
@@ -40,13 +40,13 @@ pub fn ethers_providers_crate() -> Path {
 /// ethers related dependencies.
 ///
 /// This process is a bit hacky, we run `cargo metadata` internally which
-/// resolves the current package but creating a `Cargo.lock` file in the
+/// resolves the current package but creates a new `Cargo.lock` file in the
 /// process. This is not a problem for regular workspaces but becomes an issue
 /// during publishing with `cargo publish` if the project does not ignore
 /// `Cargo.lock` in `.gitignore`, because then cargo can't proceed with
-/// publishing the crate because the created `Cargo.lock` results in a modified
+/// publishing the crate because the created `Cargo.lock` leads to a modified
 /// workspace, not the `CARGO_MANIFEST_DIR` but the workspace `cargo publish`
-/// crated in `./target/package/..`. Therefore we check prior to executing
+/// created in `./target/package/..`. Therefore we check prior to executing
 /// `cargo metadata` if a `Cargo.lock` file exists and delete it afterwards if
 /// it was created by `cargo metadata`.
 pub fn determine_ethers_crates() -> (&'static str, &'static str, &'static str) {

--- a/ethers-contract/ethers-contract-abigen/src/util.rs
+++ b/ethers-contract/ethers-contract-abigen/src/util.rs
@@ -38,26 +38,47 @@ pub fn ethers_providers_crate() -> Path {
 /// | ethers_contract`, we need to use the fitting crate ident when expand the
 /// macros This will attempt to parse the current `Cargo.toml` and check the
 /// ethers related dependencies.
+///
+/// This process is a bit hacky, we run `cargo metadata` internally which
+/// resolves the current package but creating a `Cargo.lock` file in the
+/// process. This is not a problem for regular workspaces but becomes an issue
+/// during publishing with `cargo publish` if the project does not ignore
+/// `Cargo.lock` in `.gitignore`, because then cargo can't proceed with
+/// publishing the crate because the created `Cargo.lock` results in a modified
+/// workspace, not the `CARGO_MANIFEST_DIR` but the workspace `cargo publish`
+/// crated in `./target/package/..`. Therefore we check prior to executing
+/// `cargo metadata` if a `Cargo.lock` file exists and delete it afterwards if
+/// it was created by `cargo metadata`.
 pub fn determine_ethers_crates() -> (&'static str, &'static str, &'static str) {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("No Manifest found");
+
+    // check if the lock file exists, if it's missing we need to clean up afterward
+    let lock_file = format!("{}/Cargo.lock", manifest_dir);
+    let needs_lock_file_cleanup = !std::path::Path::new(&lock_file).exists();
+
     let res = MetadataCommand::new()
-        .manifest_path(&format!(
-            "{}/Cargo.toml",
-            std::env::var("CARGO_MANIFEST_DIR").expect("No Manifest found")
-        ))
-        .no_deps()
+        .manifest_path(&format!("{}/Cargo.toml", manifest_dir))
         .exec()
         .ok()
         .and_then(|metadata| {
-            metadata.packages[0]
-                .dependencies
-                .iter()
-                .filter(|dep| dep.kind == DependencyKind::Normal)
-                .find_map(|dep| {
-                    (dep.name == "ethers")
-                        .then(|| ("ethers::core", "ethers::contract", "ethers::providers"))
-                })
+            metadata.root_package().and_then(|pkg| {
+                pkg.dependencies
+                    .iter()
+                    .filter(|dep| dep.kind == DependencyKind::Normal)
+                    .find_map(|dep| {
+                        (dep.name == "ethers")
+                            .then(|| ("ethers::core", "ethers::contract", "ethers::providers"))
+                    })
+            })
         })
         .unwrap_or(("ethers_core", "ethers_contract", "ethers_providers"));
+
+    if needs_lock_file_cleanup {
+        // delete the `Cargo.lock` file that was created by `cargo metadata`
+        // if the package is not part of a workspace
+        let _ = std::fs::remove_file(lock_file);
+    }
+
     res
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Close #430
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
check if a lock file exists before running cargo metadata and removing it if that's the case.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
