### PR TITLE
fix(solc): exclude sha2 asm feature for msvc

### DIFF
--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -33,10 +33,10 @@ tracing = "0.1.29"
 num_cpus = "1.13.0"
 tiny-keccak = { version = "2.0.2", default-features = false }
 
-[target.'cfg(not(any(target_arch = "x86", target_arch = "x86_64")))'.dependencies]
+[target.'cfg(any(not(any(target_arch = "x86", target_arch = "x86_64")), target_env = "msvc"))'.dependencies]
 sha2 = { version = "0.9.8", default-features = false }
 
-[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
+[target.'cfg(all(any(target_arch = "x86", target_arch = "x86_64"), not(target_env = "msvc")))'.dependencies]
 sha2 = { version = "0.9.8", default-features = false, features = ["asm"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

MSVC is not supported for sha2 asm https://github.com/RustCrypto/asm-hashes/issues/17

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

We disable asm if the target is msvc 

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
