### PR TITLE
feature: set nonce in fill transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   [#624](https://github.com/gakonst/ethers-rs/pull/624).
 - Fix `fee_history` to first try with `block_count` encoded as a hex `QUANTITY`.
   [#668](https://github.com/gakonst/ethers-rs/pull/668)
+- Fix `fill_transaction` to set nonces in transactions, if the sender is known
+  and no nonce is specified
 
 ## ethers-contract-abigen
 

--- a/ethers-middleware/src/nonce_manager.rs
+++ b/ethers-middleware/src/nonce_manager.rs
@@ -77,6 +77,18 @@ where
         &self.inner
     }
 
+    async fn fill_transaction(
+        &self,
+        tx: &mut TypedTransaction,
+        block: Option<BlockId>,
+    ) -> Result<(), Self::Error> {
+        if tx.nonce().is_none() {
+            tx.set_nonce(self.get_transaction_count_with_manager(block).await?);
+        }
+
+        Ok(self.inner().fill_transaction(tx, block).await.map_err(FromErr::from)?)
+    }
+
     /// Signs and broadcasts the transaction. The optional parameter `block` can be passed so that
     /// gas cost and nonce calculations take it into account. For simple transactions this can be
     /// left to `None`.

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -171,13 +171,6 @@ pub trait Middleware: Sync + Send + Debug {
             }
         }
 
-        // set the nonce, if no nonce is found
-        if tx.nonce().is_none() {
-            let nonce =
-                self.get_transaction_count(tx.from().copied().unwrap_or_default(), block).await?;
-            tx.set_nonce(nonce);
-        }
-
         // TODO: Can we poll the futures below at the same time?
         // Access List + Name resolution and then Gas price + Gas
 

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -171,6 +171,13 @@ pub trait Middleware: Sync + Send + Debug {
             }
         }
 
+        // set the nonce, if no nonce is found
+        if tx.nonce().is_none() {
+            let nonce =
+                self.get_transaction_count(tx.from().copied().unwrap_or_default(), block).await?;
+            tx.set_nonce(nonce);
+        }
+
         // TODO: Can we poll the futures below at the same time?
         // Access List + Name resolution and then Gas price + Gas
 


### PR DESCRIPTION
## Motivation

Set nonces properly when filling transactions. Previously, nonces have been set by the node or the nonce manager during `send_transaction` calls. I erroneously assumed that `fill_transaction` would set the nonce. As a result, `send_escalating` never properly sets the nonce. This PR adds two additional places a nonce may be filled

Previously, I wanted to  add a nonce filler to `fill_transaction` however, this would _always_ override the node's suggested nonce when using an RPC signer via `send_transaction`. Instead, I chose to add it to `send_escalating`

## Solution

- add a nonce check to `send_escalating`
- ensure `NonceManagerMiddleware` fills the nonce from its manager

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
