### PR TITLE
test: fix duplicate tx flakes by rotating through a list of wallets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,7 @@ dependencies = [
  "futures-util",
  "hex",
  "instant",
+ "once_cell",
  "rand 0.8.4",
  "reqwest",
  "serde",

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "1.5" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 rand = { version = "0.8.4", default-features = false }
 ethers-providers = { version = "^0.5.0", path = "../ethers-providers", default-features = false, features = ["ws", "rustls"] }
+once_cell = "1.8.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1.5", default-features = false, features = ["rt", "macros", "time"] }

--- a/ethers-providers/src/pending_transaction.rs
+++ b/ethers-providers/src/pending_transaction.rs
@@ -48,6 +48,14 @@ impl<'a, P: JsonRpcClient> PendingTransaction<'a, P> {
         }
     }
 
+    /// Returns the Provider associated with the pending transaction
+    pub fn provider(&self) -> Provider<P>
+    where
+        P: Clone,
+    {
+        self.provider.clone()
+    }
+
     /// Sets the number of confirmations for the pending transaction to resolve
     /// to a receipt
     pub fn confirmations(mut self, confs: usize) -> Self {


### PR DESCRIPTION
Is this the day our tests stop being flaky? Maybe? We now rotate over private keys associated with a mnemonic, instead of having a bunch of keys lying around and hoping we don't duplicate them somewhere & introduce race conditions.

I've pre-funded the wallets generated as documented [here](https://github.com/gakonst/ethers-rs/compare/fix/flaky-tests?expand=1#diff-be734beb2ff927faeaf4f9733808604d8fdf182a633d164c6168247ac475abddR117-R120).