### PR TITLE
refactor: move FeeHistory to core types

### DIFF
--- a/ethers-core/src/types/fee.rs
+++ b/ethers-core/src/types/fee.rs
@@ -1,0 +1,34 @@
+use std::str::FromStr;
+
+use crate::types::U256;
+use serde::{de::Deserializer, Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FeeHistory {
+    pub base_fee_per_gas: Vec<U256>,
+    pub gas_used_ratio: Vec<f64>,
+    #[serde(deserialize_with = "from_int_or_hex")]
+    /// oldestBlock is returned as an unsigned integer up to geth v1.10.6. From
+    /// geth v1.10.7, this has been updated to return in the hex encoded form.
+    /// The custom deserializer allows backward compatibility for those clients
+    /// not running v1.10.7 yet.
+    pub oldest_block: U256,
+    pub reward: Vec<Vec<U256>>,
+}
+
+fn from_int_or_hex<'de, D>(deserializer: D) -> Result<U256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum IntOrHex {
+        Int(u64),
+        Hex(String),
+    }
+    match IntOrHex::deserialize(deserializer)? {
+        IntOrHex::Int(n) => Ok(U256::from(n)),
+        IntOrHex::Hex(s) => U256::from_str(s.as_str()).map_err(serde::de::Error::custom),
+    }
+}

--- a/ethers-core/src/types/mod.rs
+++ b/ethers-core/src/types/mod.rs
@@ -54,3 +54,6 @@ pub use chain::*;
 mod proof;
 
 pub use proof::*;
+
+mod fee;
+pub use fee::*;

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -27,8 +27,8 @@ pub use pubsub::{PubsubClient, SubscriptionStream};
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use ethers_core::types::transaction::{eip2718::TypedTransaction, eip2930::AccessListWithGasUsed};
-use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
-use std::{error::Error, fmt::Debug, future::Future, pin::Pin, str::FromStr};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{error::Error, fmt::Debug, future::Future, pin::Pin};
 
 pub use provider::{FilterKind, Provider, ProviderError};
 
@@ -633,36 +633,6 @@ pub trait Middleware: Sync + Send + Debug {
         block: Option<BlockId>,
     ) -> Result<AccessListWithGasUsed, Self::Error> {
         self.inner().create_access_list(tx, block).await.map_err(FromErr::from)
-    }
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct FeeHistory {
-    pub base_fee_per_gas: Vec<U256>,
-    pub gas_used_ratio: Vec<f64>,
-    #[serde(deserialize_with = "from_int_or_hex")]
-    /// oldestBlock is returned as an unsigned integer up to geth v1.10.6. From
-    /// geth v1.10.7, this has been updated to return in the hex encoded form.
-    /// The custom deserializer allows backward compatibility for those clients
-    /// not running v1.10.7 yet.
-    pub oldest_block: U256,
-    pub reward: Vec<Vec<U256>>,
-}
-
-fn from_int_or_hex<'de, D>(deserializer: D) -> Result<U256, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum IntOrHex {
-        Int(u64),
-        Hex(String),
-    }
-    match IntOrHex::deserialize(deserializer)? {
-        IntOrHex::Int(n) => Ok(U256::from(n)),
-        IntOrHex::Hex(s) => U256::from_str(s.as_str()).map_err(serde::de::Error::custom),
     }
 }
 

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -2,7 +2,7 @@ use crate::{
     ens,
     pubsub::{PubsubClient, SubscriptionStream},
     stream::{FilterWatcher, DEFAULT_POLL_INTERVAL},
-    FeeHistory, FromErr, Http as HttpProvider, JsonRpcClient, JsonRpcClientWrapper, MockProvider,
+    FromErr, Http as HttpProvider, JsonRpcClient, JsonRpcClientWrapper, MockProvider,
     PendingTransaction, QuorumProvider,
 };
 
@@ -15,9 +15,10 @@ use ethers_core::{
     abi::{self, Detokenize, ParamType},
     types::{
         transaction::{eip2718::TypedTransaction, eip2930::AccessListWithGasUsed},
-        Address, Block, BlockId, BlockNumber, BlockTrace, Bytes, EIP1186ProofResponse, Filter, Log,
-        NameOrAddress, Selector, Signature, Trace, TraceFilter, TraceType, Transaction,
-        TransactionReceipt, TxHash, TxpoolContent, TxpoolInspect, TxpoolStatus, H256, U256, U64,
+        Address, Block, BlockId, BlockNumber, BlockTrace, Bytes, EIP1186ProofResponse, FeeHistory,
+        Filter, Log, NameOrAddress, Selector, Signature, Trace, TraceFilter, TraceType,
+        Transaction, TransactionReceipt, TxHash, TxpoolContent, TxpoolInspect, TxpoolStatus, H256,
+        U256, U64,
     },
     utils,
 };


### PR DESCRIPTION
## Motivation

`FeeHistory` is out of place in `ethers-providers`, it should go in `ethers_core::types` with all its typesy friends

## Solution

Move `FeeHistory` to `ethers-core/src/types/fee.rs` and update imports

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
