### PR TITLE
fix: allow clippy::redundant_clone and clippy::type_complexity in abigen

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract/common.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/common.rs
@@ -16,6 +16,8 @@ pub(crate) fn imports(name: &str) -> TokenStream {
     quote! {
         #![allow(clippy::enum_variant_names)]
         #![allow(dead_code)]
+        #![allow(clippy::redundant_clone)]
+        #![allow(clippy::type_complexity)]
         #![allow(unused_imports)]
         #doc
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
some files generated by abigen do not lint with clippy- e.g. 
```
warning: redundant clone
   --> src/data_sources/bindings/frax_abi.rs:812:73
    |
812 |             if let Ok(decoded) = WithdrawnLockedFilter::from_token(token.clone()) {
    |                                                                         ^^^^^^^^ help: remove this
    |
note: this value is dropped without further use
```
```
warning: very complex type used. Consider factoring parts into `type` definitions
   --> src/data_sources/bindings/frax_abi.rs:174:14
    |
174 |           ) -> ethers::contract::builders::ContractCall<
    |  ______________^
175 | |             M,
176 | |             Vec<(
177 | |                 [u8; 32],
...   |
182 | |             )>,
183 | |         > {
    | |_________^
    |
    = note: `#[warn(clippy::type_complexity)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity
```
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
adds `#![allow(clippy::redundant_clone)]` and `#![allow(clippy::type_complexity)]` to abigen

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
