### PR TITLE
format_units return was truncating the decimal places 

### DIFF
--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -79,7 +79,12 @@ pub fn format_units<T: Into<U256>, K: Into<Units>>(amount: T, units: K) -> Strin
     let amount = amount.into();
     let amount_decimals = amount % U256::from(10_u128.pow(units.as_num()));
     let amount_integer = amount / U256::from(10_u128.pow(units.as_num()));
-    amount_integer.to_string() + "." + &amount_decimals.to_string()
+    format!(
+        "{}.{:0width$}",
+        amount_integer,
+        amount_decimals.as_u128(),
+        width = units.as_num() as usize
+    )
 }
 
 /// Converts the input to a U256 and converts from Ether to Wei.
@@ -398,6 +403,9 @@ mod tests {
 
         let eth = format_units(U256::from_dec_str("1395633240123456789").unwrap(), "ether");
         assert_eq!(eth, "1.395633240123456789");
+
+        let eth = format_units(U256::from_dec_str("1005633240123456789").unwrap(), "ether");
+        assert_eq!(eth, "1.005633240123456789");
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
The recent change to format_units was truncating the leading zeros of the decimal places causing the following output as an example: 1001234567891234567 eth became 1.1234567891234567 when formatted. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Added zero padding to the decimal numbers when printed.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
