### PR TITLE
feat(providers): unify get_block_receipts for eth/parity RPCs

### DIFF
--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -557,14 +557,6 @@ pub trait Middleware: Sync + Send + Debug {
 
     // Parity namespace
 
-    /// Returns all receipts for that block. Must be done on a parity node.
-    async fn parity_block_receipts<T: Into<BlockNumber> + Send + Sync>(
-        &self,
-        block: T,
-    ) -> Result<Vec<TransactionReceipt>, Self::Error> {
-        self.inner().parity_block_receipts(block).await.map_err(FromErr::from)
-    }
-
     async fn subscribe<T, R>(
         &self,
         params: T,

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -864,7 +864,7 @@ impl<P: JsonRpcClient> Provider<P> {
 
         let resolver_address: Address = decode_bytes(ParamType::Address, data);
         if resolver_address == Address::zero() {
-            return Err(ProviderError::EnsError(ens_name.to_owned()));
+            return Err(ProviderError::EnsError(ens_name.to_owned()))
         }
 
         // resolve

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -36,6 +36,7 @@ pub enum NodeClient {
     Erigon,
     OpenEthereum,
     Nethermind,
+    Besu,
 }
 
 /// An abstract provider for interacting with the [Ethereum JSON RPC
@@ -139,6 +140,7 @@ impl<P: JsonRpcClient> Provider<P> {
                 Some("Erigon") => Some(NodeClient::Erigon),
                 Some("OpenEthereum") => Some(NodeClient::OpenEthereum),
                 Some("Nethermind") => Some(NodeClient::Nethermind),
+                Some("besu") => Some(NodeClient::Besu),
                 _ => None,
             };
         }


### PR DESCRIPTION
## Motivation

Resolve https://github.com/gakonst/ethers-rs/issues/367

## Solution

Unify `get_block_receipts` for erigon/parity nodes into one method

## PR Checklist

- [x] Introduce `NodeClient` enum w/ `TryFrom` implementation for parsing from `web3_clientVersion`
- [x] Store provider's node client type under mutex on first `Provider::node_client()` call
- [x] Decide which RPC to use for `get_block_receipts` depending on node client type
