### PR TITLE
chore: enable zeroize feature for k256

### DIFF
--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -19,7 +19,7 @@ rlp-derive = { version = "0.1.0", default-features = false }
 ecdsa = { version = "0.12.3", default-features = false, features = ["std"] }
 elliptic-curve = { version = "0.10.6", default-features = false }
 generic-array = { version = "0.14.4", default-features = false }
-k256 = { version = "0.9.5", default-features = false, features = ["keccak256", "ecdsa"] }
+k256 = { version = "0.9.5", default-features = false, features = ["keccak256", "ecdsa", "zeroize"] }
 rand = { version = "0.8.4", default-features = false }
 tiny-keccak = { version = "2.0.2", default-features = false }
 


### PR DESCRIPTION
for best security ,  the crate of the k256 is support the zeroize trait
