### PR TITLE
fix: contract version detection must respect imports

### DIFF
--- a/ethers-solc/test-data/test-contract-inheritance/child.sol
+++ b/ethers-solc/test-data/test-contract-inheritance/child.sol
@@ -1,0 +1,6 @@
+pragma solidity >=0.7.2;
+
+import "./Parent.sol";
+import "./Mother.sol";
+
+contract Child is Parent, Mother {}

--- a/ethers-solc/test-data/test-contract-inheritance/child.sol
+++ b/ethers-solc/test-data/test-contract-inheritance/child.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.7.2;
 
-import "./Parent.sol";
-import "./Mother.sol";
+import "./parent.sol";
+import "./mother.sol";
 
 contract Child is Parent, Mother {}

--- a/ethers-solc/test-data/test-contract-inheritance/grandparent.sol
+++ b/ethers-solc/test-data/test-contract-inheritance/grandparent.sol
@@ -1,0 +1,3 @@
+pragma solidity ^0.7.0;
+
+contract GrandParent {}

--- a/ethers-solc/test-data/test-contract-inheritance/mother.sol
+++ b/ethers-solc/test-data/test-contract-inheritance/mother.sol
@@ -1,0 +1,6 @@
+pragma solidity <=0.7.4;
+
+import "./grandparent.sol";
+
+contract Mother is GrandParent {}
+

--- a/ethers-solc/test-data/test-contract-inheritance/parent.sol
+++ b/ethers-solc/test-data/test-contract-inheritance/parent.sol
@@ -1,0 +1,5 @@
+pragma solidity >=0.7.3;
+
+import "./grandparent.sol";
+
+contract Parent is GrandParent { }


### PR DESCRIPTION
Currently, when detecting the Solc version in a contract, we only parse its own pragma import and use the latest version available for that constraint. 

However, a contract may also import other contracts which may restrict the pragma import.

An example can be seen in thet `test-data` folder where while `Child` would work with any compiler `>=0.7.2`, the rdependency on `Mother` which is `<=0.7.4` and `GrandParent` which is `^0.7.0` should restrict it to 0.7.4.

Before this PR, this restriction was not respected, and it'd try to use `0.8.10` (the currently latest version of the compiler)