### PR TITLE
revert: unify get_block_receipts for eth/parity RPCs

### DIFF
--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -616,6 +616,14 @@ pub trait Middleware: Sync + Send + Debug {
 
     // Parity namespace
 
+    /// Returns all receipts for that block. Must be done on a parity node.
+    async fn parity_block_receipts<T: Into<BlockNumber> + Send + Sync>(
+        &self,
+        block: T,
+    ) -> Result<Vec<TransactionReceipt>, Self::Error> {
+        self.inner().parity_block_receipts(block).await.map_err(FromErr::from)
+    }
+
     async fn subscribe<T, R>(
         &self,
         params: T,


### PR DESCRIPTION
recent unified solution prevents the use of rpcdaemon with offline db without running erigon. this commit reverts to previous state as discussed on telegram.