### PR TITLE
Prestwich/super pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Use rust types as contract function inputs for human readable abi [#482](https://github.com/gakonst/ethers-rs/pull/482)
 - Add EIP-712 `sign_typed_data` signer method; add ethers-core type `Eip712` trait and derive macro in ethers-derive-eip712 [#481](https://github.com/gakonst/ethers-rs/pull/481)
 - `LocalWallet::new_keystore` now returns a tuple `(LocalWallet, String)` instead of `LocalWallet`, where the string represents the UUID of the newly created encrypted JSON keystore. The JSON keystore is stored as a file `/dir/uuid`. The issue [#557](https://github.com/gakonst/ethers-rs/issues/557) is addressed [#559](https://github.com/gakonst/ethers-rs/pull/559)
+- add the missing constructor for `Timelag` middleware via [#568](https://github.com/gakonst/ethers-rs/pull/568)
+- re-export error types for `Http` and `Ws` providers in [#570](https://github.com/gakonst/ethers-rs/pull/570)
+- add a method on the `Middleware` to broadcast a tx with a series of escalating gas prices via [#566](https://github.com/gakonst/ethers-rs/pull/566)
 
 ### 0.5.3
 

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -93,6 +93,7 @@ use std::{error::Error, fmt::Debug, future::Future, pin::Pin, str::FromStr};
 
 pub use provider::{FilterKind, Provider, ProviderError};
 
+/// A simple gas escalation policy
 pub type EscalationPolicy = Box<dyn Fn(U256, usize) -> U256 + Send + Sync>;
 
 // Helper type alias
@@ -292,9 +293,9 @@ pub trait Middleware: Sync + Send + Debug {
     /// Send a transaction with a simple escalation policy.
     ///
     /// `escalation` should be a boxed function that maps `original_gas_price`
-    /// and `number_of_previous_escalations` -> `new_gas_price`
+    /// and `number_of_previous_escalations` -> `new_gas_price`.
     ///
-    /// e.g. ```Box::new(|start, escalations| start * 1250.pow(escalations) / 1000.pow(escalations))```
+    /// e.g. `Box::new(|start, escalations| start * 1250.pow(escalations) / 1000.pow(escalations))`
     ///
     async fn send_escalating<'a>(
         &'a self,

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -299,7 +299,6 @@ pub trait Middleware: Sync + Send + Debug {
     async fn send_escalating<'a>(
         &'a self,
         tx: &TypedTransaction,
-        from: &Address,
         escalation: EscalationPolicy,
     ) -> Result<EscalatingPending<'a, Self::Provider>, Self::Error> {
         let mut original = tx.clone();
@@ -314,7 +313,9 @@ pub trait Middleware: Sync + Send + Debug {
                 r
             })
             .map(|req| async move {
-                self.sign(req.rlp(chain_id), from).await.map(|sig| req.rlp_signed(chain_id, &sig))
+                self.sign(req.rlp(chain_id), &self.default_sender().unwrap_or_default())
+                    .await
+                    .map(|sig| req.rlp_signed(chain_id, &sig))
             })
             .collect();
 

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -295,7 +295,8 @@ pub trait Middleware: Sync + Send + Debug {
     /// `policy` should be a boxed function that maps `original_gas_price`
     /// and `number_of_previous_escalations` -> `new_gas_price`.
     ///
-    /// e.g. `Box::new(|start, escalation_index| start * 1250.pow(escalations) / 1000.pow(escalations))`
+    /// e.g. `Box::new(|start, escalation_index| start * 1250.pow(escalations) /
+    /// 1000.pow(escalations))`
     async fn send_escalating<'a>(
         &'a self,
         tx: &TypedTransaction,

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -292,10 +292,10 @@ pub trait Middleware: Sync + Send + Debug {
 
     /// Send a transaction with a simple escalation policy.
     ///
-    /// `escalation` should be a boxed function that maps `original_gas_price`
+    /// `policy` should be a boxed function that maps `original_gas_price`
     /// and `number_of_previous_escalations` -> `new_gas_price`.
     ///
-    /// e.g. `Box::new(|start, escalations| start * 1250.pow(escalations) / 1000.pow(escalations))`
+    /// e.g. `Box::new(|start, escalation_index| start * 1250.pow(escalations) / 1000.pow(escalations))`
     async fn send_escalating<'a>(
         &'a self,
         tx: &TypedTransaction,

--- a/ethers-providers/src/pending_escalator.rs
+++ b/ethers-providers/src/pending_escalator.rs
@@ -138,8 +138,8 @@ where
             Sleeping(instant) => {
                 if instant.elapsed() > *this.polling_interval {
                     // if timer has elapsed (or this is the first tx)
-                    if this.last.is_none()
-                        || (*this.last).unwrap().elapsed() > *this.broadcast_interval
+                    if this.last.is_none() ||
+                        (*this.last).unwrap().elapsed() > *this.broadcast_interval
                     {
                         // then if we have a TX to broadcast, start
                         // broadcasting it
@@ -147,14 +147,14 @@ where
                             let fut = this.provider.send_raw_transaction(next_to_broadcast);
                             *this.state = BroadcastingNew(fut);
                             cx.waker().wake_by_ref();
-                            return Poll::Pending;
+                            return Poll::Pending
                         }
                     }
 
                     check_all_receipts!(cx, this);
                 }
 
-                return Poll::Pending;
+                return Poll::Pending
             }
             BroadcastingNew(fut) => {
                 broadcast_checks!(cx, this, fut);
@@ -181,7 +181,7 @@ where
                     Poll::Pending => {
                         // stick it pack in the list for polling again later
                         futs.push(pollee);
-                        return Poll::Pending;
+                        return Poll::Pending
                     }
                 }
             }

--- a/ethers-providers/src/pending_escalator.rs
+++ b/ethers-providers/src/pending_escalator.rs
@@ -24,6 +24,7 @@ enum PendingStates<'a, P> {
 /// An EscalatingPending is a pending transaction that handles increasing its
 /// own gas price over time, by broadcasting successive versions with higher
 /// gas prices
+#[must_use]
 #[pin_project(project = PendingProj)]
 pub struct EscalatingPending<'a, P>
 where

--- a/ethers-providers/src/pending_escalator.rs
+++ b/ethers-providers/src/pending_escalator.rs
@@ -1,0 +1,181 @@
+use ethers_core::types::{Bytes, TransactionReceipt, H256};
+use pin_project::pin_project;
+use std::{
+    collections::HashMap,
+    future::{self, Future},
+    pin::Pin,
+    task::Poll,
+    time::{Duration, Instant},
+};
+use tokio::{sync::RwLock, time::Sleep};
+
+use crate::{JsonRpcClient, Middleware, PendingTransaction, Provider, ProviderError};
+
+type LockedMap<K, V> = RwLock<HashMap<K, RwLock<V>>>;
+
+/// tmp
+#[pin_project(project = PendingProj)]
+pub struct SuperPending<'a, P>
+where
+    P: JsonRpcClient,
+{
+    provider: &'a Provider<P>,
+    broadcast_interval: Duration,
+    polling_interval: Duration,
+    txns: Vec<Bytes>,
+    last: Option<Instant>,
+    sent: Vec<H256>,
+    state: PendingStates<'a, P>,
+}
+
+impl<'a, P> SuperPending<'a, P>
+where
+    P: JsonRpcClient,
+{
+    /// Instantiate a new SuperPending
+    pub(crate) fn new(
+        provider: &'a Provider<P>,
+        broadcast_interval: u64,
+        polling_interval: u64,
+        mut txns: Vec<Bytes>,
+    ) -> Self {
+        if txns.is_empty() {
+            panic!("bad args");
+        }
+
+        let first = txns.pop().expect("bad args");
+        Self {
+            provider,
+            broadcast_interval: Duration::from_millis(broadcast_interval),
+            polling_interval: Duration::from_millis(polling_interval),
+            txns,
+            last: None,
+            sent: vec![],
+            state: PendingStates::Initial(provider.send_raw_transaction(first)),
+        }
+    }
+}
+
+type PinBoxFut<'a, T> = Pin<Box<dyn future::Future<Output = T> + 'a + Send>>;
+
+enum PendingStates<'a, P> {
+    Initial(PinBoxFut<'a, Result<PendingTransaction<'a, P>, ProviderError>>),
+    Sleeping(Pin<Box<Sleep>>),
+    BroadcastingNew(PinBoxFut<'a, Result<PendingTransaction<'a, P>, ProviderError>>),
+    CheckingReceipts(Vec<PinBoxFut<'a, Result<Option<TransactionReceipt>, ProviderError>>>),
+    Completed,
+}
+
+macro_rules! check_all_receipts {
+    ($cx:ident, $this:ident) => {
+        let futs: Vec<_> = $this
+            .sent
+            .iter()
+            .map(|tx_hash| $this.provider.get_transaction_receipt(*tx_hash))
+            .collect();
+        *$this.state = CheckingReceipts(futs);
+        $cx.waker().wake_by_ref();
+        return Poll::Pending;
+    };
+}
+
+macro_rules! sleep {
+    ($cx:ident, $this:ident) => {
+        *$this.state =
+            PendingStates::Sleeping(Box::pin(tokio::time::sleep(*$this.polling_interval)));
+        $cx.waker().wake_by_ref();
+        return Poll::Pending;
+    };
+}
+
+macro_rules! completed {
+    ($this:ident, $output:expr) => {
+        *$this.state = Completed;
+        return Poll::Ready($output);
+    };
+}
+
+macro_rules! broadcast_checks {
+    ($cx:ident, $this:ident, $fut:ident) => {
+        match $fut.as_mut().poll($cx) {
+            Poll::Ready(Ok(pending)) => {
+                $this.sent.push(*pending);
+                check_all_receipts!($cx, $this);
+            }
+            Poll::Ready(Err(e)) => {
+                completed!($this, Err(e));
+            }
+            Poll::Pending => return Poll::Pending,
+        }
+    };
+}
+
+impl<'a, P> Future for SuperPending<'a, P>
+where
+    P: JsonRpcClient,
+{
+    type Output = Result<TransactionReceipt, ProviderError>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        use PendingStates::*;
+
+        let this = self.project();
+
+        match this.state {
+            Initial(fut) => {
+                broadcast_checks!(cx, this, fut);
+            }
+            Sleeping(fut) => {
+                if fut.as_mut().poll(cx).is_ready() {
+                    // if timer has elapsed (or this is the first tx)
+                    if this.last.is_none()
+                        || this.last.clone().unwrap().elapsed() > *this.broadcast_interval
+                    {
+                        // then if we have a TX to broadcast, start
+                        // broadcasting it
+                        if let Some(next_to_broadcast) = this.txns.pop() {
+                            let fut = this.provider.send_raw_transaction(next_to_broadcast);
+                            *this.state = BroadcastingNew(fut);
+                            cx.waker().wake_by_ref();
+                            return Poll::Pending;
+                        }
+                    }
+
+                    check_all_receipts!(cx, this);
+                }
+
+                return Poll::Pending;
+            }
+            BroadcastingNew(fut) => {
+                broadcast_checks!(cx, this, fut);
+            }
+            CheckingReceipts(futs) => {
+                // if drained, sleep
+                if futs.is_empty() {
+                    sleep!(cx, this);
+                }
+
+                // otherwise drain one and check if we have a receipt
+                match futs.pop().expect("checked").as_mut().poll(cx) {
+                    //
+                    Poll::Ready(Ok(Some(receipt))) => {
+                        completed!(this, Ok(receipt));
+                    }
+                    // rewake until drained
+                    Poll::Ready(Ok(None)) => cx.waker().wake_by_ref(),
+                    // bubble up errors
+                    Poll::Ready(Err(e)) => {
+                        completed!(this, Err(e));
+                    }
+                    Poll::Pending => return Poll::Pending,
+                }
+            }
+            Completed => panic!("polled after completion"),
+        }
+
+        Poll::Pending
+    }
+}

--- a/ethers-providers/src/pending_escalator.rs
+++ b/ethers-providers/src/pending_escalator.rs
@@ -63,6 +63,8 @@ where
             broadcast_interval: Duration::from_millis(150),
             polling_interval: Duration::from_millis(10),
             txns,
+            // placeholder value. We set this again after the initial broadcast
+            // future resolves
             last: Instant::now(),
             sent: vec![],
             state: PendingStates::Initial(Box::pin(provider.send_raw_transaction(first))),
@@ -112,6 +114,7 @@ macro_rules! poll_broadcast_fut {
     ($cx:ident, $this:ident, $fut:ident) => {
         match $fut.as_mut().poll($cx) {
             Poll::Ready(Ok(pending)) => {
+                *$this.last = Instant::now();
                 $this.sent.push(*pending);
                 tracing::info!(
                     tx_hash = ?*pending,

--- a/ethers-providers/src/pending_escalator.rs
+++ b/ethers-providers/src/pending_escalator.rs
@@ -72,14 +72,22 @@ where
         }
     }
 
-    pub fn broadcast_interval(mut self, duration: u64) -> Self {
-        self.broadcast_interval = Duration::from_secs(duration);
+    pub fn with_broadcast_interval(mut self, duration: impl Into<Duration>) -> Self {
+        self.broadcast_interval = duration.into();
         self
     }
 
-    pub fn polling_interval(mut self, duration: u64) -> Self {
-        self.polling_interval = Duration::from_secs(duration);
+    pub fn with_polling_interval(mut self, duration: impl Into<Duration>) -> Self {
+        self.polling_interval = duration.into();
         self
+    }
+
+    pub fn get_polling_interval(&self) -> Duration {
+        self.polling_interval
+    }
+
+    pub fn get_broadcast_interval(&self) -> Duration {
+        self.broadcast_interval
     }
 }
 

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -871,7 +871,7 @@ impl<P: JsonRpcClient> Provider<P> {
 
         let resolver_address: Address = decode_bytes(ParamType::Address, data);
         if resolver_address == Address::zero() {
-            return Err(ProviderError::EnsError(ens_name.to_owned()));
+            return Err(ProviderError::EnsError(ens_name.to_owned()))
         }
 
         // resolve

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -10,6 +10,7 @@ use crate::{
 use crate::CeloMiddleware;
 use crate::Middleware;
 use async_trait::async_trait;
+
 use ethers_core::{
     abi::{self, Detokenize, ParamType},
     types::{
@@ -870,7 +871,7 @@ impl<P: JsonRpcClient> Provider<P> {
 
         let resolver_address: Address = decode_bytes(ParamType::Address, data);
         if resolver_address == Address::zero() {
-            return Err(ProviderError::EnsError(ens_name.to_owned()))
+            return Err(ProviderError::EnsError(ens_name.to_owned()));
         }
 
         // resolve


### PR DESCRIPTION
## Motivation

Provide a reasonable and working alternative to gas escalator middleware. 

## Solution

- Introduce a new Future `EscalatingPending` that broadcasts a series of transactions
    - functions similarly to `PendingTransaction` but with a simpler (but less informative) state machine
    - it returns the _first_ receipt to confirm.
    - it also returns the _first_ RPC error to occur
    - it allows users to configure polling and broadcast intervals
- Add a middleware method `send_escalating` 
    - allows users to instantiate with a TypedTransaction and an escalation policy
    - may be better as a middleware extension trait?

## things I don't like
- Invariant enforcement is done in the Middleware method rather than the constructor. 
    - This is brittle
    - it's hard to see how to sign and nonce correctly otherwise
- Naming

## PR Checklist

- [ ] Added Tests
- [X] Added Documentation
- [x] Updated the changelog
