### PR TITLE
feat: implement hex display for Bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix `format_units` to return a `String` of representing a decimal point float
   such that the decimal places don't get truncated.
   [597](https://github.com/gakonst/ethers-rs/pull/597)
+- Implement hex display format for `ethers::core::Bytes` [#624](https://github.com/gakonst/ethers-rs/pull/624).
 
 ### Unreleased
 

--- a/ethers-core/src/types/bytes.rs
+++ b/ethers-core/src/types/bytes.rs
@@ -3,7 +3,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
-use std::fmt::{Formatter, LowerHex, Result as FmtResult};
+use std::fmt::{Display, Formatter, LowerHex, Result as FmtResult};
 
 /// Wrapper type around Bytes to deserialize/serialize "0x" prefixed ethereum hex strings
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
@@ -12,10 +12,19 @@ pub struct Bytes(
     pub  bytes::Bytes,
 );
 
+fn bytes_to_hex(b: &Bytes) -> String {
+    hex::encode(b.0.as_ref())
+}
+
+impl Display for Bytes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", bytes_to_hex(self))
+    }
+}
+
 impl LowerHex for Bytes {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        let hex = hex::encode(self.0.as_ref());
-        write!(f, "{}", hex)
+        write!(f, "{}", bytes_to_hex(self))
     }
 }
 
@@ -86,5 +95,6 @@ mod tests {
         let b = Bytes::from(vec![1, 35, 69, 103, 137, 171, 205, 239]);
         let expected = String::from("0123456789abcdef");
         assert_eq!(format!("{:x}", b), expected);
+        assert_eq!(format!("{}", b), expected);
     }
 }

--- a/ethers-core/src/types/bytes.rs
+++ b/ethers-core/src/types/bytes.rs
@@ -3,12 +3,21 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
 };
 
+use std::fmt::{Formatter, LowerHex, Result as FmtResult};
+
 /// Wrapper type around Bytes to deserialize/serialize "0x" prefixed ethereum hex strings
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]
 pub struct Bytes(
     #[serde(serialize_with = "serialize_bytes", deserialize_with = "deserialize_bytes")]
     pub  bytes::Bytes,
 );
+
+impl LowerHex for Bytes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let hex = hex::encode(self.0.as_ref());
+        write!(f, "{}", hex)
+    }
+}
 
 impl Bytes {
     pub fn to_vec(&self) -> Vec<u8> {
@@ -65,5 +74,17 @@ where
         Ok(bytes.into())
     } else {
         Err(Error::invalid_value(Unexpected::Str(&value), &"0x prefix"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_formatting() {
+        let b = Bytes::from(vec![1, 35, 69, 103, 137, 171, 205, 239]);
+        let expected = String::from("0123456789abcdef");
+        assert_eq!(format!("{:x}", b), expected);
     }
 }

--- a/ethers-core/src/types/bytes.rs
+++ b/ethers-core/src/types/bytes.rs
@@ -18,13 +18,13 @@ fn bytes_to_hex(b: &Bytes) -> String {
 
 impl Display for Bytes {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{}", bytes_to_hex(self))
+        write!(f, "0x{}", bytes_to_hex(self))
     }
 }
 
 impl LowerHex for Bytes {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{}", bytes_to_hex(self))
+        write!(f, "0x{}", bytes_to_hex(self))
     }
 }
 
@@ -93,7 +93,7 @@ mod tests {
     #[test]
     fn hex_formatting() {
         let b = Bytes::from(vec![1, 35, 69, 103, 137, 171, 205, 239]);
-        let expected = String::from("0123456789abcdef");
+        let expected = String::from("0x0123456789abcdef");
         assert_eq!(format!("{:x}", b), expected);
         assert_eq!(format!("{}", b), expected);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Addresses #622 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implement `LowerHex` and `Display` traits for `Bytes`, to display them in hexadecimal format.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
