### PR TITLE
fix(provider::ws): ignore the websocket response when the request has been cancelled

### DIFF
--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -313,7 +313,9 @@ where
             Err(_) => {}
             Ok(Incoming::Response(resp)) => {
                 if let Some(request) = self.pending.remove(&resp.id) {
-                    request.send(resp.data.into_result()).map_err(to_client_error)?;
+                    if !request.is_canceled() {
+                        request.send(resp.data.into_result()).map_err(to_client_error)?;
+                    }
                 }
             }
             Ok(Incoming::Notification(notification)) => {


### PR DESCRIPTION
In cases when the request is out, but cancelled locally before it gets back, then later on, the replied request should be ignored, otherwise, it hits an error and aborts the whole websocket connection.