### PR TITLE
Fix parse units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add EIP-712 `sign_typed_data` signer method; add ethers-core type `Eip712`
   trait and derive macro in ethers-derive-eip712
   [#481](https://github.com/gakonst/ethers-rs/pull/481)
+- Fix `format_units` to return a `String` of representing a decimal point float such that the decimal places don't get truncated. [597](https://github.com/gakonst/ethers-rs/pull/597)
 
 ### 0.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## ethers-core
 
+- Fix `format_units` to return a `String` of representing a decimal point float
+  such that the decimal places don't get truncated.
+  [597](https://github.com/gakonst/ethers-rs/pull/597)
+
 ### Unreleased
 
 ### 0.6.0
@@ -11,7 +15,6 @@
 - Add EIP-712 `sign_typed_data` signer method; add ethers-core type `Eip712`
   trait and derive macro in ethers-derive-eip712
   [#481](https://github.com/gakonst/ethers-rs/pull/481)
-- Fix `format_units` to return a `String` of representing a decimal point float such that the decimal places don't get truncated. [597](https://github.com/gakonst/ethers-rs/pull/597)
 
 ### 0.5.3
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
parse_units and format_units were not behaving as expected when the decimal number was greater than 15 such as ether amounts

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
modified parse_units and format_units to use rug::Float of 128bit such that 18 decimal point floats don't get truncated. format_units now returns a rug::Float so that might break code that is using this function however it's an easy fix for such projects.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
