### PR TITLE
test(middleware): get rinkeby private key from env var

### DIFF
--- a/ethers-middleware/tests/nonce_manager.rs
+++ b/ethers-middleware/tests/nonce_manager.rs
@@ -14,7 +14,8 @@ async fn nonce_manager() {
             .interval(Duration::from_millis(2000u64));
     let chain_id = provider.get_chainid().await.unwrap().as_u64();
 
-    let wallet = "fa4a1a79e869a96fcb42727f75e3232d6865a82ea675bb95de967a7fe6a773b2"
+    let wallet = std::env::var("RINKEBY_PRIVATE_KEY")
+        .unwrap()
         .parse::<LocalWallet>()
         .unwrap()
         .with_chain_id(chain_id);


### PR DESCRIPTION
## Motivation

Test is failing because account needs to have some ether in it and we got no ether in it, sad. If we'll send some ether to the address used in the test, it'll be drained quickly, no bueno.

## Solution

Use private key for rinkeby account from environment variable (@gakonst needs to set it for GitHub Actions and send some rinkeby ether to this account)
