### PR TITLE
fix: adds TimeLag::new() method

### DIFF
--- a/ethers-middleware/src/timelag/mod.rs
+++ b/ethers-middleware/src/timelag/mod.rs
@@ -41,6 +41,16 @@ impl<M, const K: u8> TimeLag<M, K>
 where
     M: Middleware,
 {
+    /// Instantiates TimeLag provider
+    pub fn new(inner: M) -> Self {
+        Self { inner: inner.into() }
+    }
+}
+
+impl<M, const K: u8> TimeLag<M, K>
+where
+    M: Middleware,
+{
     async fn normalize_block_id(&self, id: Option<BlockId>) -> TimeLagResult<Option<BlockId>, M> {
         match id {
             Some(BlockId::Number(n)) => {


### PR DESCRIPTION
<h1> Motivation </h1>

`ethers:middleware::TimeLag` missing `fn new(...) -> Self`

<h1> Solution </h1>

Adds function to instantiate new `TimeLag`