### PR TITLE
feat(solc): Multiple Solc Version detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,10 @@ ledger = ["ethers-signers/ledger"]
 yubi = ["ethers-signers/yubi"]
 ## contracts
 abigen = ["ethers-contract/abigen"]
+## solc
+solc-async = ["ethers-solc/async"]
+solc-full = ["ethers-solc/full"]
+
 
 
 [dependencies]

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -37,6 +37,5 @@ tokio = { version = "1.12.0", features = ["full"] }
 tempdir = "0.3.7"
 
 [features]
-default = ["full"]
 async = ["tokio", "futures-util"]
 full = ["async", "svm"]

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -37,5 +37,6 @@ tokio = { version = "1.12.0", features = ["full"] }
 tempdir = "0.3.7"
 
 [features]
+default = ["full"]
 async = ["tokio", "futures-util"]
 full = ["async", "svm"]

--- a/ethers-solc/src/artifacts.rs
+++ b/ethers-solc/src/artifacts.rs
@@ -612,7 +612,9 @@ pub struct DeployedBytecode {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct GasEstimates {
     pub creation: Creation,
+    #[serde(default)]
     pub external: BTreeMap<String, String>,
+    #[serde(default)]
     pub internal: BTreeMap<String, String>,
 }
 

--- a/ethers-solc/src/artifacts.rs
+++ b/ethers-solc/src/artifacts.rs
@@ -47,6 +47,15 @@ impl CompilerInput {
         self.settings.optimizer.runs(runs);
         self
     }
+
+    /// Normalizes the EVM version used in the settings to be up to the latest one
+    /// supported by the provided compiler version.
+    pub fn normalize_evm_version(mut self, version: &Version) -> Self {
+        if let Some(ref mut evm_version) = self.settings.evm_version {
+            self.settings.evm_version = evm_version.normalize_version(version);
+        }
+        self
+    }
 }
 
 impl Default for CompilerInput {
@@ -210,8 +219,8 @@ pub enum EvmVersion {
     Petersburg,
     Istanbul,
     Berlin,
-    London,
     Byzantium,
+    London,
 }
 
 impl EvmVersion {
@@ -871,6 +880,39 @@ mod tests {
             serde_json::from_str::<CompilerInput>(&compiler_output).unwrap_or_else(|err| {
                 panic!("Failed to read compiler output of {} {}", path.display(), err)
             });
+        }
+    }
+
+    #[test]
+    fn test_evm_version_normalization() {
+        for (solc_version, evm_version, expected) in &[
+            // Ensure 0.4.21 it always returns None
+            ("0.4.20", EvmVersion::Homestead, None),
+            // Constantinople clipping
+            ("0.4.21", EvmVersion::Homestead, Some(EvmVersion::Homestead)),
+            ("0.4.21", EvmVersion::Constantinople, Some(EvmVersion::Constantinople)),
+            ("0.4.21", EvmVersion::London, Some(EvmVersion::Constantinople)),
+            // Petersburg
+            ("0.5.5", EvmVersion::Homestead, Some(EvmVersion::Homestead)),
+            ("0.5.5", EvmVersion::Petersburg, Some(EvmVersion::Petersburg)),
+            ("0.5.5", EvmVersion::London, Some(EvmVersion::Petersburg)),
+            // Istanbul
+            ("0.5.14", EvmVersion::Homestead, Some(EvmVersion::Homestead)),
+            ("0.5.14", EvmVersion::Istanbul, Some(EvmVersion::Istanbul)),
+            ("0.5.14", EvmVersion::London, Some(EvmVersion::Istanbul)),
+            // Berlin
+            ("0.8.5", EvmVersion::Homestead, Some(EvmVersion::Homestead)),
+            ("0.8.5", EvmVersion::Berlin, Some(EvmVersion::Berlin)),
+            ("0.8.5", EvmVersion::London, Some(EvmVersion::Berlin)),
+            // London
+            ("0.8.7", EvmVersion::Homestead, Some(EvmVersion::Homestead)),
+            ("0.8.7", EvmVersion::London, Some(EvmVersion::London)),
+            ("0.8.7", EvmVersion::London, Some(EvmVersion::London)),
+        ] {
+            assert_eq!(
+                &evm_version.normalize_version(&Version::from_str(solc_version).unwrap()),
+                expected
+            )
         }
     }
 }

--- a/ethers-solc/src/compile.rs
+++ b/ethers-solc/src/compile.rs
@@ -112,7 +112,7 @@ impl Solc {
         Ok(solc)
     }
 
