### PR TITLE
feature: impl Default for eip2718::TypedTransaction

### DIFF
--- a/ethers-core/src/types/transaction/eip2718.rs
+++ b/ethers-core/src/types/transaction/eip2718.rs
@@ -34,6 +34,20 @@ pub enum TypedTransaction {
     Eip1559(Eip1559TransactionRequest),
 }
 
+#[cfg(feature = "legacy")]
+impl Default for TypedTransaction {
+    fn default() -> Self {
+        TypedTransaction::Legacy(Default::default())
+    }
+}
+
+#[cfg(not(feature = "legacy"))]
+impl Default for TypedTransaction {
+    fn default() -> Self {
+        TypedTransaction::Eip1559(Default::default())
+    }
+}
+
 use TypedTransaction::*;
 
 impl TypedTransaction {


### PR DESCRIPTION
Adds an implementation of `Default` for the `eip2718::TypedTransaction` struct. This implementation respects the `legacy` feature, and allows blank transactions to more easily be created. Using this bound in my provider work to allow generic instantiation and modification of txns implementing a Transaction trait