### PR TITLE
fix(solc): remove changed artifacts from the cache

### DIFF
--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -58,6 +58,10 @@ impl SolFilesCache {
         self.files.retain(|file, _| Path::new(file).exists())
     }
 
+    pub fn remove_changed_files(&mut self, changed_files: &Sources) {
+        self.files.retain(|file, _| !changed_files.contains_key(file))
+    }
+
     /// Returns only the files that were changed from the provided sources, to save time
     /// when compiling.
     pub fn get_changed_files<'a>(

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -251,6 +251,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
                 Some(&self.solc_config),
                 &self.paths.artifacts,
             );
+            cache.remove_changed_files(&changed_files);
 
             let cached_artifacts = if self.paths.artifacts.exists() {
                 cache.read_artifacts::<Artifacts>(&self.paths.artifacts)?

--- a/ethers-solc/test-data/cache-sample/Dapp.sol
+++ b/ethers-solc/test-data/cache-sample/Dapp.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.6.6;
+
+contract Dapp {
+
+    function modified() public {}
+}


### PR DESCRIPTION
## Motivation

When reading from the cache, there may be changed artifacts that need to be recompiled. 
Currently only missing files are removed from the cache metadata struct, but changed files remain.
Since we're now returning the cached artifacts as part of #623 on partial changes and writing new
files to the cache as part of #629, we also need to remove changed files from the cache. 

## Solution

After getting the changed sources, remove them from the cache metadata (`SolFilesCache`) so
they are no longer returned.

## PR Checklist

- [x] Added Tests