### PR TITLE
Fix/providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - add the missing constructor for `Timelag` middleware via [#568](https://github.com/gakonst/ethers-rs/pull/568)
 - re-export error types for `Http` and `Ws` providers in [#570](https://github.com/gakonst/ethers-rs/pull/570)
 - add a method on the `Middleware` to broadcast a tx with a series of escalating gas prices via [#566](https://github.com/gakonst/ethers-rs/pull/566)
+- Remove unnecessary `Serialize` constraint to `R` (the Response type) in the `request` method of `JsonRpcClient`.
+- Fix `http Provider` data race when generating new request `id`s.
 
 ### 0.5.3
 

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -116,7 +116,7 @@ pub trait JsonRpcClient: Debug + Send + Sync {
     async fn request<T, R>(&self, method: &str, params: T) -> Result<R, Self::Error>
     where
         T: Debug + Serialize + Send + Sync,
-        R: Serialize + DeserializeOwned;
+        R: DeserializeOwned;
 }
 
 use ethers_core::types::*;

--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -68,8 +68,7 @@ impl JsonRpcClient for Provider {
         method: &str,
         params: T,
     ) -> Result<R, ClientError> {
-        let next_id = self.id.load(Ordering::SeqCst) + 1;
-        self.id.store(next_id, Ordering::SeqCst);
+        let next_id = self.id.fetch_add(1, Ordering::SeqCst);
 
         let payload = Request::new(next_id, method, params);
 


### PR DESCRIPTION
## Motivation

While reviewing the ethers-providers crate I noticed two small details that could be easily fixed.

The first one is a data race when generating a new id for the http Provider.

The second one is the `JsonRpcClient` trait requiring `R` (the Response) to be `Serialize`, when in fact the Response should only require `Deserialize`.  When writing client only code, we shouldn't need to define serializers for reponse types.

## Solution

For the data race I just copied the new id generation from the Websocket implementation.

For the unnecessary `Serialize` in the `JsonRpcClient` Response, I just removed it.

## PR Checklist

- [x] Added Tests
    - I didn't add tests because the data race is hard to test, and the removal of the `Serialize` in the `JsonRpcClient` response can be already verified to work with the current tests.
- [x] Added Documentation
    - I didn't see the need to add documentation for these changes
- [x] Updated the changelog
