### PR TITLE
feat(solc): allow providing --allow-args

### DIFF
--- a/ethers-core/src/lib.rs
+++ b/ethers-core/src/lib.rs
@@ -51,6 +51,7 @@ pub mod abi;
 /// Various utilities
 pub mod utils;
 
+#[cfg(feature = "macros")]
 pub mod macros;
 
 // re-export rand to avoid potential confusion when there's rand version mismatches

--- a/ethers-solc/src/compile.rs
+++ b/ethers-solc/src/compile.rs
@@ -64,7 +64,9 @@ pub static RELEASES: Lazy<Vec<Version>> = Lazy::new(|| {
 /// Supports sync and async functions.
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Solc {
+    /// Path to the `solc` executable
     pub solc: PathBuf,
+    /// Additional arguments passed to the `solc` exectuable
     pub args: Vec<String>,
 }
 
@@ -78,6 +80,24 @@ impl Solc {
     /// A new instance which points to `solc`
     pub fn new(path: impl Into<PathBuf>) -> Self {
         Solc { solc: path.into(), args: Vec::new() }
+    }
+
+    /// Adds an argument to pass to the `solc` command.
+    pub fn arg<T: Into<String>>(mut self, arg: T) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    /// Adds multiple arguments to pass to the `solc`.
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for arg in args {
+            self = self.arg(arg);
+        }
+        self
     }
 
     /// Returns the directory in which [svm](https://github.com/roynalnaruto/svm-rs) stores all versions

--- a/ethers-solc/src/compile.rs
+++ b/ethers-solc/src/compile.rs
@@ -477,7 +477,7 @@ mod tests {
         }
         let res = Solc::find_svm_installed_version(&version.to_string()).unwrap().unwrap();
         let expected = svm::SVM_HOME.join(ver).join(format!("solc-{}", ver));
-        assert_eq!(res.0, expected);
+        assert_eq!(res.solc, expected);
     }
 
     #[test]

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -275,7 +275,6 @@ impl fmt::Debug for ArtifactOutput {
 
 use std::convert::TryFrom;
 
-#[derive(Clone, Debug)]
 /// Helper struct for serializing `--allow-paths` arguments to Solc
 ///
 /// From the [Solc docs](https://docs.soliditylang.org/en/v0.8.9/using-the-compiler.html#base-path-and-import-remapping):
@@ -285,6 +284,7 @@ use std::convert::TryFrom;
 /// but everything else is rejected by default. Additional paths (and their subdirectories)
 /// can be allowed via the --allow-paths /sample/path,/another/sample/path switch.
 /// Everything inside the path specified via --base-path is always allowed.
+#[derive(Clone, Debug, Default)]
 pub struct AllowedLibPaths(Vec<PathBuf>);
 
 impl fmt::Display for AllowedLibPaths {
@@ -292,8 +292,8 @@ impl fmt::Display for AllowedLibPaths {
         let lib_paths = self
             .0
             .iter()
-            .filter(|path| PathBuf::from(path).exists())
-            .map(|path| path.into_os_string().into_string().unwrap())
+            .filter(|path| path.exists())
+            .map(|path| format!("{}", path.display()))
             .collect::<Vec<_>>()
             .join(",");
         write!(f, "{}", lib_paths)

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -285,7 +285,7 @@ use std::convert::TryFrom;
 /// can be allowed via the --allow-paths /sample/path,/another/sample/path switch.
 /// Everything inside the path specified via --base-path is always allowed.
 #[derive(Clone, Debug, Default)]
-pub struct AllowedLibPaths(Vec<PathBuf>);
+pub struct AllowedLibPaths(pub(crate) Vec<PathBuf>);
 
 impl fmt::Display for AllowedLibPaths {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -272,3 +272,46 @@ impl fmt::Debug for ArtifactOutput {
         }
     }
 }
+
+use std::convert::TryFrom;
+
+#[derive(Clone, Debug)]
+/// Helper struct for serializing `--allow-paths` arguments to Solc
+///
+/// From the [Solc docs](https://docs.soliditylang.org/en/v0.8.9/using-the-compiler.html#base-path-and-import-remapping):
+/// For security reasons the compiler has restrictions on what directories it can access.
+/// Directories of source files specified on the command line and target paths of
+/// remappings are automatically allowed to be accessed by the file reader,
+/// but everything else is rejected by default. Additional paths (and their subdirectories)
+/// can be allowed via the --allow-paths /sample/path,/another/sample/path switch.
+/// Everything inside the path specified via --base-path is always allowed.
+pub struct AllowedLibPaths(Vec<PathBuf>);
+
+impl fmt::Display for AllowedLibPaths {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let lib_paths = self
+            .0
+            .iter()
+            .filter(|path| PathBuf::from(path).exists())
+            .map(|path| path.into_os_string().into_string().unwrap())
+            .collect::<Vec<_>>()
+            .join(",");
+        write!(f, "{}", lib_paths)
+    }
+}
+
+impl<T: Into<PathBuf>> TryFrom<Vec<T>> for AllowedLibPaths {
+    type Error = std::io::Error;
+
+    fn try_from(libs: Vec<T>) -> std::result::Result<Self, Self::Error> {
+        let libs = libs
+            .into_iter()
+            .map(|lib| {
+                let path: PathBuf = lib.into();
+                let lib = std::fs::canonicalize(path)?;
+                Ok(lib)
+            })
+            .collect::<std::result::Result<Vec<_>, std::io::Error>>()?;
+        Ok(AllowedLibPaths(libs))
+    }
+}

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -370,4 +370,35 @@ mod tests {
         // Contracts A to F
         assert_eq!(contracts.keys().count(), 5);
     }
+
+    #[test]
+    #[cfg(all(feature = "svm", feature = "async"))]
+    fn test_build_many_libs() {
+        use super::*;
+
+        let root = std::fs::canonicalize("./test-data/test-contract-libs").unwrap();
+
+        let paths = ProjectPathsConfig::builder()
+            .root(&root)
+            .sources(root.join("src"))
+            .lib(root.join("lib1"))
+            .lib(root.join("lib2"))
+            .build()
+            .unwrap();
+        let project = Project::builder()
+            .paths(paths)
+            .ephemeral()
+            .artifacts(ArtifactOutput::Nothing)
+            .build()
+            .unwrap();
+        let compiled = project.compile().unwrap();
+        let contracts = match compiled {
+            ProjectCompileOutput::Compiled((out, _)) => {
+                assert!(!out.has_error());
+                out.contracts
+            }
+            _ => panic!("must compile"),
+        };
+        assert_eq!(contracts.keys().count(), 3);
+    }
 }

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -119,10 +119,12 @@ impl Project {
             let version = Solc::detect_version(&source)?;
             // gets the solc binary for that version, it is expected tha this will succeed
             // AND find the solc since it was installed right above
-            let solc = Solc::find_svm_installed_version(version.to_string())?
-                .expect("solc should have been installed")
-                .arg("--allow-paths")
-                .arg(self.allowed_lib_paths.to_string());
+            let mut solc = Solc::find_svm_installed_version(version.to_string())?
+                .expect("solc should have been installed");
+
+            if !self.allowed_lib_paths.0.is_empty() {
+                solc = solc.arg("--allow-paths").arg(self.allowed_lib_paths.to_string());
+            }
             let entry = sources_by_version.entry(solc).or_insert_with(BTreeMap::new);
             entry.insert(path, source);
         }

--- a/ethers-solc/test-data/test-contract-libs/lib1/Bar.sol
+++ b/ethers-solc/test-data/test-contract-libs/lib1/Bar.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.8.6;
+
+contract Bar {}

--- a/ethers-solc/test-data/test-contract-libs/lib2/Baz.sol
+++ b/ethers-solc/test-data/test-contract-libs/lib2/Baz.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.8.6;
+
+contract Baz {}

--- a/ethers-solc/test-data/test-contract-libs/src/Foo.sol
+++ b/ethers-solc/test-data/test-contract-libs/src/Foo.sol
@@ -1,0 +1,6 @@
+pragma solidity 0.8.6;
+
+import "../lib1/Bar.sol";
+import "../lib2/Baz.sol";
+
+contract Foo is Bar, Baz {}


### PR DESCRIPTION
Allows providing the `--allow-paths` parameter to Solc. It defaults to `root` if none is found.