### PR TITLE
feat: trezor support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,31 +1697,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
-name = "hid"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ec4bb2e3f01d3838ea2bbbe3919d98f921c7aeed14a5491df89ac3dc4839f9"
-dependencies = [
- "hidapi-sys",
- "libc",
-]
-
-[[package]]
 name = "hidapi"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d6f5e247bc66f3255d755e96d9d43f6b191f4e182072b811d55584ff58c510f"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
-name = "hidapi-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8a9410aec7ca9f4571ff40c7b1813a28503c2a664a028921fc973073dcd4bf"
 dependencies = [
  "cc",
  "libc",
@@ -3698,14 +3677,14 @@ dependencies = [
 [[package]]
 name = "trezor"
 version = "0.0.1"
-source = "git+https://github.com/joshiedo/rust-trezor-api?rev=18ad9130db0a7dacf3ba951e45b49b7f5be7e38c#18ad9130db0a7dacf3ba951e45b49b7f5be7e38c"
+source = "git+https://github.com/joshiedo/rust-trezor-api?rev=8159dc8a7ab2fa03e85638121275253b9a42c7d4#8159dc8a7ab2fa03e85638121275253b9a42c7d4"
 dependencies = [
  "bitcoin",
  "bitcoin-bech32",
  "bitcoin_hashes",
  "byteorder",
  "hex 0.3.2",
- "hid",
+ "hidapi",
  "log",
  "primitive-types",
  "protobuf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,12 @@ checksum = "43a46022bae2c3bc5a17c2d45d59c1233ce0e2cca9ae9b92e92e9ce529874177"
 
 [[package]]
 name = "bech32"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58946044516aa9dc922182e0d6e9d124a31aafe6b421614654eb27cf90cec09c"
+
+[[package]]
+name = "bech32"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
@@ -213,6 +219,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd5e7935f613ba170459072926f01dc5ddb8aa22382dc4badf44bbb55e2d243d"
+dependencies = [
+ "bitcoin-bech32",
+ "bitcoin_hashes",
+ "byteorder",
+ "hex 0.3.2",
+ "rand 0.3.23",
+ "secp256k1",
+]
+
+[[package]]
+name = "bitcoin-bech32"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e67e8ccfc663811145e6cabdb9a2a6978877f72b048516e83eb95622e9b2554"
+dependencies = [
+ "bech32 0.6.0",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b7a2e9773ee7ae7f2560f0426c938f57902dcb9e39321b0cbd608f47ed579a4"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -504,7 +542,7 @@ dependencies = [
  "bitvec 0.17.4",
  "coins-bip32",
  "getrandom 0.2.3",
- "hex",
+ "hex 0.4.3",
  "hmac",
  "pbkdf2",
  "rand 0.8.4",
@@ -520,11 +558,11 @@ checksum = "d257d975731955ee86fa7f348000c3fea09c262e84c70c11e994a85aa4f467a7"
 dependencies = [
  "base58check",
  "base64 0.12.3",
- "bech32",
+ "bech32 0.7.3",
  "blake2",
  "digest 0.9.0",
  "generic-array 0.14.4",
- "hex",
+ "hex 0.4.3",
  "ripemd160",
  "serde",
  "serde_derive",
@@ -1023,7 +1061,7 @@ dependencies = [
  "aes",
  "ctr 0.7.0",
  "digest 0.9.0",
- "hex",
+ "hex 0.4.3",
  "hmac",
  "pbkdf2",
  "rand 0.8.4",
@@ -1044,7 +1082,7 @@ checksum = "f76ef192b63e8a44b3d08832acebbb984c3fba154b5c26f70037c860202a0d4b"
 dependencies = [
  "anyhow",
  "ethereum-types",
- "hex",
+ "hex 0.4.3",
  "serde",
  "serde_json",
  "sha3",
@@ -1092,7 +1130,7 @@ dependencies = [
  "ethers-providers",
  "ethers-signers",
  "ethers-solc",
- "hex",
+ "hex 0.4.3",
  "rand 0.8.4",
  "serde",
  "serde_json",
@@ -1112,7 +1150,7 @@ dependencies = [
  "ethers-signers",
  "ethers-solc",
  "futures-util",
- "hex",
+ "hex 0.4.3",
  "once_cell",
  "pin-project",
  "serde",
@@ -1130,7 +1168,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ethers-core",
  "getrandom 0.2.3",
- "hex",
+ "hex 0.4.3",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -1147,7 +1185,7 @@ version = "0.6.0"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
- "hex",
+ "hex 0.4.3",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -1168,7 +1206,7 @@ dependencies = [
  "ethabi",
  "futures-util",
  "generic-array 0.14.4",
- "hex",
+ "hex 0.4.3",
  "hex-literal",
  "k256",
  "once_cell",
@@ -1193,7 +1231,7 @@ dependencies = [
  "ethers-contract-derive",
  "ethers-core",
  "ethers-signers",
- "hex",
+ "hex 0.4.3",
  "proc-macro2",
  "quote",
  "serde",
@@ -1227,7 +1265,7 @@ dependencies = [
  "ethers-signers",
  "ethers-solc",
  "futures-util",
- "hex",
+ "hex 0.4.3",
  "instant",
  "once_cell",
  "rand 0.8.4",
@@ -1254,7 +1292,7 @@ dependencies = [
  "futures-core",
  "futures-timer",
  "futures-util",
- "hex",
+ "hex 0.4.3",
  "parking_lot",
  "pin-project",
  "reqwest",
@@ -1290,7 +1328,7 @@ dependencies = [
  "ethers-derive-eip712",
  "futures-executor",
  "futures-util",
- "hex",
+ "hex 0.4.3",
  "rand 0.8.4",
  "rusoto_core",
  "rusoto_kms",
@@ -1304,6 +1342,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
+ "trezor",
  "yubihsm",
 ]
 
@@ -1317,7 +1356,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.2.3",
  "glob",
- "hex",
+ "hex 0.4.3",
  "home",
  "md-5",
  "num_cpus",
@@ -1341,7 +1380,7 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
  "ethers",
- "hex",
+ "hex 0.4.3",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1641,6 +1680,12 @@ dependencies = [
 
 [[package]]
 name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+
+[[package]]
+name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
@@ -1652,10 +1697,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hid"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ec4bb2e3f01d3838ea2bbbe3919d98f921c7aeed14a5491df89ac3dc4839f9"
+dependencies = [
+ "hidapi-sys",
+ "libc",
+]
+
+[[package]]
 name = "hidapi"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d6f5e247bc66f3255d755e96d9d43f6b191f4e182072b811d55584ff58c510f"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "hidapi-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8a9410aec7ca9f4571ff40c7b1813a28503c2a664a028921fc973073dcd4bf"
 dependencies = [
  "cc",
  "libc",
@@ -2407,6 +2473,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "2.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c327e191621a2158159df97cdbc2e7074bb4e940275e35abf38eb3d2595754"
+
+[[package]]
 name = "quote"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,6 +2498,16 @@ name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "rand"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+dependencies = [
+ "libc",
+ "rand 0.4.6",
+]
 
 [[package]]
 name = "rand"
@@ -2786,7 +2868,7 @@ dependencies = [
  "chrono",
  "digest 0.9.0",
  "futures",
- "hex",
+ "hex 0.4.3",
  "hmac",
  "http",
  "hyper",
@@ -2946,6 +3028,17 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4070f3906e65249228094cf97b04a90799fba04468190bbbcfa812309cf86e32"
+dependencies = [
+ "cc",
+ "libc",
+ "rand 0.4.6",
 ]
 
 [[package]]
@@ -3261,7 +3354,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "console 0.14.1",
  "dialoguer",
- "hex",
+ "hex 0.4.3",
  "home",
  "indicatif",
  "itertools",
@@ -3603,6 +3696,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "trezor"
+version = "0.0.1"
+source = "git+https://github.com/joshiedo/rust-trezor-api?rev=18ad9130db0a7dacf3ba951e45b49b7f5be7e38c#18ad9130db0a7dacf3ba951e45b49b7f5be7e38c"
+dependencies = [
+ "bitcoin",
+ "bitcoin-bech32",
+ "bitcoin_hashes",
+ "byteorder",
+ "hex 0.3.2",
+ "hid",
+ "log",
+ "primitive-types",
+ "protobuf",
+ "rusb",
+ "secp256k1",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3645,7 +3757,7 @@ checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
 dependencies = [
  "byteorder",
  "crunchy",
- "hex",
+ "hex 0.4.3",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,12 +202,6 @@ checksum = "43a46022bae2c3bc5a17c2d45d59c1233ce0e2cca9ae9b92e92e9ce529874177"
 
 [[package]]
 name = "bech32"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58946044516aa9dc922182e0d6e9d124a31aafe6b421614654eb27cf90cec09c"
-
-[[package]]
-name = "bech32"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
@@ -219,38 +213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bitcoin"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5e7935f613ba170459072926f01dc5ddb8aa22382dc4badf44bbb55e2d243d"
-dependencies = [
- "bitcoin-bech32",
- "bitcoin_hashes",
- "byteorder",
- "hex 0.3.2",
- "rand 0.3.23",
- "secp256k1",
-]
-
-[[package]]
-name = "bitcoin-bech32"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e67e8ccfc663811145e6cabdb9a2a6978877f72b048516e83eb95622e9b2554"
-dependencies = [
- "bech32 0.6.0",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7a2e9773ee7ae7f2560f0426c938f57902dcb9e39321b0cbd608f47ed579a4"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -542,7 +504,7 @@ dependencies = [
  "bitvec 0.17.4",
  "coins-bip32",
  "getrandom 0.2.3",
- "hex 0.4.3",
+ "hex",
  "hmac",
  "pbkdf2",
  "rand 0.8.4",
@@ -558,11 +520,11 @@ checksum = "d257d975731955ee86fa7f348000c3fea09c262e84c70c11e994a85aa4f467a7"
 dependencies = [
  "base58check",
  "base64 0.12.3",
- "bech32 0.7.3",
+ "bech32",
  "blake2",
  "digest 0.9.0",
  "generic-array 0.14.4",
- "hex 0.4.3",
+ "hex",
  "ripemd160",
  "serde",
  "serde_derive",
@@ -1061,7 +1023,7 @@ dependencies = [
  "aes",
  "ctr 0.7.0",
  "digest 0.9.0",
- "hex 0.4.3",
+ "hex",
  "hmac",
  "pbkdf2",
  "rand 0.8.4",
@@ -1082,7 +1044,7 @@ checksum = "f76ef192b63e8a44b3d08832acebbb984c3fba154b5c26f70037c860202a0d4b"
 dependencies = [
  "anyhow",
  "ethereum-types",
- "hex 0.4.3",
+ "hex",
  "serde",
  "serde_json",
  "sha3",
@@ -1130,7 +1092,7 @@ dependencies = [
  "ethers-providers",
  "ethers-signers",
  "ethers-solc",
- "hex 0.4.3",
+ "hex",
  "rand 0.8.4",
  "serde",
  "serde_json",
@@ -1150,7 +1112,7 @@ dependencies = [
  "ethers-signers",
  "ethers-solc",
  "futures-util",
- "hex 0.4.3",
+ "hex",
  "once_cell",
  "pin-project",
  "serde",
@@ -1168,7 +1130,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "ethers-core",
  "getrandom 0.2.3",
- "hex 0.4.3",
+ "hex",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -1185,7 +1147,7 @@ version = "0.6.0"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
- "hex 0.4.3",
+ "hex",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -1206,7 +1168,7 @@ dependencies = [
  "ethabi",
  "futures-util",
  "generic-array 0.14.4",
- "hex 0.4.3",
+ "hex",
  "hex-literal",
  "k256",
  "once_cell",
@@ -1231,7 +1193,7 @@ dependencies = [
  "ethers-contract-derive",
  "ethers-core",
  "ethers-signers",
- "hex 0.4.3",
+ "hex",
  "proc-macro2",
  "quote",
  "serde",
@@ -1265,7 +1227,7 @@ dependencies = [
  "ethers-signers",
  "ethers-solc",
  "futures-util",
- "hex 0.4.3",
+ "hex",
  "instant",
  "once_cell",
  "rand 0.8.4",
@@ -1292,7 +1254,7 @@ dependencies = [
  "futures-core",
  "futures-timer",
  "futures-util",
- "hex 0.4.3",
+ "hex",
  "parking_lot",
  "pin-project",
  "reqwest",
@@ -1328,7 +1290,7 @@ dependencies = [
  "ethers-derive-eip712",
  "futures-executor",
  "futures-util",
- "hex 0.4.3",
+ "hex",
  "rand 0.8.4",
  "rusoto_core",
  "rusoto_kms",
@@ -1356,7 +1318,7 @@ dependencies = [
  "futures-util",
  "getrandom 0.2.3",
  "glob",
- "hex 0.4.3",
+ "hex",
  "home",
  "md-5",
  "num_cpus",
@@ -1380,7 +1342,7 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
  "ethers",
- "hex 0.4.3",
+ "hex",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1677,12 +1639,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 
 [[package]]
 name = "hex"
@@ -2480,16 +2436,6 @@ checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -2847,7 +2793,7 @@ dependencies = [
  "chrono",
  "digest 0.9.0",
  "futures",
- "hex 0.4.3",
+ "hex",
  "hmac",
  "http",
  "hyper",
@@ -3007,17 +2953,6 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4070f3906e65249228094cf97b04a90799fba04468190bbbcfa812309cf86e32"
-dependencies = [
- "cc",
- "libc",
- "rand 0.4.6",
 ]
 
 [[package]]
@@ -3333,7 +3268,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "console 0.14.1",
  "dialoguer",
- "hex 0.4.3",
+ "hex",
  "home",
  "indicatif",
  "itertools",
@@ -3676,22 +3611,17 @@ dependencies = [
 
 [[package]]
 name = "trezor-client"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebaa901ea69675239aece61fb89610264167c204c0e0e7c445fc823f2a1128e"
+checksum = "ff94fab279e0d429d762c289f9727f37a0f1b8207ea4795f09c11caad009046f"
 dependencies = [
- "bitcoin",
- "bitcoin-bech32",
- "bitcoin_hashes",
  "byteorder",
- "hex 0.3.2",
+ "hex",
  "hidapi",
  "log",
  "primitive-types",
  "protobuf",
  "rusb",
- "secp256k1",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -3737,7 +3667,7 @@ checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
 dependencies = [
  "byteorder",
  "crunchy",
- "hex 0.4.3",
+ "hex",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3677,7 +3677,7 @@ dependencies = [
 [[package]]
 name = "trezor"
 version = "0.0.1"
-source = "git+https://github.com/joshiedo/rust-trezor-api?rev=8159dc8a7ab2fa03e85638121275253b9a42c7d4#8159dc8a7ab2fa03e85638121275253b9a42c7d4"
+source = "git+https://github.com/joshiedo/rust-trezor-api?rev=f0c9775#f0c9775af70d35ec8be0677363f7e14ae6071801"
 dependencies = [
  "bitcoin",
  "bitcoin-bech32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3677,7 +3677,7 @@ dependencies = [
 [[package]]
 name = "trezor"
 version = "0.0.1"
-source = "git+https://github.com/joshiedo/rust-trezor-api?rev=f0c9775#f0c9775af70d35ec8be0677363f7e14ae6071801"
+source = "git+https://github.com/joshiedo/rust-trezor-api?rev=121a185#121a185796062d7b9ff3f9c74c094a47217fa76c"
 dependencies = [
  "bitcoin",
  "bitcoin-bech32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,7 +1342,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
- "trezor",
+ "trezor-client",
  "yubihsm",
 ]
 
@@ -3675,9 +3675,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "trezor"
-version = "0.0.1"
-source = "git+https://github.com/joshiedo/rust-trezor-api?rev=121a185#121a185796062d7b9ff3f9c74c094a47217fa76c"
+name = "trezor-client"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebaa901ea69675239aece61fb89610264167c204c0e0e7c445fc823f2a1128e"
 dependencies = [
  "bitcoin",
  "bitcoin-bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ openssl = ["ethers-providers/openssl"]
 dev-rpc = ["ethers-providers/dev-rpc"]
 ## signers
 ledger = ["ethers-signers/ledger"]
+trezor = ["ethers-signers/trezor"]
 yubi = ["ethers-signers/yubi"]
 ## contracts
 abigen = ["ethers-contract/abigen"]

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -28,7 +28,7 @@ yubihsm = { version = "0.39.0", features = ["secp256k1", "http", "usb"], optiona
 futures-util = "0.3.18"
 futures-executor = "0.3.18"
 semver = "1.0.4"
-trezor-client = { package="trezor", git = "https://github.com/joshiedo/rust-trezor-api", rev = "8159dc8a7ab2fa03e85638121275253b9a42c7d4", optional = true }
+trezor-client = { package="trezor", git = "https://github.com/joshiedo/rust-trezor-api", rev = "f0c9775", optional = true }
 
 # aws
 rusoto_core = { version = "0.47.0", optional = true }

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -28,7 +28,7 @@ yubihsm = { version = "0.39.0", features = ["secp256k1", "http", "usb"], optiona
 futures-util = "0.3.18"
 futures-executor = "0.3.18"
 semver = "1.0.4"
-trezor-client = { package="trezor", git = "https://github.com/joshiedo/rust-trezor-api", rev = "121a185", optional = true }
+trezor-client = { version = "0.0.2", optional = true }
 
 # aws
 rusoto_core = { version = "0.47.0", optional = true }

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -28,7 +28,7 @@ yubihsm = { version = "0.39.0", features = ["secp256k1", "http", "usb"], optiona
 futures-util = "0.3.18"
 futures-executor = "0.3.18"
 semver = "1.0.4"
-trezor-client = { package="trezor", git = "https://github.com/joshiedo/rust-trezor-api", rev = "18ad9130db0a7dacf3ba951e45b49b7f5be7e38c", optional = true }
+trezor-client = { package="trezor", git = "https://github.com/joshiedo/rust-trezor-api", rev = "8159dc8a7ab2fa03e85638121275253b9a42c7d4", optional = true }
 
 # aws
 rusoto_core = { version = "0.47.0", optional = true }

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -28,7 +28,7 @@ yubihsm = { version = "0.39.0", features = ["secp256k1", "http", "usb"], optiona
 futures-util = "0.3.18"
 futures-executor = "0.3.18"
 semver = "1.0.4"
-trezor-client = { version = "0.0.2", optional = true }
+trezor-client = { version = "0.0.3", optional = true, default-features = false, features = ["f_ethereum"] }
 
 # aws
 rusoto_core = { version = "0.47.0", optional = true }

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -28,6 +28,7 @@ yubihsm = { version = "0.39.0", features = ["secp256k1", "http", "usb"], optiona
 futures-util = "0.3.18"
 futures-executor = "0.3.18"
 semver = "1.0.4"
+trezor-client = { package="trezor", git = "https://github.com/joshiedo/rust-trezor-api", rev = "18ad9130db0a7dacf3ba951e45b49b7f5be7e38c", optional = true }
 
 # aws
 rusoto_core = { version = "0.47.0", optional = true }
@@ -56,3 +57,4 @@ celo = ["ethers-core/celo"]
 ledger = ["coins-ledger"]
 yubi = ["yubihsm"]
 aws = ["rusoto_core", "rusoto_kms", "tracing", "tracing-futures", "spki"]
+trezor = ["trezor-client"]

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -28,7 +28,7 @@ yubihsm = { version = "0.39.0", features = ["secp256k1", "http", "usb"], optiona
 futures-util = "0.3.18"
 futures-executor = "0.3.18"
 semver = "1.0.4"
-trezor-client = { package="trezor", git = "https://github.com/joshiedo/rust-trezor-api", rev = "f0c9775", optional = true }
+trezor-client = { package="trezor", git = "https://github.com/joshiedo/rust-trezor-api", rev = "121a185", optional = true }
 
 # aws
 rusoto_core = { version = "0.47.0", optional = true }

--- a/ethers-signers/src/ledger/app.rs
+++ b/ethers-signers/src/ledger/app.rs
@@ -206,7 +206,7 @@ impl LedgerEthereum {
         let mut bytes = vec![depth as u8];
         for derivation_index in elements {
             let hardened = derivation_index.contains('\'');
-            let mut index = derivation_index.replace("'", "").parse::<u32>().unwrap();
+            let mut index = derivation_index.replace('\'', "").parse::<u32>().unwrap();
             if hardened {
                 index |= 0x80000000;
             }

--- a/ethers-signers/src/lib.rs
+++ b/ethers-signers/src/lib.rs
@@ -25,7 +25,7 @@ mod trezor;
 #[cfg(feature = "trezor")]
 pub use trezor::{
     app::TrezorEthereum as Trezor,
-    types::{DerivationType as HDPath, TrezorError},
+    types::{DerivationType as TrezorHDPath, TrezorError},
 };
 
 #[cfg(feature = "yubi")]

--- a/ethers-signers/src/lib.rs
+++ b/ethers-signers/src/lib.rs
@@ -20,6 +20,14 @@ pub use ledger::{
     types::{DerivationType as HDPath, LedgerError},
 };
 
+#[cfg(feature = "trezor")]
+mod trezor;
+#[cfg(feature = "trezor")]
+pub use trezor::{
+    app::TrezorEthereum as Trezor,
+    types::{DerivationType as HDPath, TrezorError},
+};
+
 #[cfg(feature = "yubi")]
 pub use yubihsm;
 

--- a/ethers-signers/src/trezor/app.rs
+++ b/ethers-signers/src/trezor/app.rs
@@ -245,6 +245,24 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
+    async fn test_sign_big_data_tx() {
+        let trezor = TrezorEthereum::new(DerivationType::TrezorLive(0), 1).await.unwrap();
+
+        // invalid data
+        let big_data = hex::decode("095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff".to_string()+ &"ff".repeat(1032*2) + &"aa".to_string()).unwrap();
+        let tx_req = TransactionRequest::new()
+            .to("2ed7afa17473e17ac59908f088b4371d28585476".parse::<Address>().unwrap())
+            .gas(1000000)
+            .gas_price(400e9 as u64)
+            .nonce(5)
+            .data(big_data)
+            .value(ethers_core::utils::parse_ether(100).unwrap())
+            .into();
+        let tx = trezor.sign_transaction(&tx_req).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore]
     async fn test_sign_eip1559_tx() {
         let trezor = TrezorEthereum::new(DerivationType::TrezorLive(0), 1).await.unwrap();
 

--- a/ethers-signers/src/trezor/app.rs
+++ b/ethers-signers/src/trezor/app.rs
@@ -1,0 +1,330 @@
+#![allow(unused)]
+use trezor_client::client::{Trezor, AccessListItem as Trezor_AccessListItem};
+
+use futures_executor::block_on;
+use futures_util::lock::Mutex;
+
+use ethers_core::{
+    types::{
+        transaction::{eip2718::TypedTransaction, eip712::Eip712},
+        Address, NameOrAddress, Signature, Transaction, TransactionRequest, TxHash, H256, U256,
+    },
+    utils::keccak256,
+};
+use std::convert::TryFrom;
+use thiserror::Error;
+
+use super::types::*;
+
+/// A Trezor Ethereum App.
+///
+/// This is a simple wrapper around the [Trezor transport](Trezor)
+#[derive(Debug)]
+pub struct TrezorEthereum {
+    derivation: DerivationType,
+    pub(crate) chain_id: u64,
+    pub(crate) address: Address,
+}
+
+impl TrezorEthereum {
+    fn get_client() -> Result<Trezor, TrezorError> {
+        let mut client = trezor_client::unique(false)?;
+        client.init_device()?;
+
+        Ok(client)
+    }
+
+    pub async fn new(derivation: DerivationType, chain_id: u64) -> Result<Self, TrezorError> {
+        // Check if reachable
+        let address = Self::get_address_with_path(&derivation).await?;
+
+        Ok(Self { derivation, chain_id, address })
+    }
+
+    /// Consume self and drop the Trezor mutex
+    pub fn close(self) {}
+
+    /// Get the account which corresponds to our derivation path
+    pub async fn get_address(&self) -> Result<Address, TrezorError> {
+        Ok(TrezorEthereum::get_address_with_path(&self.derivation).await?)
+    }
+
+    /// Gets the account which corresponds to the provided derivation path
+    pub async fn get_address_with_path(
+        derivation: &DerivationType,
+    ) -> Result<Address, TrezorError> {
+        let mut client = TrezorEthereum::get_client()?;
+
+        let address_str = client.ethereum_get_address(Self::convert_path(derivation))?;
+
+        let mut address = [0; 20];
+        address.copy_from_slice(&hex::decode(&address_str[2..])?);
+
+
+        Ok(Address::from(address))
+    }
+
+    /// Signs an Ethereum transaction (requires confirmation on the Trezor)
+    pub async fn sign_tx(&self, tx: &TypedTransaction) -> Result<Signature, TrezorError> {
+
+        let mut client = TrezorEthereum::get_client()?;
+
+        let arr_path = Self::convert_path(&self.derivation);
+
+        let mut nonce = [0 as u8; 32];
+        let mut gas = [0 as u8; 32];
+        let mut gas_price = [0 as u8; 32];
+        let mut value = [0 as u8; 32];
+        let mut max_fee_per_gas: Option<Vec<u8>> = None;
+        let mut max_priority_fee_per_gas: Option<Vec<u8>> = None;
+
+        tx.nonce().unwrap().to_big_endian(&mut nonce);
+        tx.gas().unwrap().to_big_endian(&mut gas);
+        tx.gas_price().unwrap().to_big_endian(&mut gas_price);
+        tx.value().unwrap().to_big_endian(&mut value);
+
+        let to: String = match tx.to().unwrap() {
+            NameOrAddress::Name(_) => unimplemented!(),
+            NameOrAddress::Address(value) => format!("0x{}", hex::encode(value)),
+        };
+
+        let signature = match tx {
+            TypedTransaction::Eip2930(_) | TypedTransaction::Legacy(_) => {
+                client.ethereum_sign_tx(
+                    arr_path,
+                    nonce[tx.nonce().unwrap().leading_zeros() as usize/8..].to_vec(),
+                    gas_price[tx.gas_price().unwrap().leading_zeros() as usize/8..].to_vec(),
+                    gas[tx.gas().unwrap().leading_zeros() as usize/8..].to_vec(),
+                    to,
+                    value[tx.value().unwrap().leading_zeros() as usize/8..].to_vec(),
+                    tx.data().unwrap().to_vec(),
+                    self.chain_id
+                )?
+            }
+            TypedTransaction::Eip1559(eip1559_tx) => {
+                let mut m_fpg = [0 as u8; 32];
+                let mut m_pfpg = [0 as u8; 32];
+
+                eip1559_tx.max_fee_per_gas.unwrap().to_big_endian(&mut m_fpg);
+                eip1559_tx.max_priority_fee_per_gas.unwrap().to_big_endian(&mut m_pfpg);
+
+                let mut trezor_access_list: Vec<Trezor_AccessListItem> = Vec::new();
+                for item in &eip1559_tx.access_list.0 {
+
+                    let address: String = format!("0x{}", hex::encode(item.address));
+                    let mut storage_keys: Vec<Vec<u8>> = Vec::new();
+
+                    for key in &item.storage_keys {
+                        storage_keys.push(
+                            key.as_bytes().to_vec()
+                        )
+                    }
+
+                    trezor_access_list.push(
+                        Trezor_AccessListItem {
+                            address,
+                            storage_keys
+                        }
+                    )
+                }
+                
+                client.ethereum_sign_eip1559_tx(
+                    arr_path,
+                    nonce[tx.nonce().unwrap().leading_zeros() as usize/8..].to_vec(),
+                    gas[tx.gas().unwrap().leading_zeros() as usize/8..].to_vec(),
+                    to,
+                    value[tx.value().unwrap().leading_zeros() as usize/8..].to_vec(),
+                    tx.data().unwrap().to_vec(),
+                    self.chain_id,
+                    m_fpg[eip1559_tx.max_fee_per_gas.unwrap().leading_zeros() as usize / 8..].to_vec(),
+                    m_pfpg[eip1559_tx.max_priority_fee_per_gas.unwrap().leading_zeros() as usize / 8..].to_vec(),
+                    trezor_access_list
+                )?
+            }
+        };
+
+        Ok(Signature { r: signature.r, s: signature.s, v: signature.v })
+    }
+
+    /// Signs an ethereum personal message
+    pub async fn sign_message<S: AsRef<[u8]>>(&self, message: S) -> Result<Signature, TrezorError> {
+        let message = message.as_ref();
+        let mut client = TrezorEthereum::get_client()?;
+        let apath = Self::convert_path(&self.derivation);
+
+        let signs = client.ethereum_sign_message(
+            message.into(),
+            apath
+        )?;
+        Ok(Signature { r: signs.r, s: signs.s, v: signs.v })
+    }
+
+    /// Signs an EIP712 encoded domain separator and message
+    pub async fn sign_typed_struct<T>(&self, payload: &T) -> Result<Signature, TrezorError>
+    where
+        T: Eip712,
+    {
+        unimplemented!()
+    }
+
+    // helper which converts a derivation path to [u32]
+    fn convert_path(derivation: &DerivationType) -> Vec<u32> {
+        let derivation = derivation.to_string();
+        let elements = derivation.split('/').skip(1).collect::<Vec<_>>();
+        let depth = elements.len();
+
+        let mut path = vec![];
+        for derivation_index in elements {
+            let hardened = derivation_index.contains('\'');
+            let mut index = derivation_index.replace("'", "").parse::<u32>().unwrap();
+            if hardened {
+                index |= 0x80000000;
+            }
+            path.push(index);
+        }
+
+        path
+    }
+}
+
+
+#[cfg(all(test, feature = "trezor"))]
+mod tests {
+    use super::*;
+    use crate::Signer;
+    use ethers_contract::EthAbiType;
+    use ethers_core::types::{
+        transaction::eip2930::{AccessList, AccessListItem},
+        transaction::eip712::Eip712, Address, TransactionRequest, Eip1559TransactionRequest, I256, U256,
+    };
+    use ethers_derive_eip712::*;
+    use std::str::FromStr;
+
+    #[derive(Debug, Clone, Eip712, EthAbiType)]
+    #[eip712(
+        name = "Eip712Test",
+        version = "1",
+        chain_id = 1,
+        verifying_contract = "0x0000000000000000000000000000000000000001",
+        salt = "eip712-test-75F0CCte"
+    )]
+    struct FooBar {
+        foo: I256,
+        bar: U256,
+        fizz: Vec<u8>,
+        buzz: [u8; 32],
+        far: String,
+        out: Address,
+    }
+
+    #[tokio::test]
+    #[ignore]
+    // Replace this with your ETH addresses.
+    async fn test_get_address() {
+        // Instantiate it with the default trezor derivation path
+        let trezor = TrezorEthereum::new(DerivationType::TrezorLive(1), 1).await.unwrap();
+        assert_eq!(
+            trezor.get_address().await.unwrap(),
+            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".parse().unwrap()
+        );
+        assert_eq!(
+            TrezorEthereum::get_address_with_path(&DerivationType::TrezorLive(0)).await.unwrap(),
+            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".parse().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_sign_tx() {
+        let trezor = TrezorEthereum::new(DerivationType::TrezorLive(0), 1).await.unwrap();
+
+        // approve uni v2 router 0xff
+        let data = hex::decode("095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap();
+
+        let tx_req = TransactionRequest::new()
+            .to("2ed7afa17473e17ac59908f088b4371d28585476".parse::<Address>().unwrap())
+            .gas(1000000)
+            .gas_price(400e9 as u64)
+            .nonce(5)
+            .data(data)
+            .value(ethers_core::utils::parse_ether(100).unwrap())
+            .into();
+        let tx = trezor.sign_transaction(&tx_req).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_sign_eip1559_tx() {
+        let trezor = TrezorEthereum::new(DerivationType::TrezorLive(0), 1).await.unwrap();
+
+        // approve uni v2 router 0xff
+        let data = hex::decode("095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap();
+
+        let lst = AccessList(
+            vec![AccessListItem {
+                address: "0x8ba1f109551bd432803012645ac136ddd64dba72".parse().unwrap(),
+                storage_keys: vec![
+                    "0x0000000000000000000000000000000000000000000000000000000000000000"
+                        .parse()
+                        .unwrap(),
+                    "0x0000000000000000000000000000000000000000000000000000000000000042"
+                        .parse()
+                        .unwrap(),
+                ],
+            },
+            AccessListItem {
+                address: "0x2ed7afa17473e17ac59908f088b4371d28585476".parse().unwrap(),
+                storage_keys: vec![
+                    "0x0000000000000000000000000000000000000000000000000000000000000000"
+                        .parse()
+                        .unwrap(),
+                    "0x0000000000000000000000000000000000000000000000000000000000000042"
+                        .parse()
+                        .unwrap(),
+                ],
+            }
+        ]);
+        
+        let tx_req = Eip1559TransactionRequest::new()
+            .to("2ed7afa17473e17ac59908f088b4371d28585476".parse::<Address>().unwrap())
+            .gas(1000000)
+            .max_fee_per_gas(400e9 as u64)
+            .max_priority_fee_per_gas(400e9 as u64)
+            .nonce(5)
+            .data(data)
+            .access_list(lst)
+            .value(ethers_core::utils::parse_ether(100).unwrap())
+            .into();
+
+        let tx = trezor.sign_transaction(&tx_req).await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_sign_message() {
+        let trezor = TrezorEthereum::new(DerivationType::TrezorLive(0), 1).await.unwrap();
+        let message = "hello world";
+        let sig = trezor.sign_message(message).await.unwrap();
+        let addr = trezor.get_address().await.unwrap();
+        sig.verify(message, addr).unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_sign_eip712_struct() {
+        let trezor = TrezorEthereum::new(DerivationType::TrezorLive(0), 1u64).await.unwrap();
+
+        let foo_bar = FooBar {
+            foo: I256::from(10),
+            bar: U256::from(20),
+            fizz: b"fizz".to_vec(),
+            buzz: keccak256("buzz"),
+            far: String::from("space"),
+            out: Address::from([0; 20]),
+        };
+
+        let sig = trezor.sign_typed_struct(&foo_bar).await.expect("failed to sign typed data");
+        let foo_bar_hash = foo_bar.encode_eip712().unwrap();
+        sig.verify(foo_bar_hash, trezor.address).unwrap();
+    }
+}

--- a/ethers-signers/src/trezor/app.rs
+++ b/ethers-signers/src/trezor/app.rs
@@ -165,7 +165,7 @@ impl TrezorEthereum {
         let mut path = vec![];
         for derivation_index in elements {
             let hardened = derivation_index.contains('\'');
-            let mut index = derivation_index.replace("'", "").parse::<u32>().unwrap();
+            let mut index = derivation_index.replace('\'', "").parse::<u32>().unwrap();
             if hardened {
                 index |= 0x80000000;
             }

--- a/ethers-signers/src/trezor/app.rs
+++ b/ethers-signers/src/trezor/app.rs
@@ -73,8 +73,6 @@ impl TrezorEthereum {
         let mut gas = [0 as u8; 32];
         let mut gas_price = [0 as u8; 32];
         let mut value = [0 as u8; 32];
-        let mut max_fee_per_gas: Option<Vec<u8>> = None;
-        let mut max_priority_fee_per_gas: Option<Vec<u8>> = None;
 
         tx.nonce().unwrap().to_big_endian(&mut nonce);
         tx.gas().unwrap().to_big_endian(&mut gas);

--- a/ethers-signers/src/trezor/app.rs
+++ b/ethers-signers/src/trezor/app.rs
@@ -46,7 +46,7 @@ impl TrezorEthereum {
         let mut client = trezor_client::unique(false)?;
         client.init_device(None)?;
         self.session_id = client.features().unwrap().get_session_id().to_vec();
-        drop(client);
+
         Ok(())
     }
 
@@ -74,7 +74,6 @@ impl TrezorEthereum {
         let mut address = [0; 20];
         address.copy_from_slice(&hex::decode(&address_str[2..])?);
 
-        drop(client);
         Ok(Address::from(address))
     }
 
@@ -147,7 +146,6 @@ impl TrezorEthereum {
             }
         };
 
-        drop(client);
         Ok(Signature { r: signature.r, s: signature.s, v: signature.v })
     }
 
@@ -159,7 +157,6 @@ impl TrezorEthereum {
 
         let signs = client.ethereum_sign_message(message.into(), apath)?;
 
-        drop(client);
         Ok(Signature { r: signs.r, s: signs.s, v: signs.v })
     }
 

--- a/ethers-signers/src/trezor/app.rs
+++ b/ethers-signers/src/trezor/app.rs
@@ -34,7 +34,7 @@ impl TrezorEthereum {
         let mut blank = Self {
             derivation: derivation.clone(),
             chain_id,
-            address: Address::from([0 as u8; 20]),
+            address: Address::from([0_u8; 20]),
             session_id: vec![],
         };
 

--- a/ethers-signers/src/trezor/mod.rs
+++ b/ethers-signers/src/trezor/mod.rs
@@ -1,0 +1,52 @@
+pub mod app;
+pub mod types;
+
+use crate::Signer;
+use app::TrezorEthereum;
+use async_trait::async_trait;
+use ethers_core::types::{
+    transaction::{eip2718::TypedTransaction, eip712::Eip712},
+    Address, Signature,
+};
+use types::TrezorError;
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl Signer for TrezorEthereum {
+    type Error = TrezorError;
+
+    /// Signs the hash of the provided message after prefixing it
+    async fn sign_message<S: Send + Sync + AsRef<[u8]>>(
+        &self,
+        message: S,
+    ) -> Result<Signature, Self::Error> {
+        self.sign_message(message).await
+    }
+
+    /// Signs the transaction
+    async fn sign_transaction(&self, message: &TypedTransaction) -> Result<Signature, Self::Error> {
+        self.sign_tx(message).await
+    }
+
+    /// Signs a EIP712 derived struct
+    async fn sign_typed_data<T: Eip712 + Send + Sync>(
+        &self,
+        payload: &T,
+    ) -> Result<Signature, Self::Error> {
+        self.sign_typed_struct(payload).await
+    }
+
+    /// Returns the signer's Ethereum Address
+    fn address(&self) -> Address {
+        self.address
+    }
+
+    fn with_chain_id<T: Into<u64>>(mut self, chain_id: T) -> Self {
+        self.chain_id = chain_id.into();
+        self
+    }
+
+    fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+}

--- a/ethers-signers/src/trezor/types.rs
+++ b/ethers-signers/src/trezor/types.rs
@@ -48,7 +48,7 @@ pub enum TrezorError {
     SemVerError(#[from] semver::Error),
     /// Error when signing EIP712 struct with not compatible Trezor ETH app
     #[error("Trezor ethereum app requires at least version: {0:?}")]
-    UnsupportedAppVersion(String),
+    UnsupportedFirmwareVersion(String),
 }
 
 /// Trezor Transaction Struct

--- a/ethers-signers/src/trezor/types.rs
+++ b/ethers-signers/src/trezor/types.rs
@@ -66,7 +66,7 @@ pub struct TrezorTransaction {
 
 impl TrezorTransaction {
     fn to_trimmed_big_endian(_value: &U256) -> Vec<u8> {
-        let mut trimmed_value = [0 as u8; 32];
+        let mut trimmed_value = [0_u8; 32];
         _value.to_big_endian(&mut trimmed_value);
         trimmed_value[_value.leading_zeros() as usize / 8..].to_vec()
     }

--- a/ethers-signers/src/trezor/types.rs
+++ b/ethers-signers/src/trezor/types.rs
@@ -1,0 +1,41 @@
+#![allow(clippy::upper_case_acronyms)]
+//! Helpers for interacting with the Ethereum Trezor App
+//! [Official Docs](https://github.com/TrezorHQ/app-ethereum/blob/master/doc/ethapp.asc)
+use std::fmt;
+use thiserror::Error;
+
+#[derive(Clone, Debug)]
+/// Trezor wallet type
+pub enum DerivationType {
+    /// Trezor Live-generated HD path
+    TrezorLive(usize),
+}
+
+impl fmt::Display for DerivationType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "{}",
+            match self {
+                DerivationType::TrezorLive(index) => format!("m/44'/60'/{}'/0/0", index)
+            }
+        )
+    }
+}
+
+#[derive(Error, Debug)]
+/// Error when using the Trezor transport
+pub enum TrezorError {
+    /// Underlying Trezor transport error
+    #[error(transparent)]
+    TrezorError(#[from] trezor_client::error::Error),
+    #[error(transparent)]
+    /// Error when converting from a hex string
+    HexError(#[from] hex::FromHexError),
+    #[error(transparent)]
+    /// Error when converting a semver requirement
+    SemVerError(#[from] semver::Error),
+    /// Error when signing EIP712 struct with not compatible Trezor ETH app
+    #[error("Trezor ethereum app requires at least version: {0:?}")]
+    UnsupportedAppVersion(String),
+}

--- a/ethers-signers/src/trezor/types.rs
+++ b/ethers-signers/src/trezor/types.rs
@@ -17,7 +17,7 @@ impl fmt::Display for DerivationType {
             f,
             "{}",
             match self {
-                DerivationType::TrezorLive(index) => format!("m/44'/60'/{}'/0/0", index)
+                DerivationType::TrezorLive(index) => format!("m/44'/60'/{}'/0/0", index),
             }
         )
     }

--- a/ethers-signers/src/trezor/types.rs
+++ b/ethers-signers/src/trezor/types.rs
@@ -9,6 +9,9 @@ use thiserror::Error;
 pub enum DerivationType {
     /// Trezor Live-generated HD path
     TrezorLive(usize),
+    /// Any other path. Attention! Trezor by default forbids custom derivation paths
+    /// Run trezorctl set safety-checks prompt, to allow it
+    Other(String),
 }
 
 impl fmt::Display for DerivationType {
@@ -18,6 +21,7 @@ impl fmt::Display for DerivationType {
             "{}",
             match self {
                 DerivationType::TrezorLive(index) => format!("m/44'/60'/{}'/0/0", index),
+                DerivationType::Other(inner) => inner.to_owned(),
             }
         )
     }

--- a/examples/trezor.rs
+++ b/examples/trezor.rs
@@ -16,7 +16,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create and broadcast a transaction (ENS enabled!)
     // (this will require confirming the tx on the device)
-    let tx = TransactionRequest::new().to("0x99E2B13A8Ea8b00C68FA017ee250E98e870D8241").value(parse_ether(10)?);
+    let tx = TransactionRequest::new()
+        .to("0x99E2B13A8Ea8b00C68FA017ee250E98e870D8241")
+        .value(parse_ether(10)?);
     let pending_tx = client.send_transaction(tx, None).await?;
 
     // Get the receipt

--- a/examples/trezor.rs
+++ b/examples/trezor.rs
@@ -1,5 +1,4 @@
 #[tokio::main]
-// #[cfg(feature = "trezor")]
 #[cfg(feature = "trezor")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     use ethers::{prelude::*, utils::parse_ether};
@@ -26,6 +25,5 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-// #[cfg(not(feature = "trezor"))]
 #[cfg(not(feature = "trezor"))]
 fn main() {}

--- a/examples/trezor.rs
+++ b/examples/trezor.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let trezor = Trezor::new(TrezorHDPath::TrezorLive(0), 1).await?;
     let client = SignerMiddleware::new(provider, trezor);
 
-    // Create and broadcast a transaction (ENS enabled!)
+    // Create and broadcast a transaction (ENS disabled!)
     // (this will require confirming the tx on the device)
     let tx = TransactionRequest::new()
         .to("0x99E2B13A8Ea8b00C68FA017ee250E98e870D8241")

--- a/examples/trezor.rs
+++ b/examples/trezor.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // (here: mainnet) for EIP155 support.
     // EIP1559 support
     // No EIP712 support yet.
-    let trezor = Trezor::new(HDPath::TrezorLive(0), 1).await?;
+    let trezor = Trezor::new(TrezorHDPath::TrezorLive(0), 1).await?;
     let client = SignerMiddleware::new(provider, trezor);
 
     // Create and broadcast a transaction (ENS enabled!)

--- a/examples/trezor.rs
+++ b/examples/trezor.rs
@@ -1,0 +1,29 @@
+#[tokio::main]
+// #[cfg(feature = "trezor")]
+#[cfg(feature = "trezor")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use ethers::{prelude::*, utils::parse_ether};
+
+    // Connect over websockets
+    let provider = Provider::new(Ws::connect("ws://localhost:8545").await?);
+    // Instantiate the connection to trezor with Trezor Live derivation path and
+    // the wallet's index. You may also provide the chain_id.
+    // (here: mainnet) for EIP155 support.
+    // EIP1559 support
+    // No EIP712 support yet.
+    let trezor = Trezor::new(HDPath::TrezorLive(0), 1).await?;
+    let client = SignerMiddleware::new(provider, trezor);
+
+    // Create and broadcast a transaction (ENS enabled!)
+    // (this will require confirming the tx on the device)
+    let tx = TransactionRequest::new().to("0x99E2B13A8Ea8b00C68FA017ee250E98e870D8241").value(parse_ether(10)?);
+    let pending_tx = client.send_transaction(tx, None).await?;
+
+    // Get the receipt
+    let _receipt = pending_tx.confirmations(3).await?;
+    Ok(())
+}
+
+// #[cfg(not(feature = "trezor"))]
+#[cfg(not(feature = "trezor"))]
+fn main() {}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Ref: #1
Adding trezor signing support, with the end goal of adding it to [foundry/cast](https://github.com/gakonst/foundry/tree/master/cast).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Forked a year old rust client (https://github.com/romanz/rust-trezor-api -> https://github.com/joshieDo/rust-trezor-api) and added the ethereum interface it lacked, along with updating the libusb (+rusb) to be compatible with ethers-rs.  I'm not much experienced in Rust, so an additional pair of eyes in my fork is most welcome.

On the `ethers-signers` implementation, I tried to follow the existing Ledger structure as much as possible.

- [x] get_address
- [x] sign_message
- [x] sign_tx
- [x] sign_eip1559
- [ ] sign_eip712

## ~~WIP~~

~~Fixing: Passphrase is being requested on every request~~

## Missing EIP712

I need to understand  EIP712 better from both sides, At first glance, it seems tricky to pass the intended data from `ethers-rs` to the `trezor client`. I was hoping that could be done in a future issue/PR. What do you think?

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
