### PR TITLE
fix: handling empty tx parameters on trezor-client

### DIFF
--- a/ethers-signers/src/trezor/app.rs
+++ b/ethers-signers/src/trezor/app.rs
@@ -263,6 +263,20 @@ mod tests {
 
     #[tokio::test]
     #[ignore]
+    async fn test_sign_empty_txes() {
+        let trezor = TrezorEthereum::new(DerivationType::TrezorLive(0), 1).await.unwrap();
+        {
+            let tx_req = Eip1559TransactionRequest::new().into();
+            let tx = trezor.sign_transaction(&tx_req).await.unwrap();
+        }
+        {
+            let tx_req = TransactionRequest::new().into();
+            let tx = trezor.sign_transaction(&tx_req).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    #[ignore]
     async fn test_sign_eip1559_tx() {
         let trezor = TrezorEthereum::new(DerivationType::TrezorLive(0), 1).await.unwrap();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
I wrongly assumed that a transaction would come with the necessary params (even if 0, or empty), and would only be None, if they were not even necessary.
When adding trezor to foundry, i realized that's not the case.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This PR makes sure the none values are converted into `vec![]` or `0` when necessary.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
