### PR TITLE
fix: bump svm-rs for windows support

### DIFF
--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -27,7 +27,7 @@ md-5 = "0.10.0"
 thiserror = "1.0.30"
 hex = "0.4.3"
 colored = "2.0.0"
-svm = { package = "svm-rs", version = "0.2.0", optional = true }
+svm = { package = "svm-rs", version = "0.2.1", optional = true }
 glob = "0.3.0"
 tracing = "0.1.29"
 num_cpus = "1.13.0"


### PR DESCRIPTION
As title, updates svm to have https://github.com/roynalnaruto/svm-rs/pull/9 which makes it windows compatible 