### PR TITLE
chore: re-export http client error in providers transports

### DIFF
--- a/ethers-providers/src/transports/mod.rs
+++ b/ethers-providers/src/transports/mod.rs
@@ -24,7 +24,7 @@ if_not_wasm! {
 }
 
 mod http;
-pub use http::Provider as Http;
+pub use http::{ClientError as HttpClientError, Provider as Http};
 
 #[cfg(feature = "ws")]
 mod ws;

--- a/ethers-providers/src/transports/mod.rs
+++ b/ethers-providers/src/transports/mod.rs
@@ -29,7 +29,7 @@ pub use http::{ClientError as HttpClientError, Provider as Http};
 #[cfg(feature = "ws")]
 mod ws;
 #[cfg(feature = "ws")]
-pub use ws::Ws;
+pub use ws::{ClientError as WsClientError, Ws};
 
 mod quorum;
 pub(crate) use quorum::JsonRpcClientWrapper;


### PR DESCRIPTION

## Motivation

Allow direct wrapping of the Provider to enable (e.g.) providers with exponenital backoff. Because we want to change the functionality of the `request` method, this cannot be a middleware and must be a provider

## Solution

Exported the un-exported `http::ClientError` and `ws::ClientError` types so that wrapping types can name them

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
