### PR TITLE
fix: remove redundant cache read

### DIFF
--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -219,15 +219,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
             // once matched, proceed to compile with it
             compiled.extend(self.compile_with_version(&solc, sources)?);
         }
-        if !compiled.has_compiled_contracts() &&
-            !compiled.has_compiler_errors() &&
-            self.cached &&
-            self.paths.cache.exists()
-        {
-            let cache = SolFilesCache::read(&self.paths.cache)?;
-            let artifacts = cache.read_artifacts::<Artifacts>(&self.paths.artifacts)?;
-            compiled.artifacts.extend(artifacts);
-        }
+
         Ok(compiled)
     }
 


### PR DESCRIPTION
This seems to be redundant with the code [right below](https://github.com/gakonst/ethers-rs/blob/master/ethers-solc/src/lib.rs#L252-L264)