### PR TITLE
add GethTrace

### DIFF
--- a/ethers-core/src/types/trace/filter.rs
+++ b/ethers-core/src/types/trace/filter.rs
@@ -1,5 +1,5 @@
 //! Types for the Parity Transaction-Trace Filtering API
-use crate::types::{Address, BlockNumber, Bytes, H160, H256, U256};
+use crate::types::{trace::BTreeMap, Address, BlockNumber, Bytes, H160, H256, U256};
 use serde::{Deserialize, Serialize};
 
 /// Trace filter
@@ -264,6 +264,32 @@ pub enum RewardType {
     /// External (attributed as part of an external protocol)
     #[serde(rename = "external")]
     External,
+}
+
+/// Basic trace type for the Geth client.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct GethTrace {
+    failed: bool,
+    gas: i64,
+    #[serde(rename = "returnValue")]
+    return_value: Option<Bytes>,
+    #[serde(rename = "structLogs")]
+    struct_logs: Vec<OpCodeLog>,
+}
+
+/// OpCodeLog type for the Geth trace.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct OpCodeLog {
+    depth: u64,
+    error: Option<String>,
+    gas: u64,
+    #[serde(rename = "gasCost")]
+    gas_cost: u64,
+    memory: Option<Bytes>,
+    op: String,
+    pc: usize,
+    stack: Option<Vec<U256>>,
+    storage: Option<BTreeMap<H256, H256>>,
 }
 
 #[cfg(test)]

--- a/ethers-core/src/types/trace/filter.rs
+++ b/ethers-core/src/types/trace/filter.rs
@@ -282,14 +282,48 @@ pub struct GethTrace {
 pub struct OpCodeLog {
     depth: u64,
     error: Option<String>,
-    gas: u64,
+    gas: U256,
     #[serde(rename = "gasCost")]
     gas_cost: u64,
     memory: Option<Bytes>,
     op: String,
     pc: usize,
-    stack: Option<Vec<U256>>,
-    storage: Option<BTreeMap<H256, H256>>,
+    stack: StackLog,
+    storage: StorageLog,
+}
+
+/// Stack trace of a Geth trace.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum StackLog {
+    /// None
+    #[serde(rename = "none")]
+    None,
+    /// Stack
+    Stack(Vec<U256>),
+}
+
+impl Default for StackLog {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// Storage trace of a Geth trace.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum StorageLog {
+    /// None
+    #[serde(rename = "none")]
+    None,
+    /// Storage
+    Storage(BTreeMap<H256, H256>),
+}
+
+impl Default for StorageLog {
+    fn default() -> Self {
+        Self::None
+    }
 }
 
 #[cfg(test)]

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -555,6 +555,13 @@ pub trait Middleware: Sync + Send + Debug {
         self.inner().trace_transaction(hash).await.map_err(FromErr::from)
     }
 
