### PR TITLE
chore: don't look for remappings on hardhat

### DIFF
--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -81,7 +81,6 @@ impl PathStyle {
                 .sources(root.join("contracts"))
                 .artifacts(root.join("artifacts"))
                 .lib(root.join("node_modules"))
-                .remappings(Remapping::find_many(&root.join("node_modules"))?)
                 .root(root)
                 .build()?,
         })


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Remapping::find_mapping looks through the whole node_modules folder which takes ages.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
