### PR TITLE
Update Cryptography crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,6 @@ jobs:
             export PATH=$HOME/bin:$PATH
             geth version
 
-      - name: Install libusb (for Ledger)
-        run: sudo apt update && sudo apt install pkg-config libudev-dev
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -121,8 +119,6 @@ jobs:
           profile: minimal
           components: rustfmt, clippy
           override: true
-      - name: Install Dependencies
-        run: sudo apt-get install libudev-dev
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,9 +956,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01ff20862362c34074072c8be2de97399633d6b1d2114afa56bf77a8b7f0a4"
+checksum = "decb3a27ea454a5f23f96eb182af0671c12694d64ecc33dada74edd1301f6cfc"
 dependencies = [
  "crypto-bigint",
  "der",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,21 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,15 +41,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "anomaly"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550632e31568ae1a5f47998c3aa48563030fc49b9ec91913ca337cf64fbc5ccb"
-dependencies = [
- "backtrace",
 ]
 
 [[package]]
@@ -150,21 +126,6 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "backtrace"
-version = "0.3.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base58"
@@ -452,7 +413,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
  "winapi",
 ]
 
@@ -488,14 +448,15 @@ dependencies = [
 
 [[package]]
 name = "coins-bip32"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b669993c632e5fec4a297085ec57381f53e4646c123cb77a7ca754e005c921"
+checksum = "471b39eadc9323de375dce5eff149a5a1ebd21c67f1da34a56f87ee62191d4ea"
 dependencies = [
  "bincode",
  "bs58",
  "coins-core",
  "digest 0.9.0",
+ "getrandom 0.2.3",
  "hmac",
  "k256",
  "lazy_static",
@@ -506,16 +467,16 @@ dependencies = [
 
 [[package]]
 name = "coins-bip39"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38426029442f91bd49973d6f59f28e3dbb14e633e3019ac4ec6bce402c44f81c"
+checksum = "8f473ea37dfc9d2cb94fdde50c3d41f28c3f384b367573d66386fea38d76d466"
 dependencies = [
  "bitvec 0.17.4",
  "coins-bip32",
  "getrandom 0.2.3",
  "hex",
  "hmac",
- "pbkdf2",
+ "pbkdf2 0.8.0",
  "rand 0.8.4",
  "sha2 0.9.8",
  "thiserror",
@@ -544,16 +505,16 @@ dependencies = [
 
 [[package]]
 name = "coins-ledger"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2943c8f53555b1f2ab5c047520b9fd73e5b0b22d216375b5b0112a7d2ae2a1c"
+checksum = "498841803f751d49bb08fe4a88b514087c52e5df885575ed4757f14ab151e239"
 dependencies = [
  "async-trait",
  "blake2b_simd",
  "byteorder",
  "cfg-if 0.1.10",
  "futures",
- "hidapi",
+ "hidapi-rusb",
  "js-sys",
  "lazy_static",
  "libc",
@@ -614,12 +575,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
 
 [[package]]
 name = "const-oid"
@@ -763,18 +718,6 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
-dependencies = [
- "generic-array 0.14.4",
- "rand_core 0.6.3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
@@ -889,20 +832,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
-dependencies = [
- "const-oid 0.6.2",
-]
-
-[[package]]
-name = "der"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
- "const-oid 0.7.1",
+ "const-oid",
 ]
 
 [[package]]
@@ -981,13 +915,13 @@ checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
 name = "ecdsa"
-version = "0.12.4"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
+checksum = "e91ae02c7618ee05108cd86a0be2f5586d1f0d965bede7ecfd46815f1b860227"
 dependencies = [
- "der 0.4.5",
- "elliptic-curve 0.10.6",
- "hmac",
+ "der",
+ "elliptic-curve",
+ "rfc6979",
  "signature",
 ]
 
@@ -1022,30 +956,17 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
-dependencies = [
- "crypto-bigint 0.2.11",
- "ff",
- "generic-array 0.14.4",
- "group",
- "pkcs8",
- "rand_core 0.6.3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01ff20862362c34074072c8be2de97399633d6b1d2114afa56bf77a8b7f0a4"
 dependencies = [
- "crypto-bigint 0.3.2",
- "der 0.5.1",
+ "crypto-bigint",
+ "der",
+ "ff",
  "generic-array 0.14.4",
+ "group",
  "rand_core 0.6.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -1076,7 +997,7 @@ dependencies = [
  "digest 0.9.0",
  "hex",
  "hmac",
- "pbkdf2",
+ "pbkdf2 0.8.0",
  "rand 0.8.4",
  "scrypt",
  "serde",
@@ -1214,7 +1135,7 @@ dependencies = [
  "cargo_metadata",
  "convert_case",
  "ecdsa",
- "elliptic-curve 0.11.5",
+ "elliptic-curve",
  "ethabi",
  "futures-util",
  "generic-array 0.14.4",
@@ -1333,7 +1254,7 @@ dependencies = [
  "coins-bip32",
  "coins-bip39",
  "coins-ledger",
- "elliptic-curve 0.11.5",
+ "elliptic-curve",
  "eth-keystore",
  "ethers-contract",
  "ethers-core",
@@ -1415,9 +1336,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "ff"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -1623,12 +1544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
-
-[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,9 +1551,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "group"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
 dependencies = [
  "ff",
  "rand_core 0.6.3",
@@ -1669,12 +1584,6 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
-name = "harp"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bf12c625ed5e96f81609ae4377c34e9fa3e4d1fada392404322daeace511ab"
 
 [[package]]
 name = "hashbrown"
@@ -1713,14 +1622,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
-name = "hidapi"
+name = "hidapi-rusb"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6f5e247bc66f3255d755e96d9d43f6b191f4e182072b811d55584ff58c510f"
+checksum = "99e0b15c35f9c35cbadd0c388197364e8ff3feffd23b69cd45524a014932f5f1"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
+ "rusb",
 ]
 
 [[package]]
@@ -1947,13 +1857,14 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
+checksum = "58e786b08b1c90389266b21e238894b88c03296b44db6c6a797484c6fb3e6e5a"
 dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
- "elliptic-curve 0.10.6",
+ "elliptic-curve",
+ "sec1",
  "sha2 0.9.8",
  "sha3",
 ]
@@ -1978,9 +1889,9 @@ checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libusb1-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22e89d08bbe6816c6c5d446203b859eba35b8fa94bf1b7edb2f6d25d43f023f"
+checksum = "b8772b7e8d4d988e19684aec5a3f5e470ecaf5c705cf0303da3973508e873027"
 dependencies = [
  "cc",
  "libc",
@@ -2058,16 +1969,6 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
 
 [[package]]
 name = "mio"
@@ -2167,15 +2068,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "object"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,23 +2135,25 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
+checksum = "d0e0c5310031b5d4528ac6534bccc1446c289ac45c47b277d5aa91089c5f74fa"
 dependencies = [
  "ecdsa",
- "elliptic-curve 0.10.6",
+ "elliptic-curve",
+ "sec1",
  "sha2 0.9.8",
 ]
 
 [[package]]
 name = "p384"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23bc88c404ccc881c8a1ad62ba5cd7d336a64ecbf46de4874f2ad955f67b157"
+checksum = "755d8266e41f57bd8562ed9b6e93cdcf73ead050e1e8c3a27ea3871b6643a20c"
 dependencies = [
  "ecdsa",
- "elliptic-curve 0.10.6",
+ "elliptic-curve",
+ "sec1",
 ]
 
 [[package]]
@@ -2338,6 +2232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05894bce6a1ba4be299d0c5f29563e08af2bc18bb7d48313113bed71e904739"
+dependencies = [
+ "crypto-mac 0.11.1",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,12 +2290,13 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.7.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
 dependencies = [
- "der 0.4.5",
+ "der",
  "spki",
+ "zeroize",
 ]
 
 [[package]]
@@ -2765,6 +2669,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+dependencies = [
+ "crypto-bigint",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2813,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "rusb"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a5084628cc5be77b1c750b3e5ee0cc519d2f2491b3f06b78b3aac3328b00ad"
+checksum = "83b454219aa5007af92a042ec13b2035325318a21d3c6be18bf592f841430794"
 dependencies = [
  "libc",
  "libusb1-sys",
@@ -2903,12 +2818,6 @@ dependencies = [
  "sha2 0.9.8",
  "tokio",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hex"
@@ -3001,7 +2910,7 @@ dependencies = [
  "base64ct",
  "hmac",
  "password-hash",
- "pbkdf2",
+ "pbkdf2 0.8.0",
  "salsa20",
  "sha2 0.9.8",
 ]
@@ -3014,6 +2923,19 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+dependencies = [
+ "der",
+ "generic-array 0.14.4",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3276,11 +3198,12 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.4.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
+checksum = "964d3a6f8b7ef6d6d20887f4c30c4848f4ffa05f600c87277d30a5b4fe32cb4b"
 dependencies = [
- "der 0.4.5",
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3449,12 +3372,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
  "libc",
- "winapi",
+ "serde",
 ]
 
 [[package]]
@@ -3659,13 +3582,13 @@ dependencies = [
 
 [[package]]
 name = "trezor-client"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff94fab279e0d429d762c289f9727f37a0f1b8207ea4795f09c11caad009046f"
+checksum = "7f18d3fc60e99a85219fcd5a95311e20fb05805aab70719992b09853d47cae09"
 dependencies = [
  "byteorder",
  "hex",
- "hidapi",
+ "hidapi-rusb",
  "log",
  "primitive-types",
  "protobuf",
@@ -4056,28 +3979,25 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "yubihsm"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c32cd8146a6966df8137f5dbb77010ae5253e6937b21d1fd6ed55213478b4d0"
+checksum = "6c7ba281142fd52beba6ed6e67752bdb93242dd7520908a1d93054bfb4dcc02d"
 dependencies = [
  "aes",
- "anomaly",
  "bitflags",
  "block-modes",
  "ccm",
- "chrono",
  "cmac",
  "digest 0.9.0",
  "ecdsa",
  "ed25519",
  "ed25519-dalek",
- "harp",
  "hmac",
  "k256",
  "log",
  "p256",
  "p384",
- "pbkdf2",
+ "pbkdf2 0.9.0",
  "rand_core 0.6.3",
  "rusb",
  "serde",
@@ -4086,6 +4006,7 @@ dependencies = [
  "signature",
  "subtle",
  "thiserror",
+ "time",
  "uuid",
  "zeroize",
 ]

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -16,10 +16,10 @@ arrayvec = { version = "0.7.2", default-features = false }
 rlp-derive = { version = "0.1.0", default-features = false }
 
 # crypto
-ecdsa = { version = "0.12.3", default-features = false, features = ["std"] }
+ecdsa = { version = "0.13.3", default-features = false, features = ["std"] }
 elliptic-curve = { version = "0.11.5", default-features = false }
 generic-array = { version = "0.14.4", default-features = false }
-k256 = { version = "0.10.0-pre.1", default-features = false, features = ["keccak256", "ecdsa"] }
+k256 = { version = "0.10.0", default-features = false, features = ["keccak256", "ecdsa"] }
 rand = { version = "0.8.4", default-features = false }
 tiny-keccak = { version = "2.0.2", default-features = false }
 

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -19,7 +19,7 @@ rlp-derive = { version = "0.1.0", default-features = false }
 ecdsa = { version = "0.12.3", default-features = false, features = ["std"] }
 elliptic-curve = { version = "0.11.5", default-features = false }
 generic-array = { version = "0.14.4", default-features = false }
-k256 = { version = "0.9.5", default-features = false, features = ["keccak256", "ecdsa", "zeroize"] }
+k256 = { version = "0.10.0-pre.1", default-features = false, features = ["keccak256", "ecdsa"] }
 rand = { version = "0.8.4", default-features = false }
 tiny-keccak = { version = "2.0.2", default-features = false }
 

--- a/ethers-core/src/utils/ganache.rs
+++ b/ethers-core/src/utils/ganache.rs
@@ -194,7 +194,7 @@ impl Ganache {
             if is_private_key && line.starts_with('(') {
                 let key_str = &line[6..line.len() - 1];
                 let key_hex = hex::decode(key_str).expect("could not parse as hex");
-                let key = K256SecretKey::from_bytes(&key_hex).expect("did not get private key");
+                let key = K256SecretKey::from_be_bytes(&key_hex).expect("did not get private key");
                 addresses.push(secret_key_to_address(&SigningKey::from(&key)));
                 private_keys.push(key);
             }

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -27,7 +27,8 @@ pub use hex;
 
 use crate::types::{Address, Bytes, U256};
 use ethabi::ethereum_types::FromDecStrErr;
-use k256::{ecdsa::SigningKey, EncodedPoint as K256PublicKey};
+use elliptic_curve::sec1::ToEncodedPoint;
+use k256::{ecdsa::SigningKey, PublicKey as K256PublicKey};
 use std::{convert::TryInto, ops::Neg};
 use thiserror::Error;
 
@@ -242,9 +243,9 @@ pub fn get_create2_address_from_hash(
 
 /// Converts a K256 SigningKey to an Ethereum Address
 pub fn secret_key_to_address(secret_key: &SigningKey) -> Address {
-    // TODO: Can we do this in a better way?
-    let uncompressed_pub_key = K256PublicKey::from(&secret_key.verifying_key()).decompress();
-    let public_key = uncompressed_pub_key.unwrap().to_bytes();
+    let public_key = K256PublicKey::from(&secret_key.verifying_key());
+    let public_key = public_key.to_encoded_point(/* compress = */ false);
+    let public_key = public_key.as_bytes();
     debug_assert_eq!(public_key[0], 0x04);
     let hash = keccak256(&public_key[1..]);
     Address::from_slice(&hash[12..])

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -26,8 +26,8 @@ pub use rlp;
 pub use hex;
 
 use crate::types::{Address, Bytes, U256};
-use ethabi::ethereum_types::FromDecStrErr;
 use elliptic_curve::sec1::ToEncodedPoint;
+use ethabi::ethereum_types::FromDecStrErr;
 use k256::{ecdsa::SigningKey, PublicKey as K256PublicKey};
 use std::{convert::TryInto, ops::Neg};
 use thiserror::Error;

--- a/ethers-core/src/utils/moonbeam.rs
+++ b/ethers-core/src/utils/moonbeam.rs
@@ -46,99 +46,49 @@ impl MoonbeamDev {
     }
 }
 
+fn to_secret_key(s: &str) -> SecretKey {
+    SecretKey::from_be_bytes(&hex::decode(s).unwrap()).unwrap()
+}
+
 impl Default for MoonbeamDev {
     fn default() -> Self {
         Self {
             keys: BTreeMap::from([
                 (
                     "Alith",
-                    SecretKey::from_bytes(
-                        hex::decode(
-                            "5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133",
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap(),
+                    to_secret_key("5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133"),
                 ),
                 (
                     "Baltathar",
-                    SecretKey::from_bytes(
-                        hex::decode(
-                            "8075991ce870b93a8870eca0c0f91913d12f47948ca0fd25b49c6fa7cdbeee8b",
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap(),
+                    to_secret_key("8075991ce870b93a8870eca0c0f91913d12f47948ca0fd25b49c6fa7cdbeee8b"),
                 ),
                 (
                     "Charleth",
-                    SecretKey::from_bytes(
-                        hex::decode(
-                            "0b6e18cafb6ed99687ec547bd28139cafdd2bffe70e6b688025de6b445aa5c5b",
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap(),
+                    to_secret_key("0b6e18cafb6ed99687ec547bd28139cafdd2bffe70e6b688025de6b445aa5c5b"),
                 ),
                 (
                     "Dorothy",
-                    SecretKey::from_bytes(
-                        hex::decode(
-                            "39539ab1876910bbf3a223d84a29e28f1cb4e2e456503e7e91ed39b2e7223d68",
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap(),
+                    to_secret_key("39539ab1876910bbf3a223d84a29e28f1cb4e2e456503e7e91ed39b2e7223d68"),
                 ),
                 (
                     "Faith",
-                    SecretKey::from_bytes(
-                        hex::decode(
-                            "b9d2ea9a615f3165812e8d44de0d24da9bbd164b65c4f0573e1ce2c8dbd9c8df",
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap(),
+                    to_secret_key("b9d2ea9a615f3165812e8d44de0d24da9bbd164b65c4f0573e1ce2c8dbd9c8df"),
                 ),
                 (
                     "Goliath",
-                    SecretKey::from_bytes(
-                        hex::decode(
-                            "96b8a38e12e1a31dee1eab2fffdf9d9990045f5b37e44d8cc27766ef294acf18",
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap(),
+                    to_secret_key("96b8a38e12e1a31dee1eab2fffdf9d9990045f5b37e44d8cc27766ef294acf18"),
                 ),
                 (
                     "Heath",
-                    SecretKey::from_bytes(
-                        hex::decode(
-                            "0d6dcaaef49272a5411896be8ad16c01c35d6f8c18873387b71fbc734759b0ab",
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap(),
+                    to_secret_key("0d6dcaaef49272a5411896be8ad16c01c35d6f8c18873387b71fbc734759b0ab"),
                 ),
                 (
                     "Ida",
-                    SecretKey::from_bytes(
-                        hex::decode(
-                            "4c42532034540267bf568198ccec4cb822a025da542861fcb146a5fab6433ff8",
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap(),
+                    to_secret_key("4c42532034540267bf568198ccec4cb822a025da542861fcb146a5fab6433ff8"),
                 ),
                 (
                     "Judith",
-                    SecretKey::from_bytes(
-                        hex::decode(
-                            "94c49300a58d576011096bcb006aa06f5a91b34b4383891e8029c21dc39fbb8b",
-                        )
-                        .unwrap(),
-                    )
-                    .unwrap(),
+                    to_secret_key("94c49300a58d576011096bcb006aa06f5a91b34b4383891e8029c21dc39fbb8b"),
                 ),
             ]),
         }

--- a/ethers-core/src/utils/moonbeam.rs
+++ b/ethers-core/src/utils/moonbeam.rs
@@ -56,39 +56,57 @@ impl Default for MoonbeamDev {
             keys: BTreeMap::from([
                 (
                     "Alith",
-                    to_secret_key("5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133"),
+                    to_secret_key(
+                        "5fb92d6e98884f76de468fa3f6278f8807c48bebc13595d45af5bdc4da702133",
+                    ),
                 ),
                 (
                     "Baltathar",
-                    to_secret_key("8075991ce870b93a8870eca0c0f91913d12f47948ca0fd25b49c6fa7cdbeee8b"),
+                    to_secret_key(
+                        "8075991ce870b93a8870eca0c0f91913d12f47948ca0fd25b49c6fa7cdbeee8b",
+                    ),
                 ),
                 (
                     "Charleth",
-                    to_secret_key("0b6e18cafb6ed99687ec547bd28139cafdd2bffe70e6b688025de6b445aa5c5b"),
+                    to_secret_key(
+                        "0b6e18cafb6ed99687ec547bd28139cafdd2bffe70e6b688025de6b445aa5c5b",
+                    ),
                 ),
                 (
                     "Dorothy",
-                    to_secret_key("39539ab1876910bbf3a223d84a29e28f1cb4e2e456503e7e91ed39b2e7223d68"),
+                    to_secret_key(
+                        "39539ab1876910bbf3a223d84a29e28f1cb4e2e456503e7e91ed39b2e7223d68",
+                    ),
                 ),
                 (
                     "Faith",
-                    to_secret_key("b9d2ea9a615f3165812e8d44de0d24da9bbd164b65c4f0573e1ce2c8dbd9c8df"),
+                    to_secret_key(
+                        "b9d2ea9a615f3165812e8d44de0d24da9bbd164b65c4f0573e1ce2c8dbd9c8df",
+                    ),
                 ),
                 (
                     "Goliath",
-                    to_secret_key("96b8a38e12e1a31dee1eab2fffdf9d9990045f5b37e44d8cc27766ef294acf18"),
+                    to_secret_key(
+                        "96b8a38e12e1a31dee1eab2fffdf9d9990045f5b37e44d8cc27766ef294acf18",
+                    ),
                 ),
                 (
                     "Heath",
-                    to_secret_key("0d6dcaaef49272a5411896be8ad16c01c35d6f8c18873387b71fbc734759b0ab"),
+                    to_secret_key(
+                        "0d6dcaaef49272a5411896be8ad16c01c35d6f8c18873387b71fbc734759b0ab",
+                    ),
                 ),
                 (
                     "Ida",
-                    to_secret_key("4c42532034540267bf568198ccec4cb822a025da542861fcb146a5fab6433ff8"),
+                    to_secret_key(
+                        "4c42532034540267bf568198ccec4cb822a025da542861fcb146a5fab6433ff8",
+                    ),
                 ),
                 (
                     "Judith",
-                    to_secret_key("94c49300a58d576011096bcb006aa06f5a91b34b4383891e8029c21dc39fbb8b"),
+                    to_secret_key(
+                        "94c49300a58d576011096bcb006aa06f5a91b34b4383891e8029c21dc39fbb8b",
+                    ),
                 ),
             ]),
         }

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -16,26 +16,26 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 ethers-core = { version = "^0.6.0", path = "../ethers-core", features = ["eip712"]}
 thiserror = { version = "1.0.30", default-features = false }
-coins-bip32 = "0.3.0"
-coins-bip39 = "0.3.0"
-coins-ledger = { version = "0.4.2", default-features = false, optional = true }
+coins-bip32 = "0.6.0"
+coins-bip39 = "0.6.0"
+coins-ledger = { version = "0.6.0", default-features = false, optional = true }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 async-trait = { version = "0.1.50", default-features = false }
 elliptic-curve = { version = "0.11.5", default-features = false }
 sha2 = { version = "0.9.8", default-features = false }
 rand = { version = "0.8.4", default-features = false }
-yubihsm = { version = "0.39.0", features = ["secp256k1", "http", "usb"], optional = true }
+yubihsm = { version = "0.40.0", features = ["secp256k1", "http", "usb"], optional = true }
 futures-util = "^0.3"
 futures-executor = "^0.3"
 semver = "1.0.4"
-trezor-client = { version = "0.0.3", optional = true, default-features = false, features = ["f_ethereum"] }
+trezor-client = { version = "0.0.4", optional = true, default-features = false, features = ["f_ethereum"] }
 
 # aws
 rusoto_core = { version = "0.47.0", optional = true }
 rusoto_kms = { version = "0.47.0", optional = true }
 tracing = { version = "0.1.29", optional = true }
 tracing-futures = { version = "0.2.5", optional = true }
-spki = { version = "0.4.1", optional = true }
+spki = { version = "0.5.2", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 eth-keystore = { version = "0.3.0" }
@@ -45,10 +45,10 @@ ethers-contract = { version = "^0.6.0", path = "../ethers-contract", features = 
 ethers-derive-eip712 = { version = "0.2.0", path = "../ethers-core/ethers-derive-eip712" }
 serde_json = { version = "1.0.64" }
 tracing-subscriber = "0.3.3"
-yubihsm = { version = "0.39.0", features = ["secp256k1", "usb", "mockhsm"] }
+yubihsm = { version = "0.40.0", features = ["secp256k1", "usb", "mockhsm"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-yubihsm = { version = "0.39.0", features = ["secp256k1", "usb", "mockhsm"] }
+yubihsm = { version = "0.40.0", features = ["secp256k1", "usb", "mockhsm"] }
 tokio = { version = "1.5", default-features = false, features = ["macros", "rt"] }
 tempfile = "3.2.0"
 

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -21,7 +21,7 @@ coins-bip39 = "0.6.0"
 coins-ledger = { version = "0.6.0", default-features = false, optional = true }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 async-trait = { version = "0.1.50", default-features = false }
-elliptic-curve = { version = "0.11.5", default-features = false }
+elliptic-curve = { version = "0.11.6", default-features = false }
 sha2 = { version = "0.9.8", default-features = false }
 rand = { version = "0.8.4", default-features = false }
 yubihsm = { version = "0.40.0", features = ["secp256k1", "http", "usb"], optional = true }

--- a/ethers-signers/src/aws/mod.rs
+++ b/ethers-signers/src/aws/mod.rs
@@ -83,7 +83,7 @@ pub enum AwsSignerError {
     #[error("{0}")]
     K256(#[from] K256Error),
     #[error("{0}")]
-    Spki(spki::der::Error),
+    Spki(spki::Error),
     #[error("{0}")]
     Other(String),
     #[error(transparent)]
@@ -100,8 +100,8 @@ impl From<String> for AwsSignerError {
     }
 }
 
-impl From<spki::der::Error> for AwsSignerError {
-    fn from(e: spki::der::Error) -> Self {
+impl From<spki::Error> for AwsSignerError {
+    fn from(e: spki::Error) -> Self {
         Self::Spki(e)
     }
 }

--- a/ethers-signers/src/aws/utils.rs
+++ b/ethers-signers/src/aws/utils.rs
@@ -93,7 +93,8 @@ pub(super) fn decode_signature(resp: SignResponse) -> Result<KSig, AwsSignerErro
         .signature
         .ok_or_else(|| AwsSignerError::from("Signature not found in response".to_owned()))?;
 
-    let mut sig = KSig::from_der(&raw)?;
-    sig.normalize_s()?;
+    let sig = KSig::from_der(&raw)?
+        .normalize_s()
+        .ok_or_else(|| AwsSignerError::from("Could not normalize `s`".to_owned()))?;
     Ok(sig)
 }

--- a/ethers-signers/src/wallet/mnemonic.rs
+++ b/ethers-signers/src/wallet/mnemonic.rs
@@ -180,7 +180,7 @@ impl<W: Wordlist> MnemonicBuilder<W> {
     ) -> Result<Wallet<SigningKey>, WalletError> {
         let derived_priv_key =
             mnemonic.derive_key(&self.derivation_path, self.password.as_deref())?;
-        let key: &SigningKey = derived_priv_key.as_ref();
+        let key: &coins_bip32::prelude::SigningKey = derived_priv_key.as_ref();
         let signer = SigningKey::from_bytes(&key.to_bytes())?;
         let address = secret_key_to_address(&signer);
 

--- a/ethers-signers/src/wallet/private_key.rs
+++ b/ethers-signers/src/wallet/private_key.rs
@@ -121,8 +121,7 @@ use ethers_core::k256::SecretKey as K256SecretKey;
 
 impl From<K256SecretKey> for Wallet<SigningKey> {
     fn from(key: K256SecretKey) -> Self {
-        let signer = SigningKey::from_bytes(&*key.to_bytes())
-            .expect("private key should always be convertible to signing key");
+        let signer = key.into();
         let address = secret_key_to_address(&signer);
 
         Self { signer, address, chain_id: 1 }

--- a/ethers-signers/src/wallet/yubi.rs
+++ b/ethers-signers/src/wallet/yubi.rs
@@ -1,6 +1,11 @@
 //! Helpers for creating wallets for YubiHSM2
 use super::Wallet;
-use ethers_core::{k256::Secp256k1, types::Address, utils::keccak256};
+use elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+use ethers_core::{
+    k256::{PublicKey, Secp256k1},
+    types::Address,
+    utils::keccak256,
+};
 use yubihsm::{
     asymmetric::Algorithm::EcK256, ecdsa::Signer as YubiSigner, object, object::Label, Capability,
     Client, Connector, Credentials, Domain,
@@ -50,7 +55,10 @@ impl Wallet<YubiSigner<Secp256k1>> {
 
 impl From<YubiSigner<Secp256k1>> for Wallet<YubiSigner<Secp256k1>> {
     fn from(signer: YubiSigner<Secp256k1>) -> Self {
-        let public_key = signer.public_key().decompress().unwrap().to_bytes();
+        // this will never fail
+        let public_key = PublicKey::from_encoded_point(signer.public_key()).unwrap();
+        let public_key = public_key.to_encoded_point(/* compress = */ false);
+        let public_key = public_key.as_bytes();
         debug_assert_eq!(public_key[0], 0x04);
         let hash = keccak256(&public_key[1..]);
         let address = Address::from_slice(&hash[12..]);


### PR DESCRIPTION
New round of crypto crate updates! 

Some breaking changes, with which I hope @tarcieri can give some guidelines on if we've approached them correctly:
> there were some changes to the ecdsa::hazmat APIs that might impact you
> namely RecoverableSignPrimitive and SignPrimitive are now merged into a single trait (and the ecdsa crate finally has fully generic implementations of ECDSA signing/verification)

Checklist
* [x] ecdsa
* [x] spki
* [x] yubihsm: blocked on its [k256 update](https://github.com/iqlusioninc/yubihsm.rs/blob/main/Cargo.toml#L31)
* [x] coins-ledger: <s>blocked on its [k256 update](https://github.com/summa-tx/bitcoins-rs/blob/main/bip32/Cargo.toml#L20) (cc @prestwich, the new k256 is `0.10.0-pre.1`)</s> fixed: https://github.com/summa-tx/bitcoins-rs/pull/91