+    /// Returns all traces of a given transaction
+    ///
+    /// Note: this should be only be used for the Geth client
+    async fn geth_trace_transaction(&self, hash: H256) -> Result<GethTrace, Self::Error> {
+        self.inner().geth_trace_transaction(hash).await.map_err(FromErr::from)
+    }
+
     // Parity namespace
 
     async fn subscribe<T, R>(

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -15,7 +15,7 @@ use ethers_core::{
     types::{
         transaction::{eip2718::TypedTransaction, eip2930::AccessListWithGasUsed},
         Address, Block, BlockId, BlockNumber, BlockTrace, Bytes, EIP1186ProofResponse, Filter, Log,
-        NameOrAddress, Selector, Signature, Trace, TraceFilter, TraceType, Transaction,
+        NameOrAddress, Selector, Signature, Trace, TraceFilter, TraceType, Transaction, GethTrace,
         TransactionReceipt, TxHash, TxpoolContent, TxpoolInspect, TxpoolStatus, H256, U256, U64,
     },
     utils,
@@ -775,6 +775,14 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
     async fn trace_transaction(&self, hash: H256) -> Result<Vec<Trace>, ProviderError> {
         let hash = utils::serialize(&hash);
         self.request("trace_transaction", vec![hash]).await
+    }
+
+    /// Returns all basic traces of a given transaction
+    ///
+    /// Note: this should be only be used for the Geth client
+    async fn geth_trace_transaction(&self, hash: H256) -> Result<GethTrace, Self::Error> {
+        let hash = utils::serialize(&hash);
+        self.request("debug_traceTransaction", vec![hash]).await
     }
 
     async fn subscribe<T, R>(

--- a/ethers-providers/src/transports/ipc.rs
+++ b/ethers-providers/src/transports/ipc.rs
@@ -236,7 +236,6 @@ where
     ) -> Result<(), IpcError> {
         // Extend buffer of previously unread with the new read bytes
         read_buffer.extend_from_slice(&bytes);
-        dbg!(read_buffer.len());
 
         let read_len = {
             // Deserialize as many full elements from the stream as exists

--- a/ethers-providers/src/transports/ipc.rs
+++ b/ethers-providers/src/transports/ipc.rs
@@ -236,6 +236,7 @@ where
     ) -> Result<(), IpcError> {
         // Extend buffer of previously unread with the new read bytes
         read_buffer.extend_from_slice(&bytes);
+        dbg!(read_buffer.len());
 
         let read_len = {
             // Deserialize as many full elements from the stream as exists

--- a/ethers-providers/src/transports/ipc.rs
+++ b/ethers-providers/src/transports/ipc.rs
@@ -37,18 +37,9 @@ type Subscription = mpsc::UnboundedSender<serde_json::Value>;
 
 #[derive(Debug)]
 enum TransportMessage {
-    Request {
-        id: u64,
-        request: String,
-        sender: Pending,
-    },
-    Subscribe {
-        id: U256,
-        sink: Subscription,
-    },
-    Unsubscribe {
-        id: U256,
-    },
+    Request { id: u64, request: String, sender: Pending },
+    Subscribe { id: U256, sink: Subscription },
+    Unsubscribe { id: U256 },
 }
 
 impl Ipc {
@@ -112,10 +103,7 @@ impl PubsubClient for Ipc {
 
     fn subscribe<T: Into<U256>>(&self, id: T) -> Result<Self::NotificationStream, IpcError> {
         let (sink, stream) = mpsc::unbounded();
-        self.send(TransportMessage::Subscribe {
-            id: id.into(),
-            sink,
-        })?;
+        self.send(TransportMessage::Subscribe { id: id.into(), sink })?;
         Ok(stream)
     }
 
@@ -157,10 +145,7 @@ where
         let f = async move {
             let mut read_buffer = Vec::new();
             loop {
-                let closed = self
-                    .process(&mut read_buffer)
-                    .await
-                    .expect("WS Server panic");
+                let closed = self.process(&mut read_buffer).await.expect("WS Server panic");
                 if closed && self.pending.is_empty() {
                     break;
                 }
@@ -197,11 +182,7 @@ where
 
     async fn handle_request(&mut self, msg: TransportMessage) -> Result<(), IpcError> {
         match msg {
-            TransportMessage::Request {
-                id,
-                request,
-                sender,
-            } => {
+            TransportMessage::Request { id, request, sender } => {
                 if self.pending.insert(id, sender).is_some() {
                     warn!("Replacing a pending request with id {:?}", id);
                 }
@@ -218,10 +199,7 @@ where
             }
             TransportMessage::Unsubscribe { id } => {
                 if self.subscriptions.remove(&id).is_none() {
-                    warn!(
-                        "Unsubscribing from non-existent subscription with id {:?}",
-                        id
-                    );
+                    warn!("Unsubscribing from non-existent subscription with id {:?}", id);
                 }
             }
         };
@@ -338,7 +316,10 @@ impl From<IpcError> for ProviderError {
 #[cfg(not(feature = "celo"))]
 mod test {
     use super::*;
-    use ethers_core::{utils::Geth, types::{Block, TxHash, U256}};
+    use ethers_core::{
+        types::{Block, TxHash, U256},
+        utils::Geth,
+    };
     use tempfile::NamedTempFile;
 
     #[tokio::test]
@@ -366,11 +347,7 @@ mod test {
 
         // Subscribing requires sending the sub request and then subscribing to
         // the returned sub_id
-        let block_num: u64 = ipc
-            .request::<_, U256>("eth_blockNumber", ())
-            .await
-            .unwrap()
-            .as_u64();
+        let block_num: u64 = ipc.request::<_, U256>("eth_blockNumber", ()).await.unwrap().as_u64();
         let mut blocks = Vec::new();
         for _ in 0..3 {
             let item = stream.next().await.unwrap();
@@ -378,13 +355,6 @@ mod test {
             blocks.push(block.number.unwrap_or_default().as_u64());
         }
         let offset = blocks[0] - block_num;
-        assert_eq!(
-            blocks,
-            &[
-                block_num + offset,
-                block_num + offset + 1,
-                block_num + offset + 2
-            ]
-        )
+        assert_eq!(blocks, &[block_num + offset, block_num + offset + 1, block_num + offset + 2])
     }
 }


### PR DESCRIPTION
## Motivation

Currently ethers-rs lacks support for transaction tracing when using the Geth client. This pull request extends the `Middleware` trait to include such functionalities.

## Solution

The implementation consists in the `GethTrace` and `OpCodeLog` structs, which handle the trace type, and the `geth_trace_transaction` method, which sends a `debug_traceTransaction` json RPC request to the node.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
