### PR TITLE
Serialize block count as quantity 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   [597](https://github.com/gakonst/ethers-rs/pull/597)
 - Implement hex display format for `ethers::core::Bytes`
   [#624](https://github.com/gakonst/ethers-rs/pull/624).
+- Fix `fee_history` to first try with `block_count` encoded as a hex `QUANTITY`.
+  [#668](https://github.com/gakonst/ethers-rs/pull/668)
 
 ## ethers-solc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Implement hex display format for `ethers::core::Bytes`
   [#624](https://github.com/gakonst/ethers-rs/pull/624).
 - Fix `fee_history` to first try with `block_count` encoded as a hex `QUANTITY`.
-  [#668](https://github.com/gakonst/ethers-rs/pull/668)
+  [#669](https://github.com/gakonst/ethers-rs/pull/669)
 
 ## ethers-solc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Implement hex display format for `ethers::core::Bytes`
   [#624](https://github.com/gakonst/ethers-rs/pull/624).
 - Fix `fee_history` to first try with `block_count` encoded as a hex `QUANTITY`.
-  [#669](https://github.com/gakonst/ethers-rs/pull/669)
+  [#668](https://github.com/gakonst/ethers-rs/pull/668)
 
 ## ethers-solc
 

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -854,6 +854,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         last_block: BlockNumber,
         reward_percentiles: &[f64],
     ) -> Result<FeeHistory, Self::Error> {
+        let block_count = block_count.into();
         let last_block = utils::serialize(&last_block);
         let reward_percentiles = utils::serialize(&reward_percentiles);
 
@@ -862,13 +863,13 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         // decode the param from client side would fallback to the old API spec.
         self.request(
             "eth_feeHistory",
-            [utils::serialize(&block_count.into()), last_block.clone(), reward_percentiles.clone()],
+            [utils::serialize(&block_count), last_block.clone(), reward_percentiles.clone()],
         )
         .await
         .or(self
             .request(
                 "eth_feeHistory",
-                [utils::serialize(&block_count.into().as_u64()), last_block, reward_percentiles],
+                [utils::serialize(&block_count.as_u64()), last_block, reward_percentiles],
             )
             .await)
     }

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -848,7 +848,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.subscribe([logs, filter]).await
     }
 
-    async fn fee_history<T: Into<U256> + serde::Serialize + Send + Sync>(
+    async fn fee_history<T: Into<U256> + Send + Sync>(
         &self,
         block_count: T,
         last_block: BlockNumber,
@@ -862,7 +862,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         // decode the param from client side would fallback to the old API spec.
         self.request(
             "eth_feeHistory",
-            [utils::serialize(&block_count), last_block.clone(), reward_percentiles.clone()],
+            [utils::serialize(&block_count.into()), last_block.clone(), reward_percentiles.clone()],
         )
         .await
         .or(self

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -863,7 +863,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         // decode the param from client side would fallback to the old API spec.
         self.request(
             "eth_feeHistory",
-            [utils::serialize(&block_count.into()), last_block.clone(), reward_percentiles.clone()],
+            [utils::serialize(&block_count), last_block.clone(), reward_percentiles.clone()],
         )
         .await
         .or(self


### PR DESCRIPTION
**Sorry, there was an issue with #668**

I created the PR too quickly and didn't run `cargo check` :see_no_evil:. It turns out there was an issue where I was moving `block_count` when doing `block_count.into()` and needed to first convert `block_count` to a `U256` to avoid move issues.

Sorry for breaking your `master` builds!

## PR Checklist

- [ ] Added Tests (No - but should be covered by existing tests?)
- [ ] Added Documentation (No - behaviour shouldn't have been changed)
- [ ] Updated the changelog (No - just fixes my broken PR).


Also, make sure to run check commands:
```
$ cargo check --all-features
$ cargo +nightly fmt --all
$ cargo build --all-features
$ cargo test --all-features
```