### PR TITLE
feat: expand solc capabilities / chore: update ethabi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,8 +805,7 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "14.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01317735d563b3bad2d5f90d2e1799f414165408251abb762510f40e790e69a"
+source = "git+https://github.com/gakonst/ethabi/?branch=patch-1#01763cdf2446a5bf3a2b0065c364e672a45d391b"
 dependencies = [
  "anyhow",
  "ethereum-types",
@@ -833,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
+checksum = "0dd6bde671199089e601e8d47e153368b893ef885f11f365a3261ec58153c211"
 dependencies = [
  "ethbloom",
  "fixed-hash",
@@ -1946,9 +1945,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "primitive-types"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06345ee39fbccfb06ab45f3a1a5798d9dafa04cb8921a76d227040003a234b0e"
+checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
  "impl-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "14.1.0"
-source = "git+https://github.com/gakonst/ethabi/?branch=patch-1#01763cdf2446a5bf3a2b0065c364e672a45d391b"
+source = "git+https://github.com/rust-ethereum/ethabi/?branch=master#506f6cc364cdb458ac09f2be4f300779da256b08"
 dependencies = [
  "anyhow",
  "ethereum-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,5 +87,3 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 tokio = { version = "1.5", features = ["macros", "rt-multi-thread"] }
 
-[patch.'crates-io']
-ethabi = { git = "https://github.com/gakonst/ethabi/", branch = "patch-1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,6 @@ rand = "0.8.4"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 tokio = { version = "1.5", features = ["macros", "rt-multi-thread"] }
+
+[patch.'crates-io']
+ethabi = { git = "https://github.com/gakonst/ethabi/", branch = "patch-1" }

--- a/ethers-contract/ethers-contract-derive/src/abigen.rs
+++ b/ethers-contract/ethers-contract-derive/src/abigen.rs
@@ -169,6 +169,7 @@ impl Parse for Method {
                     Ok(Param {
                         name: "".into(),
                         kind,
+                        internal_type: None,
                     })
                 })
                 .collect::<ParseResult<Vec<_>>>()?;

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -11,7 +11,8 @@ keywords = ["ethereum", "web3", "celo", "ethers"]
 
 [dependencies]
 rlp = { version = "0.5.0", default-features = false }
-ethabi = { version = "14.1.0", default-features = false }
+# ethabi = { version = "14.1.0", default-features = false }
+ethabi = { git = "https://github.com/rust-ethereum/ethabi/", branch = "master" }
 arrayvec = { version = "0.7.1", default-features = false }
 rlp-derive = { version = "0.1.0", default-features = false }
 

--- a/ethers-core/src/abi/human_readable.rs
+++ b/ethers-core/src/abi/human_readable.rs
@@ -364,6 +364,7 @@ impl AbiParser {
         Ok(Param {
             name: name.to_string(),
             kind: self.parse_type(type_str)?,
+            internal_type: None,
         })
     }
 }

--- a/ethers-core/src/utils/solc.rs
+++ b/ethers-core/src/utils/solc.rs
@@ -77,7 +77,7 @@ pub struct Solc {
 }
 
 impl Solc {
-    /// Instantiates the Solc builder for the provided paths
+    /// Instantiates The Solc builder with the provided glob of Solidity files
     pub fn new(path: &str) -> Self {
         // Convert the glob to a vector of string paths
         // TODO: This might not be the most robust way to do this
@@ -85,7 +85,11 @@ impl Solc {
             .expect("could not get glob")
             .map(|path| path.expect("path not found").to_string_lossy().to_string())
             .collect::<Vec<String>>();
+        Self::new_with_paths(paths)
+    }
 
+    /// Instantiates the Solc builder for the provided paths
+    pub fn new_with_paths(paths: Vec<String>) -> Self {
         Self {
             paths,
             solc_path: None,

--- a/ethers-core/src/utils/solc.rs
+++ b/ethers-core/src/utils/solc.rs
@@ -21,7 +21,7 @@ pub enum SolcError {
     SerdeJson(#[from] serde_json::Error),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 /// The result of a solc compilation
 pub struct CompiledContract {
     /// The contract's ABI

--- a/ethers-core/src/utils/solc.rs
+++ b/ethers-core/src/utils/solc.rs
@@ -57,6 +57,9 @@ pub struct CompiledContract {
 /// # }
 /// ```
 pub struct Solc {
+    /// The path to the Solc binary
+    pub solc_path: Option<PathBuf>,
+
     /// The path where contracts will be read from
     pub paths: Vec<String>,
 
@@ -85,6 +88,7 @@ impl Solc {
 
         Self {
             paths,
+            solc_path: None,
             optimizer: Some(200), // default optimizer runs = 200
             evm_version: EvmVersion::Istanbul,
             allowed_paths: Vec::new(),
@@ -94,7 +98,7 @@ impl Solc {
 
     /// Gets the ABI for the contracts
     pub fn build_raw(self) -> Result<HashMap<String, CompiledContractStr>> {
-        let mut command = Command::new(SOLC);
+        let mut command = Command::new(self.solc_path.unwrap_or_else(|| PathBuf::from(SOLC)));
 
         command
             .arg("--evm-version")
@@ -234,6 +238,12 @@ impl Solc {
     /// Sets the EVM version for compilation
     pub fn evm_version(mut self, version: EvmVersion) -> Self {
         self.evm_version = version;
+        self
+    }
+
+    /// Sets the path to the solc binary
+    pub fn solc_path(mut self, path: PathBuf) -> Self {
+        self.solc_path = Some(std::fs::canonicalize(path).unwrap());
         self
     }
 


### PR DESCRIPTION
* ethabi: Adds support for `internal_type` which we could/should use for abiencoder-v2 support in human readable abi. Also upgrades ethereum-types to 0.12.0.
* solc: allows providing `runtime-bin` as well as skips setting the evm-version on older compilers