### PR TITLE
refactor!: make artifactoutput a trait

### DIFF
--- a/ethers-solc/src/artifacts.rs
+++ b/ethers-solc/src/artifacts.rs
@@ -403,11 +403,20 @@ impl CompilerOutput {
 
     /// Finds the first contract with the given name
     pub fn find(&self, contract: impl AsRef<str>) -> Option<CompactContractRef> {
-        let contract = contract.as_ref();
-        self.contracts
-            .values()
-            .find_map(|contracts| contracts.get(contract))
-            .map(CompactContractRef::from)
+        let contract_name = contract.as_ref();
+        self.contracts_iter().find_map(|(name, contract)| {
+            (name == contract_name).then(|| CompactContractRef::from(contract))
+        })
+    }
+
+    /// Iterate over all contracts and their names
+    pub fn contracts_iter(&self) -> impl Iterator<Item = (&String, &Contract)> {
+        self.contracts.values().flatten()
+    }
+
+    /// Iterate over all contracts and their names
+    pub fn contracts_into_iter(self) -> impl Iterator<Item = (String, Contract)> {
+        self.contracts.into_values().flatten()
     }
 
     /// Given the contract file's path and the contract's name, tries to return the contract's

--- a/ethers-solc/src/artifacts.rs
+++ b/ethers-solc/src/artifacts.rs
@@ -296,8 +296,8 @@ impl FromStr for EvmVersion {
 }
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SettingsMetadata {
-    #[serde(rename = "useLiteralContent")]
-    pub use_literal_content: bool,
+    #[serde(default, rename = "useLiteralContent", skip_serializing_if = "Option::is_none")]
+    pub use_literal_content: Option<bool>,
     #[serde(default, rename = "bytecodeHash", skip_serializing_if = "Option::is_none")]
     pub bytecode_hash: Option<String>,
 }

--- a/ethers-solc/src/artifacts.rs
+++ b/ethers-solc/src/artifacts.rs
@@ -779,6 +779,7 @@ pub struct Ewasm {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct StorageLayout {
     pub storage: Vec<Storage>,
+    #[serde(default)]
     pub types: BTreeMap<String, StorageType>,
 }
 

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -311,15 +311,15 @@ pub struct HardhatArtifacts;
 impl ArtifactsOutput for HardhatArtifacts {
     type Artifact = serde_json::Value;
 
-    fn on_output(output: &CompilerOutput, layout: &ProjectPathsConfig) -> Result<()> {
+    fn on_output(_output: &CompilerOutput, _layout: &ProjectPathsConfig) -> Result<()> {
         todo!("Hardhat style artifacts not yet implemented")
     }
 
-    fn read_cached_artifact(path: impl AsRef<Path>) -> Result<Self::Artifact> {
+    fn read_cached_artifact(_path: impl AsRef<Path>) -> Result<Self::Artifact> {
         todo!("Hardhat style artifacts not yet implemented")
     }
 
-    fn output_to_artifacts(output: CompilerOutput) -> Vec<Self::Artifact> {
+    fn output_to_artifacts(_output: CompilerOutput) -> Vec<Self::Artifact> {
         todo!("Hardhat style artifacts not yet implemented")
     }
 }

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -332,28 +332,6 @@ pub trait ArtifactOutput {
     }
 }
 
-/// An artifacts implementation that does not emit
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct NoArtifacts;
-
-impl ArtifactOutput for NoArtifacts {
-    type Artifact = ();
-
-    fn on_output(_: &CompilerOutput, _: &ProjectPathsConfig) -> Result<()> {
-        Ok(())
-    }
-
-    fn output_exists(_: impl AsRef<Path>, _: impl AsRef<str>, _: impl AsRef<Path>) -> bool {
-        true
-    }
-
-    fn read_cached_artifact(_: impl AsRef<Path>) -> Result<Self::Artifact> {
-        Ok(())
-    }
-
-    fn contract_to_artifact(_: Contract) -> Self::Artifact {}
-}
-
 /// An Artifacts implementation that uses a compact representation
 ///
 /// Creates a single json artifact with

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -76,8 +76,8 @@ impl Project {
     /// or use the builder directly
     ///
     /// ```rust
-    /// use ethers_solc::ProjectBuilder;
-    /// let config = ProjectBuilder::default().build().unwrap();
+    /// use ethers_solc::{MinimalCombinedArtifacts, ProjectBuilder};
+    /// let config = ProjectBuilder::<MinimalCombinedArtifacts>::default().build().unwrap();
     /// ```
     pub fn builder() -> ProjectBuilder {
         ProjectBuilder::default()

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -171,7 +171,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
         for (solc, sources) in sources_by_version {
             let output = self.compile_with_version(&solc, sources)?;
             // TODO(mattsse): this is still a bit clunky, because if there are both compiled and
-            //  unchanged, the unchanged artifacts are not included in the res compileroutput
+            //  unchanged, the unchanged artifacts are not included in the res compiler output
             if let ProjectCompileOutput::Compiled((compiled, _)) = output {
                 res.errors.extend(compiled.errors);
                 res.sources.extend(compiled.sources);

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -407,9 +407,14 @@ impl<Artifacts: ArtifactOutput> Default for ProjectBuilder<Artifacts> {
     }
 }
 
+/// The outcome of `Project::compile`
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct ProjectCompileOutput<T: ArtifactOutput> {
+    /// If solc was invoked multiple times in `Project::compile` then this contains a merged
+    /// version of all `CompilerOutput`s. If solc was called only once then `compiler_output`
+    /// holds the `CompilerOutput` of that call.
     pub compiler_output: Option<CompilerOutput>,
+    /// All artifacts that were read from cache
     artifacts: BTreeMap<PathBuf, T::Artifact>,
     ignored_error_codes: Vec<u64>,
 }
@@ -438,6 +443,7 @@ impl<T: ArtifactOutput> ProjectCompileOutput<T> {
         }
     }
 
+    /// Combine two outputs
     pub fn extend(&mut self, compiled: ProjectCompileOutput<T>) {
         let ProjectCompileOutput { compiler_output, artifacts, .. } = compiled;
         self.artifacts.extend(artifacts);
@@ -452,6 +458,7 @@ impl<T: ArtifactOutput> ProjectCompileOutput<T> {
         }
     }
 
+    /// Whether this type does not contain compiled contracts
     pub fn is_unchanged(&self) -> bool {
         !self.has_compiled_contracts()
     }

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -413,7 +413,7 @@ pub struct ProjectCompileOutput<T: ArtifactOutput> {
     /// If solc was invoked multiple times in `Project::compile` then this contains a merged
     /// version of all `CompilerOutput`s. If solc was called only once then `compiler_output`
     /// holds the `CompilerOutput` of that call.
-    pub compiler_output: Option<CompilerOutput>,
+    compiler_output: Option<CompilerOutput>,
     /// All artifacts that were read from cache
     artifacts: BTreeMap<PathBuf, T::Artifact>,
     ignored_error_codes: Vec<u64>,
@@ -441,6 +441,20 @@ impl<T: ArtifactOutput> ProjectCompileOutput<T> {
             artifacts: Default::default(),
             ignored_error_codes,
         }
+    }
+
+    /// Get the (merged) solc compiler output
+    /// ```no_run
+    /// use std::collections::BTreeMap;
+    /// use ethers_solc::artifacts::Contract;
+    /// use ethers_solc::Project;
+    ///
+    /// let project = Project::builder().build().unwrap();
+    /// let contracts: BTreeMap<String, Contract> =
+    ///     project.compile().unwrap().output().contracts_into_iter().collect();
+    /// ```
+    pub fn output(self) -> CompilerOutput {
+        self.compiler_output.unwrap_or_default()
     }
 
     /// Combine two outputs
@@ -580,7 +594,7 @@ mod tests {
             Project::builder().artifacts::<NoArtifacts>().paths(paths).ephemeral().build().unwrap();
         let compiled = project.compile().unwrap();
         assert!(!compiled.has_compiler_errors());
-        let contracts = compiled.compiler_output.unwrap().contracts;
+        let contracts = compiled.output().contracts;
         // Contracts A to F
         assert_eq!(contracts.keys().count(), 5);
     }
@@ -603,7 +617,7 @@ mod tests {
             Project::builder().paths(paths).ephemeral().artifacts::<NoArtifacts>().build().unwrap();
         let compiled = project.compile().unwrap();
         assert!(!compiled.has_compiler_errors());
-        let contracts = compiled.compiler_output.unwrap().contracts;
+        let contracts = compiled.output().contracts;
         assert_eq!(contracts.keys().count(), 3);
     }
 
@@ -623,7 +637,7 @@ mod tests {
             Project::builder().artifacts::<NoArtifacts>().paths(paths).ephemeral().build().unwrap();
         let compiled = project.compile().unwrap();
         assert!(!compiled.has_compiler_errors());
-        let contracts = compiled.compiler_output.unwrap().contracts;
+        let contracts = compiled.output().contracts;
         assert_eq!(contracts.keys().count(), 2);
     }
 }

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn serde() {
         let remapping = "oz=../b/c/d";
-        let remapping = Remapping::from_str(&remapping).unwrap();
+        let remapping = Remapping::from_str(remapping).unwrap();
         assert_eq!(remapping.name, "oz".to_string());
         assert_eq!(remapping.path, "../b/c/d".to_string());
 

--- a/ethers-solc/test-data/dapp-sample/src/Dapp.sol
+++ b/ethers-solc/test-data/dapp-sample/src/Dapp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.6.6;
+pragma solidity >=0.6.6;
 
 contract Dapp {
 }

--- a/ethers-solc/test-data/dapp-sample/src/Dapp.t.sol
+++ b/ethers-solc/test-data/dapp-sample/src/Dapp.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.6.6;
+pragma solidity >=0.6.6;
 
 import "ds-test/test.sol";
 

--- a/ethers-solc/test-data/hardhat-sample/contracts/Greeter.sol
+++ b/ethers-solc/test-data/hardhat-sample/contracts/Greeter.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity ^0.6.0;
+pragma solidity >=0.6.0;
 
 import "hardhat/console.sol";
 

--- a/ethers-solc/test-data/out/compiler-out-1.json
+++ b/ethers-solc/test-data/out/compiler-out-1.json
@@ -33,7 +33,6 @@
     "sourceFile.sol": {
       "ContractName": {
         "abi": [],
-        "metadata": "{/* ... */}",
         "userdoc": {},
         "devdoc": {},
         "ir": "",

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -26,12 +26,25 @@ fn can_compile_hardhat_sample() {
 
     let project = Project::builder().paths(paths).build().unwrap();
     let compiled = project.compile().unwrap();
+    assert!(compiled.find("Greeter").is_some());
+    assert!(compiled.find("console").is_some());
     match compiled {
         ProjectCompileOutput::Compiled((out, _)) => assert!(!out.has_error()),
         _ => panic!("must compile"),
     }
+
     // nothing to compile
-    assert!(project.compile().unwrap().is_unchanged());
+    let compiled = project.compile().unwrap();
+    assert!(compiled.find("Greeter").is_some());
+    assert!(compiled.find("console").is_some());
+    assert!(compiled.is_unchanged());
+
+    // delete artifacts
+    std::fs::remove_dir_all(&project.paths.artifacts).unwrap();
+    let compiled = project.compile().unwrap();
+    assert!(compiled.find("Greeter").is_some());
+    assert!(compiled.find("console").is_some());
+    assert!(!compiled.is_unchanged());
 }
 
 #[test]
@@ -53,10 +66,19 @@ fn can_compile_dapp_sample() {
 
     let project = Project::builder().paths(paths).build().unwrap();
     let compiled = project.compile().unwrap();
+    assert!(compiled.find("Dapp").is_some());
     match compiled {
         ProjectCompileOutput::Compiled((out, _)) => assert!(!out.has_error()),
         _ => panic!("must compile"),
     }
     // nothing to compile
-    assert!(project.compile().unwrap().is_unchanged());
+    let compiled = project.compile().unwrap();
+    assert!(compiled.find("Dapp").is_some());
+    assert!(compiled.is_unchanged());
+
+    // delete artifacts
+    std::fs::remove_dir_all(&project.paths.artifacts).unwrap();
+    let compiled = project.compile().unwrap();
+    assert!(compiled.find("Dapp").is_some());
+    assert!(!compiled.is_unchanged());
 }

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -31,7 +31,7 @@ fn can_compile_hardhat_sample() {
         _ => panic!("must compile"),
     }
     // nothing to compile
-    assert_eq!(project.compile().unwrap(), ProjectCompileOutput::Unchanged);
+    assert!(project.compile().unwrap().is_unchanged());
 }
 
 #[test]
@@ -58,5 +58,5 @@ fn can_compile_dapp_sample() {
         _ => panic!("must compile"),
     }
     // nothing to compile
-    assert_eq!(project.compile().unwrap(), ProjectCompileOutput::Unchanged);
+    assert!(project.compile().unwrap().is_unchanged());
 }

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -1,8 +1,6 @@
 //! project tests
 
-use ethers_solc::{
-    cache::SOLIDITY_FILES_CACHE_FILENAME, Project, ProjectCompileOutput, ProjectPathsConfig,
-};
+use ethers_solc::{cache::SOLIDITY_FILES_CACHE_FILENAME, Project, ProjectPathsConfig};
 use std::path::PathBuf;
 use tempdir::TempDir;
 
@@ -28,10 +26,7 @@ fn can_compile_hardhat_sample() {
     let compiled = project.compile().unwrap();
     assert!(compiled.find("Greeter").is_some());
     assert!(compiled.find("console").is_some());
-    match compiled {
-        ProjectCompileOutput::Compiled((out, _)) => assert!(!out.has_error()),
-        _ => panic!("must compile"),
-    }
+    assert!(!compiled.has_compiler_errors());
 
     // nothing to compile
     let compiled = project.compile().unwrap();
@@ -67,10 +62,8 @@ fn can_compile_dapp_sample() {
     let project = Project::builder().paths(paths).build().unwrap();
     let compiled = project.compile().unwrap();
     assert!(compiled.find("Dapp").is_some());
-    match compiled {
-        ProjectCompileOutput::Compiled((out, _)) => assert!(!out.has_error()),
-        _ => panic!("must compile"),
-    }
+    assert!(!compiled.has_compiler_errors());
+
     // nothing to compile
     let compiled = project.compile().unwrap();
     assert!(compiled.find("Dapp").is_some());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Improved artifacts handling in `Project::compile`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* introduce `ArtifactOutput` trait
* keep mapping contract file -> artrifacts
* ensure artifacts exists when checking cache
* get easy access to `Artifact` from `ProjectCompilerOutput` whether it's unchanged or compiled.
* make `ProjectCompileOutput` a struct

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