-    /// Assuming the `versions` array is sorted, it returns the first element which satisfies
+    /// Assuming the `versions` array is sorted, it returns the latest element which satisfies
     /// the provided [`VersionReq`]
     pub fn find_matching_installation(
         versions: &[Version],

--- a/ethers-solc/src/compile.rs
+++ b/ethers-solc/src/compile.rs
@@ -35,6 +35,7 @@ pub const BERLIN_SOLC: Version = Version::new(0, 8, 5);
 /// https://blog.soliditylang.org/2021/08/11/solidity-0.8.7-release-announcement/
 pub const LONDON_SOLC: Version = Version::new(0, 8, 7);
 
+#[cfg(all(feature = "svm", feature = "async"))]
 use once_cell::sync::Lazy;
 
 #[cfg(all(feature = "svm", feature = "async"))]
@@ -106,6 +107,7 @@ impl Solc {
         Ok(solc)
     }
 
+    #[cfg(all(feature = "svm", feature = "async"))]
     fn find_matching_installation(
         versions: &[Version],
         required_version: &VersionReq,
@@ -150,7 +152,7 @@ impl Solc {
 
     /// Parses the given source looking for the `pragma` definition and
     /// returns the corresponding SemVer version requirement.
-    fn version_req(source: &Source) -> Result<VersionReq> {
+    pub fn version_req(source: &Source) -> Result<VersionReq> {
         let version = crate::utils::find_version_pragma(&source.content)
             .ok_or(SolcError::PragmaNotFound)?
             .replace(" ", ",");

--- a/ethers-solc/src/compile.rs
+++ b/ethers-solc/src/compile.rs
@@ -56,7 +56,7 @@ pub static RELEASES: Lazy<Vec<Version>> = Lazy::new(|| {
 /// Abstraction over `solc` command line utility
 ///
 /// Supports sync and async functions.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Solc(pub PathBuf);
 
 impl Default for Solc {

--- a/ethers-solc/src/error.rs
+++ b/ethers-solc/src/error.rs
@@ -8,6 +8,10 @@ pub enum SolcError {
     /// Internal solc error
     #[error("Solc Error: {0}")]
     SolcError(String),
+    #[error("missing pragma from solidity file")]
+    PragmaNotFound,
+    #[error("could not find solc version locally or upstream")]
+    VersionNotFound,
     #[error(transparent)]
     SemverError(#[from] semver::Error),
     /// Deserialization error
@@ -16,6 +20,9 @@ pub enum SolcError {
     /// Deserialization error
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[cfg(feature = "svm")]
+    #[error(transparent)]
+    SvmError(#[from] svm::SolcVmError),
 }
 
 impl SolcError {

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -93,8 +93,58 @@ impl Project {
     ///
     /// NOTE: this does not check if the contracts were successfully compiled, see
     /// `CompilerOutput::has_error` instead.
+
+    /// NB: If the `svm` feature is enabled, this function will automatically detect
+    /// solc versions across files.
     pub fn compile(&self) -> Result<ProjectCompileOutput> {
-        let mut sources = self.sources()?;
+        let sources = self.sources()?;
+
+        #[cfg(not(all(feature = "svm", feature = "async")))]
+        {
+            self.compile_with_version(&self.solc, sources)
+        }
+        #[cfg(all(feature = "svm", feature = "async"))]
+        self.svm_compile(sources)
+    }
+
+    #[cfg(all(feature = "svm", feature = "async"))]
+    fn svm_compile(&self, sources: Sources) -> Result<ProjectCompileOutput> {
+        // split them by version
+        let mut sources_by_version = BTreeMap::new();
+        for (path, source) in sources.into_iter() {
+            // will detect and install the solc version
+            let version = Solc::detect_version(&source)?;
+            // gets the solc binary for that version, it is expected tha this will succeed
+            // AND find the solc since it was installed right above
+            let solc = Solc::find_svm_installed_version(version.to_string())?
+                .expect("solc should have been installed");
+            let entry = sources_by_version.entry(solc).or_insert_with(BTreeMap::new);
+            entry.insert(path, source);
+        }
+
+        // run the compilation step for each version
+        let mut res = CompilerOutput::default();
+        for (solc, sources) in sources_by_version {
+            let output = self.compile_with_version(&solc, sources)?;
+            if let ProjectCompileOutput::Compiled((compiled, _)) = output {
+                res.errors.extend(compiled.errors);
+                res.sources.extend(compiled.sources);
+                res.contracts.extend(compiled.contracts);
+            }
+        }
+
+        Ok(if res.contracts.is_empty() {
+            ProjectCompileOutput::Unchanged
+        } else {
+            ProjectCompileOutput::Compiled((res, &self.ignored_error_codes))
+        })
+    }
+
+    pub fn compile_with_version(
+        &self,
+        solc: &Solc,
+        mut sources: Sources,
+    ) -> Result<ProjectCompileOutput> {
         // add all libraries to the source set while keeping track of their actual disk path
         let mut source_name_path = HashMap::new();
         let mut path_source_name = HashMap::new();
@@ -246,5 +296,36 @@ impl<'a> fmt::Display for ProjectCompileOutput<'a> {
                 output.diagnostics(ignored_error_codes).fmt(f)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(all(feature = "svm", feature = "async"))]
+    fn test_build_all_versions() {
+        let paths = ProjectPathsConfig::builder()
+            .root("./test-data/test-contract-versions")
+            .sources("./test-data/test-contract-versions")
+            .build()
+            .unwrap();
+        let project = Project::builder()
+            .paths(paths)
+            .ephemeral()
+            .artifacts(ArtifactOutput::Nothing)
+            .build()
+            .unwrap();
+        let compiled = project.compile().unwrap();
+        let contracts = match compiled {
+            ProjectCompileOutput::Compiled((out, _)) => {
+                assert!(!out.has_error());
+                out.contracts
+            }
+            _ => panic!("must compile"),
+        };
+        // Contracts A to F
+        assert_eq!(contracts.keys().count(), 5);
     }
 }

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -301,11 +301,12 @@ impl<'a> fmt::Display for ProjectCompileOutput<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
 
     #[test]
     #[cfg(all(feature = "svm", feature = "async"))]
     fn test_build_all_versions() {
+        use super::*;
+
         let paths = ProjectPathsConfig::builder()
             .root("./test-data/test-contract-versions")
             .sources("./test-data/test-contract-versions")

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -120,8 +120,8 @@ impl Project {
         // replace absolute path with source name to make solc happy
         let sources = apply_mappings(sources, path_source_name);
 
-        let input = CompilerInput::with_sources(sources);
-        let output = self.solc.compile(&input)?;
+        let input = CompilerInput::with_sources(sources).normalize_evm_version(&solc.version()?);
+        let output = solc.compile(&input)?;
         if output.has_error() {
             return Ok(ProjectCompileOutput::Compiled((output, &self.ignored_error_codes)))
         }

--- a/ethers-solc/test-data/test-contract-versions/caret-0.4.14.sol
+++ b/ethers-solc/test-data/test-contract-versions/caret-0.4.14.sol
@@ -1,0 +1,5 @@
+pragma solidity ^0.4.14;
+
+contract B {
+    function foo() public {}
+}

--- a/ethers-solc/test-data/test-contract-versions/greater-equal-0.5.0.sol
+++ b/ethers-solc/test-data/test-contract-versions/greater-equal-0.5.0.sol
@@ -1,0 +1,5 @@
+pragma solidity >=0.5.0;
+
+contract C {
+    function foo() public {}
+}

--- a/ethers-solc/test-data/test-contract-versions/pinned-0.4.14.sol
+++ b/ethers-solc/test-data/test-contract-versions/pinned-0.4.14.sol
@@ -1,0 +1,5 @@
+pragma solidity =0.4.14;
+
+contract D {
+    function foo() public {}
+}

--- a/ethers-solc/test-data/test-contract-versions/range-0.5.0.sol
+++ b/ethers-solc/test-data/test-contract-versions/range-0.5.0.sol
@@ -1,0 +1,5 @@
+pragma solidity >=0.4.0 <0.5.0;
+
+contract E {
+    function foo() public {}
+}

--- a/ethers-solc/test-data/test-contract-versions/simple-0.4.14.sol
+++ b/ethers-solc/test-data/test-contract-versions/simple-0.4.14.sol
@@ -1,0 +1,5 @@
+pragma solidity =0.4.14;
+
+contract F {
+    function foo() public {}
+}

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -25,7 +25,11 @@ fn can_compile_hardhat_sample() {
     // let paths = ProjectPathsConfig::hardhat(root).unwrap();
 
     let project = Project::builder().paths(paths).build().unwrap();
-    assert_ne!(project.compile().unwrap(), ProjectCompileOutput::Unchanged);
+    let compiled = project.compile().unwrap();
+    match compiled {
+        ProjectCompileOutput::Compiled((out, _)) => assert!(!out.has_error()),
+        _ => panic!("must compile"),
+    }
     // nothing to compile
     assert_eq!(project.compile().unwrap(), ProjectCompileOutput::Unchanged);
 }
@@ -46,10 +50,13 @@ fn can_compile_dapp_sample() {
         .root(root)
         .build()
         .unwrap();
-    // let paths = ProjectPathsConfig::dapptools(root).unwrap();
 
     let project = Project::builder().paths(paths).build().unwrap();
-    assert_ne!(project.compile().unwrap(), ProjectCompileOutput::Unchanged);
+    let compiled = project.compile().unwrap();
+    match compiled {
+        ProjectCompileOutput::Compiled((out, _)) => assert!(!out.has_error()),
+        _ => panic!("must compile"),
+    }
     // nothing to compile
     assert_eq!(project.compile().unwrap(), ProjectCompileOutput::Unchanged);
 }


### PR DESCRIPTION
We port over the logic for detecting and automatically using the right solc version from [dapptools-rs solc](https://github.com/gakonst/dapptools-rs/tree/master/solc), leveraging the SVM and Async features. If these features are disabled, no automatic solc detection will be done, and it will use the solc version as defined in `ethers_solc::Solc`'s rules.