### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Improve error message from failure in `ethers_contract_abigen::Source::parse` [#552](https://github.com/gakonst/ethers-rs/pull/552)
 - use enumerated aliases for overloaded functions [#545](https://github.com/gakonst/ethers-rs/pull/545)
 - move `AbiEncode` `AbiDecode` trait to ethers-core and implement for core types [#531](https://github.com/gakonst/ethers-rs/pull/531)
 - add `EthCall` trait and derive macro which generates matching structs for contract calls [#517](https://github.com/gakonst/ethers-rs/pull/517)

--- a/ethers-contract/ethers-contract-abigen/src/source.rs
+++ b/ethers-contract/ethers-contract-abigen/src/source.rs
@@ -76,19 +76,19 @@ impl Source {
         P: AsRef<Path>,
         S: AsRef<str>,
     {
+        let root = root.as_ref();
         cfg_if! {
             if #[cfg(target_arch = "wasm32")] {
-                let root = root.as_ref();
                 let root = if root.starts_with("/") {
                     format!("file:://{}", root.display())
                 } else {
                     format!("{}", root.display())
                 };
                 let base = Url::parse(&root)
-                    .map_err(|_| anyhow!("root path '{}' is not absolute"))?;
+                    .map_err(|_| anyhow!("root path '{}' is not absolute", root))?;
             } else {
                 let base = Url::from_directory_path(root)
-                    .map_err(|_| anyhow!("root path '{}' is not absolute"))?;
+                    .map_err(|_| anyhow!("root path '{}' is not absolute", root.display()))?;
             }
         }
         let url = base.join(source.as_ref())?;

--- a/ethers-contract/ethers-contract-abigen/src/source.rs
+++ b/ethers-contract/ethers-contract-abigen/src/source.rs
@@ -77,18 +77,18 @@ impl Source {
         S: AsRef<str>,
     {
         cfg_if! {
-             if #[cfg(target_arch = "wasm32")] {
-               let root = root.as_ref();
+            if #[cfg(target_arch = "wasm32")] {
+                let root = root.as_ref();
                 let root = if root.starts_with("/") {
-                   format!("file:://{}", root.display())
+                    format!("file:://{}", root.display())
                 } else {
                     format!("{}", root.display())
                 };
                 let base = Url::parse(&root)
                     .map_err(|_| anyhow!("root path '{}' is not absolute"))?;
-             } else {
-                   let base = Url::from_directory_path(root)
-            .map_err(|_| anyhow!("root path '{}' is not absolute"))?;
+            } else {
+                let base = Url::from_directory_path(root)
+                    .map_err(|_| anyhow!("root path '{}' is not absolute"))?;
             }
         }
         let url = base.join(source.as_ref())?;


### PR DESCRIPTION
Without this, the error message would literally be "root path '{}' is not absolute" with curly braces in it instead of the root path.

Test plan:

`cd ethers-contract/ethers-contract-abigen`
`cargo check`
`cargo check --target wasm32-unknown-unknown`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
