### PR TITLE
Fix handling of `nonce too low` error

### DIFF
--- a/ethers-providers/src/pending_escalator.rs
+++ b/ethers-providers/src/pending_escalator.rs
@@ -142,7 +142,7 @@ macro_rules! poll_broadcast_fut {
             Poll::Ready(Err(e)) => {
                 // kludge. Prevents erroring on "nonce too low" which indicates
                 // a previous escalation confirmed during this broadcast attempt
-                if format!("{}", e).contains("nonce too low") {
+                if format!("{:?}", e).contains("nonce too low") {
                     check_all_receipts!($cx, $this);
                 } else {
                     tracing::error!(
@@ -187,7 +187,7 @@ where
                         let fut = this.provider.send_raw_transaction(next_to_broadcast);
                         *this.state = BroadcastingNew(fut);
                         cx.waker().wake_by_ref();
-                        return Poll::Pending
+                        return Poll::Pending;
                     }
                 }
                 check_all_receipts!(cx, this);


### PR DESCRIPTION
## Motivation
There is a problem currently in EscalatingPending Future implementation, which is responsible for backing the `send_escalating` method in `Middleware`.
The problem is in the part of the Future which tests for the `nonce too low` issues. That test consists of checking if the error's `Display` contains string `nonce too low`. The point here is that the error's display might not have `nonce too low`. For instance, a custom error's Display might not provide the desired `nonce too low`, while Debug would. Here is an example from POC which shows Display (`error_display`) and Debug(`error_debug`) of an error

```
 Poll::Ready(Err(e)) => {
     // kludge. Prevents erroring on "nonce too low" which indicates
     // a previous escalation confirmed during this broadcast attempt
     tracing::info!(
         error_display = %e,
         error_debug = ?e,
         "Want to see the diffrernce for error"
     );
     if format!("{}", e).contains("nonce too low") {
```
Debug line produces:
```
{"timestamp":"Jan 01 01:01:01.1337","level":"INFO","fields":{"message":"Want to see the diffrernce for error","error_display":"Max requests reached","error_debug":"JsonRpcClientError(MaxRequests([JsonRpcError(JsonRpcError { code: -32000, message: \"nonce too low\", data: None }), JsonRpcError(JsonRpcError { code: -32000, message: \"nonce too low\", data....
```

## Solution
Obviously, Debug includes wrapped parts, which expose the desired line, whereas Display shows only `Max requests reached`. In order to fix the test I propose to change the format from `format!("{}", e)` to `format!("{:?}", e)`, which would expose the debug.

