### PR TITLE
Serialize `eth_feeHistory` block count as `QUANTITY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   [597](https://github.com/gakonst/ethers-rs/pull/597)
 - Implement hex display format for `ethers::core::Bytes`
   [#624](https://github.com/gakonst/ethers-rs/pull/624).
+- Fix `fee_history` to first try with `block_count` encoded as a hex `QUANTITY`.
+  [#668](https://github.com/gakonst/ethers-rs/pull/668)
 
 ## ethers-solc
 

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -848,7 +848,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.subscribe([logs, filter]).await
     }
 
-    async fn fee_history<T: Into<U256> + serde::Serialize + Send + Sync>(
+    async fn fee_history<T: Into<U256> + Send + Sync>(
         &self,
         block_count: T,
         last_block: BlockNumber,
@@ -862,7 +862,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         // decode the param from client side would fallback to the old API spec.
         self.request(
             "eth_feeHistory",
-            [utils::serialize(&block_count), last_block.clone(), reward_percentiles.clone()],
+            [utils::serialize(&block_count.into()), last_block.clone(), reward_percentiles.clone()],
         )
         .await
         .or(self


### PR DESCRIPTION
## Motivation

Retrieving fee history with, say, a `u64` would serialize the the `block_count` as a number twice, instead of first trying as a `QUANTITY` which is my understanding of what it is meant to do (i.e. hex-encoded string - e.g. `0x42`). This PR aims to fix that.

## Solution

Instead of serializing the `block_count` that is passed in, it first converts to a `U256` (which serializes as a `QUANTITY`).

## PR Checklist

- [ ] Added Tests (No - but should be covered by existing tests?)
- [ ] Added Documentation (No - behaviour shouldn't have been changed)
- [x] Updated the changelog
