### PR TITLE
feat: support human readable struct inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+* Use rust types as contract function inputs for human readable abi [#482](https://github.com/gakonst/ethers-rs/pull/482)
 * Allow configuring the optimizer & passing arbitrary arguments to solc [#427](https://github.com/gakonst/ethers-rs/pull/427)
 
 ### 0.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@
 ### Unreleased
 
 * Use rust types as contract function inputs for human readable abi [#482](https://github.com/gakonst/ethers-rs/pull/482)
+* 
+### 0.5.3
+
 * Allow configuring the optimizer & passing arbitrary arguments to solc [#427](https://github.com/gakonst/ethers-rs/pull/427)
+* Decimal support for `ethers_core::utils::parse_units` [#463](https://github.com/gakonst/ethers-rs/pull/463)
+* Fixed Wei unit calculation in `Units` [#460](https://github.com/gakonst/ethers-rs/pull/460)
+* Add `ethers_core::utils::get_create2_address_from_hash` [#444](https://github.com/gakonst/ethers-rs/pull/444)
+* Bumped ethabi to 0.15.0 and fixing breaking changes [#469](https://github.com/gakonst/ethers-rs/pull/469), [#448](https://github.com/gakonst/ethers-rs/pull/448), [#445](https://github.com/gakonst/ethers-rs/pull/445)
 
 ### 0.5.2
 * Correctly RLP Encode transactions as received from the mempool ([#415](https://github.com/gakonst/ethers-rs/pull/415))
@@ -13,6 +20,11 @@
 ## ethers-providers
 
 ### Unreleased
+
+### 0.5.3
+
+* Expose `ens` module [#435](https://github.com/gakonst/ethers-rs/pull/435)
+* Add `eth_getProof` [#459](https://github.com/gakonst/ethers-rs/pull/459)
 
 ### 0.5.2
 * Set resolved ENS name during gas estimation ([1e5a9e](https://github.com/gakonst/ethers-rs/commit/1e5a9efb3c678eecd43d5c341b4932da35445831))
@@ -24,12 +36,14 @@
 ## ethers-contract
 
 ### Unreleased
+
+### 0.5.3
 * (De)Tokenize structs and events with only a single field as `Token:Tuple` ([#417](https://github.com/gakonst/ethers-rs/pull/417))
 
 ## ethers-middleware
 
 ### Unreleased
 
-## ethers
+### 0.5.3
 
-### Unreleased
+* Added Time Lagged middleware [#457](https://github.com/gakonst/ethers-rs/pull/457)

--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -82,8 +82,6 @@ impl Context {
                 Ok(quote! {[#ty; #size]})
             }
             ParamType::Tuple(_) => {
-                eprintln!("function {:?}", fun);
-
                 let ty = if let Some(rust_struct_name) = self
                     .internal_structs
                     .get_function_input_struct_type(&fun.name, param)
@@ -93,7 +91,6 @@ impl Context {
                 } else {
                     types::expand(kind)?
                 };
-                eprintln!("{:?}", ty);
                 Ok(ty)
             }
             _ => types::expand(kind),

--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -82,6 +82,8 @@ impl Context {
                 Ok(quote! {[#ty; #size]})
             }
             ParamType::Tuple(_) => {
+                eprintln!("function {:?}", fun);
+
                 let ty = if let Some(rust_struct_name) = self
                     .internal_structs
                     .get_function_input_struct_type(&fun.name, param)
@@ -91,6 +93,7 @@ impl Context {
                 } else {
                     types::expand(kind)?
                 };
+                eprintln!("{:?}", ty);
                 Ok(ty)
             }
             _ => types::expand(kind),

--- a/ethers-contract/ethers-contract-abigen/src/contract/structs.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/structs.rs
@@ -194,22 +194,22 @@ impl Context {
 #[derive(Debug, Clone, Default)]
 pub struct InternalStructs {
     /// All unique internal types that are function inputs or outputs
-    top_level_internal_types: HashMap<String, Component>,
+    pub(crate) top_level_internal_types: HashMap<String, Component>,
 
     /// (function name, param name) -> struct which are the identifying properties we get the name from ethabi.
-    function_params: HashMap<(String, String), String>,
+    pub(crate) function_params: HashMap<(String, String), String>,
 
     /// (function name) -> Vec<structs> all structs the function returns
-    outputs: HashMap<String, Vec<String>>,
+    pub(crate) outputs: HashMap<String, Vec<String>>,
 
     /// All the structs extracted from the abi with their identifier as key
-    structs: HashMap<String, SolStruct>,
+    pub(crate) structs: HashMap<String, SolStruct>,
 
     /// solidity structs as tuples
-    struct_tuples: HashMap<String, ParamType>,
+    pub(crate) struct_tuples: HashMap<String, ParamType>,
 
     /// Contains the names for the rust types (id -> rust type name)
-    rust_type_names: HashMap<String, String>,
+    pub(crate) rust_type_names: HashMap<String, String>,
 }
 
 impl InternalStructs {

--- a/ethers-core/src/abi/human_readable.rs
+++ b/ethers-core/src/abi/human_readable.rs
@@ -289,16 +289,8 @@ impl AbiParser {
             "" => None,
             input_params_args => Some(input_params_args),
         };
-        let modifiers = match input_args_modifiers_iter
-            .next()
-            .ok_or_else(|| format_err!("Expected input args parentheses at `{}`", s))?
-        {
-            "" => None,
-            modifiers => Some(modifiers),
-        };
 
         let inputs = if let Some(params) = input_args {
-            
             self
                 .parse_params(params)?
                 .into_iter()

--- a/ethers-core/src/abi/human_readable.rs
+++ b/ethers-core/src/abi/human_readable.rs
@@ -13,6 +13,10 @@ pub struct AbiParser {
     pub structs: HashMap<String, SolStruct>,
     /// solidity structs as tuples
     pub struct_tuples: HashMap<String, Vec<ParamType>>,
+    /// (function name, param name) -> struct which are the identifying properties we get the name from ethabi.
+    pub function_params: HashMap<(String, String), String>,
+    /// (function name) -> Vec<structs> all structs the function returns
+    pub outputs: HashMap<String, Vec<String>>,
 }
 
 impl AbiParser {
@@ -89,7 +93,22 @@ impl AbiParser {
                     .or_default()
                     .push(event);
             } else if line.starts_with("constructor") {
-                abi.constructor = Some(self.parse_constructor(line)?);
+                let inputs = self
+                    .constructor_inputs(line)?
+                    .into_iter()
+                    .map(|(input, struct_name)| {
+                        if let Some(struct_name) = struct_name {
+                            // keep track of the user defined struct of that param
+                            self.function_params.insert(
+                                ("constructor".to_string(), input.name.clone()),
+                                struct_name,
+                            );
+                        }
+                        input
+                    })
+                    .collect();
+
+                abi.constructor = Some(Constructor { inputs });
             } else {
                 bail!("Illegal abi `{}`", line)
             }
@@ -146,6 +165,8 @@ impl AbiParser {
                 .map(|s| (s.name().to_string(), s))
                 .collect(),
             struct_tuples: HashMap::new(),
+            function_params: Default::default(),
+            outputs: Default::default(),
         }
     }
 
@@ -231,7 +252,7 @@ impl AbiParser {
         Ok(EventParam {
             name: name.to_string(),
             indexed,
-            kind: self.parse_type(type_str)?,
+            kind: self.parse_type(type_str)?.0,
         })
     }
 
@@ -264,7 +285,18 @@ impl AbiParser {
         .strip_prefix('(')
         .ok_or(ParseError::ParseError(super::Error::InvalidData))?;
 
-        let inputs = self.parse_params(input_params)?;
+        let inputs = self
+            .parse_params(input_params)?
+            .into_iter()
+            .map(|(input, struct_name)| {
+                if let Some(struct_name) = struct_name {
+                    // keep track of the user defined struct of that param
+                    self.function_params
+                        .insert((name.clone(), input.name.clone()), struct_name);
+                }
+                input
+            })
+            .collect();
 
         let outputs = if let Some(params) = iter.next() {
             let params = params
@@ -272,7 +304,20 @@ impl AbiParser {
                 .strip_prefix('(')
                 .and_then(|s| s.strip_suffix(')'))
                 .ok_or_else(|| format_err!("Expected parentheses at `{}`", s))?;
-            self.parse_params(params)?
+
+            let output_params = self.parse_params(params)?;
+            let mut outputs = Vec::with_capacity(output_params.len());
+            let mut output_types = Vec::new();
+
+            for (output, struct_name) in output_params {
+                if let Some(struct_name) = struct_name {
+                    // keep track of the user defined struct of that param
+                    output_types.push(struct_name);
+                }
+                outputs.push(output);
+            }
+            self.outputs.insert(name.clone(), output_types);
+            outputs
         } else {
             Vec::new()
         };
@@ -289,31 +334,33 @@ impl AbiParser {
         })
     }
 
-    fn parse_params(&self, s: &str) -> Result<Vec<Param>> {
+    fn parse_params(&self, s: &str) -> Result<Vec<(Param, Option<String>)>> {
         s.split(',')
             .filter(|s| !s.is_empty())
             .map(|s| self.parse_param(s))
             .collect::<Result<Vec<_>, _>>()
     }
 
-    fn parse_type(&self, type_str: &str) -> Result<ParamType> {
+    /// Returns the `ethabi` `ParamType` for the function parameter and the aliased struct type, if it is a user defined struct
+    fn parse_type(&self, type_str: &str) -> Result<(ParamType, Option<String>)> {
         if let Ok(kind) = Reader::read(type_str) {
-            Ok(kind)
+            Ok((kind, None))
         } else {
             // try struct instead
             if let Ok(field) = StructFieldType::parse(type_str) {
                 let struct_ty = field
                     .as_struct()
                     .ok_or_else(|| format_err!("Expected struct type `{}`", type_str))?;
+                let name = struct_ty.name();
                 let tuple = self
                     .struct_tuples
-                    .get(struct_ty.name())
+                    .get(name)
                     .cloned()
                     .map(ParamType::Tuple)
                     .ok_or_else(|| format_err!("Unknown struct `{}`", struct_ty.name()))?;
 
                 if let Some(field) = field.as_struct() {
-                    Ok(field.as_param(tuple))
+                    Ok((field.as_param(tuple), Some(name.to_string())))
                 } else {
                     bail!("Expected struct type")
                 }
@@ -324,6 +371,15 @@ impl AbiParser {
     }
 
     pub fn parse_constructor(&self, s: &str) -> Result<Constructor> {
+        let inputs = self
+            .constructor_inputs(s)?
+            .into_iter()
+            .map(|s| s.0)
+            .collect();
+        Ok(Constructor { inputs })
+    }
+
+    fn constructor_inputs(&self, s: &str) -> Result<Vec<(Param, Option<String>)>> {
         let mut input = s.trim();
         if !input.starts_with("constructor") {
             bail!("Not a constructor `{}`", input)
@@ -338,12 +394,10 @@ impl AbiParser {
             .last()
             .ok_or_else(|| format_err!("Expected closing `)` in `{}`", s))?;
 
-        let inputs = self.parse_params(params)?;
-
-        Ok(Constructor { inputs })
+        self.parse_params(params)
     }
 
-    fn parse_param(&self, param: &str) -> Result<Param> {
+    fn parse_param(&self, param: &str) -> Result<(Param, Option<String>)> {
         let mut iter = param.trim().rsplitn(3, is_whitespace);
 
         let mut name = iter
@@ -360,11 +414,14 @@ impl AbiParser {
             type_str = name;
             name = "";
         }
-
-        Ok(Param {
-            name: name.to_string(),
-            kind: self.parse_type(type_str)?,
-        })
+        let (kind, user_struct) = self.parse_type(type_str)?;
+        Ok((
+            Param {
+                name: name.to_string(),
+                kind,
+            },
+            user_struct,
+        ))
     }
 }
 

--- a/ethers-core/src/abi/human_readable.rs
+++ b/ethers-core/src/abi/human_readable.rs
@@ -289,9 +289,16 @@ impl AbiParser {
             "" => None,
             input_params_args => Some(input_params_args),
         };
+        let modifiers = match input_args_modifiers_iter
+            .next()
+            .ok_or_else(|| format_err!("Expected input args parentheses at `{}`", s))?
+        {
+            "" => None,
+            modifiers => Some(modifiers),
+        };
 
         let inputs = if let Some(params) = input_args {
-            self
+            let inputs = self
                 .parse_params(params)?
                 .into_iter()
                 .map(|(input, struct_name)| {
@@ -302,7 +309,8 @@ impl AbiParser {
                     }
                     input
                 })
-                .collect()
+                .collect();
+            inputs
         } else {
             Vec::new()
         };

--- a/ethers-core/src/abi/human_readable.rs
+++ b/ethers-core/src/abi/human_readable.rs
@@ -298,7 +298,8 @@ impl AbiParser {
         };
 
         let inputs = if let Some(params) = input_args {
-            let inputs = self
+            
+            self
                 .parse_params(params)?
                 .into_iter()
                 .map(|(input, struct_name)| {
@@ -309,8 +310,7 @@ impl AbiParser {
                     }
                     input
                 })
-                .collect();
-            inputs
+                .collect()
         } else {
             Vec::new()
         };

--- a/ethers-core/src/abi/human_readable.rs
+++ b/ethers-core/src/abi/human_readable.rs
@@ -298,8 +298,7 @@ impl AbiParser {
         };
 
         let inputs = if let Some(params) = input_args {
-            let inputs = self
-                .parse_params(params)?
+            self.parse_params(params)?
                 .into_iter()
                 .map(|(input, struct_name)| {
                     if let Some(struct_name) = struct_name {
@@ -309,8 +308,7 @@ impl AbiParser {
                     }
                     input
                 })
-                .collect();
-            inputs
+                .collect()
         } else {
             Vec::new()
         };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Support custom structs as contract params in human readable abi
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* keep track of the function's types (input, output) in the abi parser, this is added on top the existing parser and adds a bit more verbosity in to the param parse functions...
* reuse the existing `InternalStructs` when determine function inputs
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
