### PR TITLE
fix(ethabi): breaking changes and force enable serialize for eth-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,6 +825,7 @@ checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
 dependencies = [
  "crunchy",
  "fixed-hash",
+ "impl-rlp",
  "impl-serde",
  "tiny-keccak",
 ]
@@ -837,6 +838,7 @@ checksum = "0dd6bde671199089e601e8d47e153368b893ef885f11f365a3261ec58153c211"
 dependencies = [
  "ethbloom",
  "fixed-hash",
+ "impl-rlp",
  "impl-serde",
  "primitive-types",
  "uint",
@@ -921,6 +923,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "ethabi",
+ "ethereum-types",
  "futures-util",
  "generic-array 0.14.4",
  "glob",
@@ -1434,6 +1437,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
 name = "impl-serde"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,6 +1952,7 @@ checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-rlp",
  "impl-serde",
  "uint",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "14.1.0"
-source = "git+https://github.com/rust-ethereum/ethabi/?branch=master#506f6cc364cdb458ac09f2be4f300779da256b08"
+source = "git+https://github.com/rust-ethereum/ethabi/?branch=master#8bd90d13956edf18bb47c6e39dcf7ab99bf264c7"
 dependencies = [
  "anyhow",
  "ethereum-types",
@@ -825,7 +825,6 @@ checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
 dependencies = [
  "crunchy",
  "fixed-hash",
- "impl-rlp",
  "impl-serde",
  "tiny-keccak",
 ]
@@ -838,7 +837,6 @@ checksum = "0dd6bde671199089e601e8d47e153368b893ef885f11f365a3261ec58153c211"
 dependencies = [
  "ethbloom",
  "fixed-hash",
- "impl-rlp",
  "impl-serde",
  "primitive-types",
  "uint",
@@ -1436,15 +1434,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
-dependencies = [
- "rlp",
-]
-
-[[package]]
 name = "impl-serde"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,7 +1940,6 @@ checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "impl-rlp",
  "impl-serde",
  "uint",
 ]

--- a/ethers-contract/src/base.rs
+++ b/ethers-contract/src/base.rs
@@ -8,7 +8,12 @@ use ethers_core::{
 };
 use ethers_providers::Middleware;
 
-use std::{collections::HashMap, fmt::Debug, hash::Hash, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt::Debug,
+    hash::Hash,
+    sync::Arc,
+};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -175,7 +180,7 @@ pub fn decode_function_data<D: Detokenize, T: AsRef<[u8]>>(
 /// Utility function for creating a mapping between a unique signature and a
 /// name-index pair for accessing contract ABI items.
 fn create_mapping<T, S, F>(
-    elements: &HashMap<String, Vec<T>>,
+    elements: &BTreeMap<String, Vec<T>>,
     signature: F,
 ) -> HashMap<S, (String, usize)>
 where

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["ethereum", "web3", "celo", "ethers"]
 rlp = { version = "0.5.0", default-features = false }
 # ethabi = { version = "14.1.0", default-features = false }
 ethabi = { git = "https://github.com/rust-ethereum/ethabi/", branch = "master" }
+ethereum-types = { version = "0.12.0", default-features = false, features = ["serialize", "rlp"] }
 arrayvec = { version = "0.7.1", default-features = false }
 rlp-derive = { version = "0.1.0", default-features = false }
 

--- a/ethers-core/src/abi/human_readable.rs
+++ b/ethers-core/src/abi/human_readable.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 
 use crate::abi::error::{bail, format_err, ParseError, Result};
 use crate::abi::struct_def::{FieldType, StructFieldType};
@@ -52,8 +52,8 @@ impl AbiParser {
         // parse struct first
         let mut abi = Abi {
             constructor: None,
-            functions: HashMap::new(),
-            events: HashMap::new(),
+            functions: BTreeMap::new(),
+            events: BTreeMap::new(),
             receive: false,
             fallback: false,
         };


### PR DESCRIPTION
Fixes breaking changes from https://github.com/rust-ethereum/ethabi/pull/236

We also need to force enable `serialize` because they removed it upstream, pending fix https://github.com/rust-ethereum/ethabi/pull/239