### PR TITLE
fix(solc): do not overwrite existing cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,6 +1190,7 @@ dependencies = [
  "tempdir",
  "thiserror",
  "tokio",
+ "tracing",
  "walkdir",
 ]
 

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -98,7 +98,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
         let mut cache = SolFilesCache::builder()
             .root(&self.paths.root)
             .solc_config(self.solc_config.clone())
-            .insert_files(sources)?;
+            .insert_files(sources, Some(self.paths.cache.clone()))?;
 
         // add the artifacts for each file to the cache entry
         for (file, artifacts) in artifacts {


### PR DESCRIPTION
previously if 1 file changed, it'd overwrite the existing cache on disk with just
that 1 changed file. this change reads the cache from disk and merges it with the new checksums

ref: https://github.com/gakonst/ethers-rs/pull/623
