### PR TITLE
refactor(solc): add new io error with path info

### DIFF
--- a/ethers-solc/src/compile.rs
+++ b/ethers-solc/src/compile.rs
@@ -247,7 +247,7 @@ impl Solc {
         let version = self.version_short()?;
         let mut version_path = svm::version_path(version.to_string().as_str());
         version_path.push(format!("solc-{}", version.to_string().as_str()));
-        let content = std::fs::read(version_path)?;
+        let content = std::fs::read(&version_path).map_err(|err| SolcError::io(err, version_path))?;
 
         use sha2::Digest;
         let mut hasher = sha2::Sha256::new();
@@ -265,6 +265,7 @@ impl Solc {
 
     /// Convenience function for compiling all sources under the given path
     pub fn compile_source(&self, path: impl AsRef<Path>) -> Result<CompilerOutput> {
+        let path = path.as_ref();
         self.compile(&CompilerInput::new(path)?)
     }
 
@@ -302,11 +303,12 @@ impl Solc {
             .stdin(Stdio::piped())
             .stderr(Stdio::piped())
             .stdout(Stdio::piped())
-            .spawn()?;
+            .spawn()
+            .map_err(|err| SolcError::io(err, &self.solc))?;
         let stdin = child.stdin.take().unwrap();
 
         serde_json::to_writer(stdin, input)?;
-        compile_output(child.wait_with_output()?)
+        compile_output(child.wait_with_output().map_err(|err| SolcError::io(err, &self.solc))?)
     }
 
     pub fn version_short(&self) -> Result<Version> {
@@ -322,7 +324,8 @@ impl Solc {
                 .stdin(Stdio::piped())
                 .stderr(Stdio::piped())
                 .stdout(Stdio::piped())
-                .output()?,
+                .output()
+                .map_err(|err| SolcError::io(err, &self.solc))?,
         )
     }
 }
@@ -363,11 +366,12 @@ impl Solc {
             .stdin(Stdio::piped())
             .stderr(Stdio::piped())
             .stdout(Stdio::piped())
-            .spawn()?;
+            .spawn()
+            .map_err(|err| SolcError::io(err, &self.solc))?;
         let stdin = child.stdin.as_mut().unwrap();
-        stdin.write_all(&content).await?;
-        stdin.flush().await?;
-        compile_output(child.wait_with_output().await?)
+        stdin.write_all(&content).await .map_err(|err| SolcError::io(err, &self.solc))?;
+        stdin.flush().await.map_err(|err| SolcError::io(err, &self.solc))?;
+        compile_output(child.wait_with_output().await .map_err(|err| SolcError::io(err, &self.solc))  ?)
     }
 
     pub async fn async_version(&self) -> Result<Version> {
@@ -377,9 +381,11 @@ impl Solc {
                 .stdin(Stdio::piped())
                 .stderr(Stdio::piped())
                 .stdout(Stdio::piped())
-                .spawn()?
+                .spawn()
+                .map_err(|err| SolcError::io(err, &self.solc))?
                 .wait_with_output()
-                .await?,
+                .await
+                .map_err(|err| SolcError::io(err, &self.solc))?
         )
     }
 
@@ -470,7 +476,8 @@ fn version_from_output(output: Output) -> Result<Version> {
             .stdout
             .lines()
             .last()
-            .ok_or_else(|| SolcError::solc("version not found in solc output"))??;
+            .ok_or_else(|| SolcError::solc("version not found in solc output"))?
+            .map_err(|err| SolcError::msg(format!("Failed to read output: {}", err)))?;
         // NOTE: semver doesn't like `+` in g++ in build metadata which is invalid semver
         Ok(Version::from_str(&version.trim_start_matches("Version: ").replace(".g++", ".gcc"))?)
     } else {

--- a/ethers-solc/src/compile.rs
+++ b/ethers-solc/src/compile.rs
@@ -247,7 +247,8 @@ impl Solc {
         let version = self.version_short()?;
         let mut version_path = svm::version_path(version.to_string().as_str());
         version_path.push(format!("solc-{}", version.to_string().as_str()));
-        let content = std::fs::read(&version_path).map_err(|err| SolcError::io(err, version_path))?;
+        let content =
+            std::fs::read(&version_path).map_err(|err| SolcError::io(err, version_path))?;
 
         use sha2::Digest;
         let mut hasher = sha2::Sha256::new();
@@ -369,9 +370,11 @@ impl Solc {
             .spawn()
             .map_err(|err| SolcError::io(err, &self.solc))?;
         let stdin = child.stdin.as_mut().unwrap();
-        stdin.write_all(&content).await .map_err(|err| SolcError::io(err, &self.solc))?;
+        stdin.write_all(&content).await.map_err(|err| SolcError::io(err, &self.solc))?;
         stdin.flush().await.map_err(|err| SolcError::io(err, &self.solc))?;
-        compile_output(child.wait_with_output().await .map_err(|err| SolcError::io(err, &self.solc))  ?)
+        compile_output(
+            child.wait_with_output().await.map_err(|err| SolcError::io(err, &self.solc))?,
+        )
     }
 
     pub async fn async_version(&self) -> Result<Version> {
@@ -385,7 +388,7 @@ impl Solc {
                 .map_err(|err| SolcError::io(err, &self.solc))?
                 .wait_with_output()
                 .await
-                .map_err(|err| SolcError::io(err, &self.solc))?
+                .map_err(|err| SolcError::io(err, &self.solc))?,
         )
     }
 

--- a/ethers-solc/src/error.rs
+++ b/ethers-solc/src/error.rs
@@ -1,3 +1,4 @@
+use std::{io, path::PathBuf};
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, SolcError>;
@@ -21,7 +22,7 @@ pub enum SolcError {
     SerdeJson(#[from] serde_json::Error),
     /// Filesystem IO error
     #[error(transparent)]
-    Io(#[from] std::io::Error),
+    Io(#[from] SolcIoError),
     #[cfg(feature = "svm")]
     #[error(transparent)]
     SvmError(#[from] svm::SolcVmError),
@@ -35,10 +36,32 @@ pub enum SolcError {
 }
 
 impl SolcError {
+    pub(crate) fn io(err: io::Error, path: impl Into<PathBuf>) -> Self {
+        SolcIoError::new(err, path).into()
+    }
     pub(crate) fn solc(msg: impl Into<String>) -> Self {
         SolcError::SolcError(msg.into())
     }
     pub(crate) fn msg(msg: impl Into<String>) -> Self {
         SolcError::Message(msg.into())
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("\"{}\": {io}", self.path.display())]
+pub struct SolcIoError {
+    io: io::Error,
+    path: PathBuf,
+}
+
+impl SolcIoError {
+    pub fn new(io: io::Error, path: impl Into<PathBuf>) -> Self {
+        Self { io, path: path.into() }
+    }
+}
+
+impl From<SolcIoError> for io::Error {
+    fn from(err: SolcIoError) -> Self {
+        err.io
     }
 }

--- a/ethers-solc/src/hh.rs
+++ b/ethers-solc/src/hh.rs
@@ -73,7 +73,8 @@ impl ArtifactOutput for HardhatArtifacts {
                     })?;
                 }
                 let artifact = Self::contract_to_artifact(file, name, contract.clone());
-                fs::write(&artifact_file, serde_json::to_vec_pretty(&artifact)?)?
+                fs::write(&artifact_file, serde_json::to_vec_pretty(&artifact)?)
+                    .map_err(|err| SolcError::io(err, artifact_file))?
             }
         }
         Ok(())

--- a/ethers-solc/src/utils.rs
+++ b/ethers-solc/src/utils.rs
@@ -52,7 +52,6 @@ pub fn find_version_pragma(contract: &str) -> Option<&str> {
 /// let sources = utils::source_files("./contracts");
 /// ```
 pub fn source_files(root: impl AsRef<Path>) -> Vec<PathBuf> {
-    
     WalkDir::new(root)
         .into_iter()
         .filter_map(Result::ok)

--- a/ethers-solc/src/utils.rs
+++ b/ethers-solc/src/utils.rs
@@ -49,17 +49,17 @@ pub fn find_version_pragma(contract: &str) -> Option<&str> {
 ///
 /// ```no_run
 /// use ethers_solc::utils;
-/// let sources = utils::source_files("./contracts").unwrap();
+/// let sources = utils::source_files("./contracts");
 /// ```
-pub fn source_files(root: impl AsRef<Path>) -> walkdir::Result<Vec<PathBuf>> {
-    let files = WalkDir::new(root)
+pub fn source_files(root: impl AsRef<Path>) -> Vec<PathBuf> {
+    
+    WalkDir::new(root)
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| e.file_type().is_file())
         .filter(|e| e.path().extension().map(|ext| ext == "sol").unwrap_or_default())
         .map(|e| e.path().into())
-        .collect();
-    Ok(files)
+        .collect()
 }
 
 /// Returns the source name for the given source path, the ancestors of the root path
@@ -192,7 +192,7 @@ mod tests {
         File::create(&file_c).unwrap();
         File::create(&file_d).unwrap();
 
-        let files: HashSet<_> = source_files(tmp_dir.path()).unwrap().into_iter().collect();
+        let files: HashSet<_> = source_files(tmp_dir.path()).into_iter().collect();
         let expected: HashSet<_> = [file_a, file_b, file_c, file_d].into();
         assert_eq!(files, expected);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
If there was an error due to a `File not found` io::Error then there is no info about the path, because `io::File` and alike consists of file descriptors and lacks file name information.

The general solution to that is to add additional context with anyhow::Context for example.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add a `SolcIoError` that also holds the path info when doing general io like reading from files
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
