### PR TITLE
Feat/add call deployer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Unreleased
 
-- Add `.call()` method to `Deployer` for performing dry runs of contract deployments.
+- Add `.call()` method to `Deployer` for performing dry runs of contract deployments. [#554](https://github.com/gakonst/ethers-rs/pull/554)
 - Improve error message from failure in `ethers_contract_abigen::Source::parse` [#552](https://github.com/gakonst/ethers-rs/pull/552)
 - use enumerated aliases for overloaded functions [#545](https://github.com/gakonst/ethers-rs/pull/545)
 - move `AbiEncode` `AbiDecode` trait to ethers-core and implement for core types [#531](https://github.com/gakonst/ethers-rs/pull/531)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Add `.call()` method to `Deployer` for performing dry runs of contract deployments.
 - Improve error message from failure in `ethers_contract_abigen::Source::parse` [#552](https://github.com/gakonst/ethers-rs/pull/552)
 - use enumerated aliases for overloaded functions [#545](https://github.com/gakonst/ethers-rs/pull/545)
 - move `AbiEncode` `AbiDecode` trait to ethers-core and implement for core types [#531](https://github.com/gakonst/ethers-rs/pull/531)

--- a/ethers-contract/src/factory.rs
+++ b/ethers-contract/src/factory.rs
@@ -46,6 +46,19 @@ impl<M: Middleware> Deployer<M> {
         self
     }
 
+    /// Dry runs the deployment of the contract
+    ///
+    /// Note: this function _does not_ send a transaction from your account
+    pub async fn call(&self) -> Result<(), ContractError<M>> {
+        self.client
+            .call(&self.tx, Some(self.block.into()))
+            .await
+            .map_err(ContractError::MiddlewareError)?;
+
+        // TODO: It would be nice to handle reverts in a structured way.
+        Ok(())
+    }
+
     /// Broadcasts the contract deployment transaction and after waiting for it to
     /// be sufficiently confirmed (default: 1), it returns a [`Contract`](crate::Contract)
     /// struct at the deployed contract's address.

--- a/ethers-contract/tests/common/mod.rs
+++ b/ethers-contract/tests/common/mod.rs
@@ -49,5 +49,7 @@ pub fn connect(ganache: &GanacheInstance, idx: usize) -> Arc<Provider<Http>> {
 /// Launches a ganache instance and deploys the SimpleStorage contract
 pub async fn deploy<M: Middleware>(client: Arc<M>, abi: Abi, bytecode: Bytes) -> Contract<M> {
     let factory = ContractFactory::new(abi, bytecode, client);
-    factory.deploy("initial value".to_string()).unwrap().legacy().send().await.unwrap()
+    let deployer = factory.deploy("initial value".to_string()).unwrap();
+    assert!(deployer.call().await.is_ok());
+    deployer.legacy().send().await.unwrap()
 }

--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -39,6 +39,9 @@ mod eth_tests {
         // (practically it's not expected that you'll need to deploy multiple instances of
         // the _same_ deployer, so it's fine to clone here from a dev UX vs perf tradeoff)
         let deployer = factory.deploy("initial value".to_string()).unwrap().legacy();
+        // dry runs the deployment of the contract. takes the deployer by reference, no need to
+        // clone.
+        assert!(deployer.call().await.is_ok());
         let contract = deployer.clone().send().await.unwrap();
 
         let get_value = contract.method::<_, String>("getValue", ()).unwrap();


### PR DESCRIPTION
## Motivation

As it can be useful, for plentiful reasons, to perform one or several dry test runs of a contract's deployment, I hereby propose an implementation of `.call()` for the `Deployer` struct.

## Solution

The implementation is straightforward, as it consist in invoking the client's`.call()` method from the `Middleware` trait to simulate the deployment. Such doing leaves plenty of room to handle reverts in a more structured way in the future.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
