### PR TITLE
test(middleware): fix flapping gas oracle

### DIFF
--- a/ethers-middleware/tests/gas_oracle.rs
+++ b/ethers-middleware/tests/gas_oracle.rs
@@ -39,7 +39,7 @@ async fn using_gas_oracle() {
 
     // assign a gas oracle to use
     let gas_oracle = FakeGasOracle {
-        gas_price: U256::from(1337),
+        gas_price: 1337.into(),
     };
     let expected_gas_price = gas_oracle.fetch().await.unwrap();
 


### PR DESCRIPTION
## Motivation

[CI tests are flapping](https://github.com/gakonst/ethers-rs/runs/3914532490) because gas price changes between retrieving from Gas Station as expected and using it in middleware.

## Solution

Implement fake gas price oracle, so we can be sure price doesn't change during the test.

## PR Checklist

- [x] Implement `FakeGasOracle`
