### PR TITLE
chore: bump ethers-core to 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "arrayvec 0.7.2",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ethers-core"
 license = "MIT OR Apache-2.0"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"
 description = "Core structures for the ethers-rs crate"


### PR DESCRIPTION
## Motivation

We bumped `impl-serde` to new version but forgot to do so for `ethers-core` where it's used

## Solution

1. Bump `ethers-core` and `ethers` versions
2. Publish crate (@gakonst help needed)

