### PR TITLE
feat(contract, abigen): support artifact format in proc macro

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -10,14 +10,14 @@ use super::Abigen;
 use crate::contract::structs::InternalStructs;
 use crate::rawabi::RawAbi;
 use anyhow::{anyhow, Context as _, Result};
-use ethers_core::abi::AbiParser;
 use ethers_core::{
-    abi::{parse_abi, Abi},
+    abi::{parse_abi, Abi, AbiParser},
     types::Address,
 };
 use inflector::Inflector;
 use proc_macro2::{Ident, Literal, TokenStream};
 use quote::quote;
+use serde::Deserialize;
 use std::collections::BTreeMap;
 use syn::{Path, Visibility};
 
@@ -119,15 +119,24 @@ impl Context {
     /// Create a context from the code generation arguments.
     fn from_abigen(args: Abigen) -> Result<Self> {
         // get the actual ABI string
-        let abi_str = args.abi_source.get().context("failed to get ABI JSON")?;
+        let mut abi_str = args.abi_source.get().context("failed to get ABI JSON")?;
         let mut abi_parser = AbiParser::default();
-        // parse it
-        let (abi, human_readable): (Abi, _) = if let Ok(abi) = serde_json::from_str(&abi_str) {
-            // normal abi format
-            (abi, false)
+
+        let (abi, human_readable): (Abi, _) = if let Ok(abi) = abi_parser.parse_str(&abi_str) {
+            (abi, true)
         } else {
-            // heuristic for parsing the human readable format
-            (abi_parser.parse_str(&abi_str)?, true)
+            // a best-effort coercion of an ABI or an artifact JSON into an artifact JSON.
+            if abi_str.trim().starts_with('[') {
+                abi_str = format!(r#"{{"abi":{}}}"#, abi_str.trim());
+            }
+
+            #[derive(Deserialize)]
+            struct Contract {
+                abi: Abi,
+            }
+
+            let contract = serde_json::from_str::<Contract>(&abi_str)?;
+            (contract.abi, false)
         };
 
         // try to extract all the solidity structs from the normal JSON ABI


### PR DESCRIPTION
## Motivation

Resolve https://github.com/gakonst/ethers-rs/issues/476 once again, since https://github.com/gakonst/ethers-rs/pull/478 didn't solve the issue with `abigen!` proc macro.

## Solution

Make a best-effort coercion of an ABI or an artifact JSON into an artifact JSON (idea from https://github.com/gnosis/ethcontract-rs/blob/5db6ad486256abac7509193649b7bc0f5ed40f96/ethcontract-generate/src/source.rs#L246).

