### PR TITLE
fix(solc): do not unnecessarily query for solc version

### DIFF
--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -3,7 +3,7 @@ use crate::{
     cache::SOLIDITY_FILES_CACHE_FILENAME,
     error::Result,
     remappings::Remapping,
-    CompilerOutput, Solc,
+    CompilerOutput,
 };
 use ethers_core::{abi::Abi, types::Bytes};
 use serde::{Deserialize, Serialize};
@@ -178,8 +178,6 @@ impl ProjectPathsConfigBuilder {
 /// The config to use when compiling the contracts
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SolcConfig {
-    /// Configured solc version
-    pub version: String,
     /// How the file was compiled
     pub settings: Settings,
 }
@@ -200,16 +198,10 @@ impl SolcConfig {
 
 #[derive(Default)]
 pub struct SolcConfigBuilder {
-    version: Option<String>,
     settings: Option<Settings>,
 }
 
 impl SolcConfigBuilder {
-    pub fn version(mut self, version: impl Into<String>) -> Self {
-        self.version = Some(version.into());
-        self
-    }
-
     pub fn settings(mut self, settings: Settings) -> Self {
         self.settings = Some(settings);
         self
@@ -219,11 +211,8 @@ impl SolcConfigBuilder {
     ///
     /// If no solc version is configured then it will be determined by calling `solc --version`.
     pub fn build(self) -> Result<SolcConfig> {
-        let Self { version, settings } = self;
-        let version =
-            version.map(Ok).unwrap_or_else(|| Solc::default().version().map(|s| s.to_string()))?;
-        let settings = settings.unwrap_or_default();
-        Ok(SolcConfig { version, settings })
+        let Self { settings } = self;
+        Ok(SolcConfig { settings: settings.unwrap_or_default() })
     }
 }
 

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -385,10 +385,7 @@ impl<Artifacts: ArtifactOutput> ProjectBuilder<Artifacts> {
         } = self;
 
         let solc = solc.unwrap_or_default();
-        let solc_config = solc_config.map(Ok).unwrap_or_else(|| {
-            let version = solc.version()?;
-            SolcConfig::builder().version(version.to_string()).build()
-        })?;
+        let solc_config = solc_config.map(Ok).unwrap_or_else(|| SolcConfig::builder().build())?;
 
         let paths = paths.map(Ok).unwrap_or_else(ProjectPathsConfig::current_hardhat)?;
 


### PR DESCRIPTION
The parameter is not used in any useful way currently, and it prevents us from using clean installations of SVM
which do not have an instantiated /Users/gakonst/.svm directory