### PR TITLE
feat(providers) Extract DevMiddleware trait

### DIFF
--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -34,7 +34,7 @@ pub use provider::{FilterKind, Provider, ProviderError};
 
 // feature-enabled support for dev-rpc methods
 #[cfg(feature = "dev-rpc")]
-pub use provider::dev_rpc::DevRpcMiddleware;
+pub use provider::dev_rpc::{DevMiddleware, DevRpcMiddleware};
 
 /// A simple gas escalation policy
 pub type EscalationPolicy = Box<dyn Fn(U256, usize) -> U256 + Send + Sync>;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Extracts a `DevMiddleware` trait, implementing it for `DevRpcMiddleware`. I needed this trait locally, but I think the trait will probably change once we add an [evm-adapters](https://github.com/gakonst/foundry/blob/3635682343318d7e7584b74157793562c9e62c81/evm-adapters/src/sputnik/evm.rs#L78-L81) middleware.

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
- [ ] Updated the changelog -- TODO
