### PR TITLE
chore: makes etherscan::Result pub(crate)

### DIFF
--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -13,7 +13,7 @@ pub mod errors;
 pub mod gas;
 pub mod transaction;
 
-pub type Result<T> = std::result::Result<T, EtherscanError>;
+pub(crate) type Result<T> = std::result::Result<T, EtherscanError>;
 
 /// The Etherscan.io API client.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Otherwise doing `ethers::prelude::*` leaks the exported `Result` type