### PR TITLE
fix: source parsing for local paths

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -151,7 +151,8 @@ impl Context {
     /// Create a context from the code generation arguments.
     pub fn from_abigen(args: Abigen) -> Result<Self> {
         // get the actual ABI string
-        let abi_str = args.abi_source.get().context("failed to get ABI JSON")?;
+        let abi_str =
+            args.abi_source.get().map_err(|e| anyhow!("failed to get ABI JSON: {}", e))?;
         let mut abi_parser = AbiParser::default();
 
         let (abi, human_readable): (Abi, _) = if let Ok(abi) = abi_parser.parse_str(&abi_str) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
followup on #631 that prevents path resolution while parsing the path
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
don't canonicalize local paths like `./testdata/console.json` in `Source::parse`, resolving paths for `Source::Local` happens at a later stage at `Source::get`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
