### PR TITLE
docs: fix broken ethers-js link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 
 //! # Complete Ethereum & Celo library and wallet implementation.
 //!
-//! > ethers-rs is a port of [ethers-js](github.com/ethers-io/ethers.js) in Rust.
+//! > ethers-rs is a port of [ethers-js](https://github.com/ethers-io/ethers.js) in Rust.
 //!
 //! ## Quickstart: `prelude`
 //!


### PR DESCRIPTION
## Motivation

Link to `ethers-js` is broken on https://docs.rs/ethers/0.5.3/ethers/#complete-ethereum--celo-library-and-wallet-implementation

![image](https://user-images.githubusercontent.com/5773434/135074273-205f58c6-b3bc-4435-97aa-c3560c1b7b8c.png)


## Solution

Fix the link!
