### PR TITLE
Prestwich/escalator fixes

### DIFF
--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -167,6 +167,14 @@ where
         true
     }
 
+    async fn sign_transaction(
+        &self,
+        tx: &TypedTransaction,
+        _: Address,
+    ) -> Result<Signature, Self::Error> {
+        Ok(self.signer.sign_transaction(tx).await.map_err(SignerMiddlewareError::SignerError)?)
+    }
+
     /// Helper for filling a transaction's nonce using the wallet
     async fn fill_transaction(
         &self,

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -315,7 +315,7 @@ pub trait Middleware: Sync + Send + Debug {
                 r
             })
             .map(|req| async move {
-                self.sign(req.rlp(chain_id), &self.default_sender().unwrap_or_default())
+                self.sign_transaction(&req, self.default_sender().unwrap_or_default())
                     .await
                     .map(|sig| req.rlp_signed(chain_id, &sig))
             })
@@ -454,6 +454,15 @@ pub trait Middleware: Sync + Send + Debug {
         from: &Address,
     ) -> Result<Signature, Self::Error> {
         self.inner().sign(data, from).await.map_err(FromErr::from)
+    }
+
+    /// Sign a transaction via RPC call
+    async fn sign_transaction(
+        &self,
+        tx: &TypedTransaction,
+        from: Address,
+    ) -> Result<Signature, Self::Error> {
+        self.inner().sign_transaction(tx, from).await.map_err(FromErr::from)
     }
 
     ////// Contract state

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -125,6 +125,9 @@ pub enum ProviderError {
 
     #[error("unsupported node client")]
     UnsupportedNodeClient,
+
+    #[error("Attempted to sign a transaction with no available signer. Hint: did you mean to use a SignerMiddleware?")]
+    SignerUnavailable,
 }
 
 /// Types of filters supported by the JSON-RPC.
@@ -515,6 +518,15 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         let sig = hex::decode(sig)?;
         Ok(Signature::try_from(sig.as_slice())
             .map_err(|e| ProviderError::CustomError(e.to_string()))?)
+    }
+
+    /// Sign a transaction via RPC call
+    async fn sign_transaction(
+        &self,
+        _tx: &TypedTransaction,
+        _from: Address,
+    ) -> Result<Signature, Self::Error> {
+        Err(ProviderError::SignerUnavailable).map_err(FromErr::from)
     }
 
     ////// Contract state


### PR DESCRIPTION
## Motivation

Pending escalation broken by lack of availability of tx signing on middleware

## Solution

Add `Middleware::sign_transaction`. It errors unless there is a `SignerMiddleware` in the stack somewhere. The `from` field has no effect (matching behavior of `SignerMiddleware::sign` but is added to match the `Middleware::sign` API for potential future use.

driveby: while testing escalation locally, hit an edge case with tx braodcast failing due to a previous escalation confirming during broadcast. Added a handler for that in the `Broadcasting` state transition

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
