### PR TITLE
fix: remove assert to check cache format

### DIFF
--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -273,15 +273,14 @@ impl SolFilesCacheBuilder {
             files.insert(file, entry);
         }
 
-        let cache = if let Some(ref dest) = dest.as_ref().filter(|dest|dest.exists()) {
-                // read the existing cache and extend it by the files that changed
-                // (if we just wrote to the cache file, we'd overwrite the existing data)
-                let reader = std::io::BufReader::new(
-                    File::open(dest).map_err(|err| SolcError::io(err, dest))?,
-                );
-                let mut cache: SolFilesCache = serde_json::from_reader(reader)?;
-                cache.files.extend(files);
-                cache
+        let cache = if let Some(dest) = dest.as_ref().filter(|dest| dest.exists()) {
+            // read the existing cache and extend it by the files that changed
+            // (if we just wrote to the cache file, we'd overwrite the existing data)
+            let reader =
+                std::io::BufReader::new(File::open(dest).map_err(|err| SolcError::io(err, dest))?);
+            let mut cache: SolFilesCache = serde_json::from_reader(reader)?;
+            cache.files.extend(files);
+            cache
         } else {
             SolFilesCache { format, files }
         };

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -273,20 +273,15 @@ impl SolFilesCacheBuilder {
             files.insert(file, entry);
         }
 
-        let cache = if let Some(ref dest) = dest {
-            if dest.exists() {
+        let cache = if let Some(ref dest) = dest.as_ref().filter(|dest|dest.exists()) {
                 // read the existing cache and extend it by the files that changed
                 // (if we just wrote to the cache file, we'd overwrite the existing data)
                 let reader = std::io::BufReader::new(
                     File::open(dest).map_err(|err| SolcError::io(err, dest))?,
                 );
                 let mut cache: SolFilesCache = serde_json::from_reader(reader)?;
-                assert_eq!(cache.format, format);
                 cache.files.extend(files);
                 cache
-            } else {
-                SolFilesCache { format, files }
-            }
         } else {
             SolFilesCache { format, files }
         };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
removes an assert! that would cause a panic if the project was previously built with hardhat.

it is not required that the format ids match and is currently used to provide a way to distinguish whether the file was previously built with hardhat.

I'm not sure what the most straight forward approach to remove possible friction between ethers-solc/foundry builds and hardhat would be

possible solutions:
* always check for matching ethers format id, treat cache as empty if it was written by hardhat
* use a different cache file than hardhat
* keep it like it is and make `MinimalCombinedArtifactsHardhatFallback` artifact output the default which supports reading hardhat style artifacts 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
