### PR TITLE
fix: contract creation on trezor

### DIFF
--- a/ethers-signers/src/trezor/app.rs
+++ b/ethers-signers/src/trezor/app.rs
@@ -294,10 +294,6 @@ mod tests {
             let tx_req = TransactionRequest::new().data(data.clone()).into();
             let tx = trezor.sign_transaction(&tx_req).await.unwrap();
         }
-        {
-            let tx_req = TransactionRequest::new().to("").data(data).into();
-            let tx = trezor.sign_transaction(&tx_req).await.unwrap();
-        }
     }
 
     #[tokio::test]

--- a/ethers-signers/src/trezor/app.rs
+++ b/ethers-signers/src/trezor/app.rs
@@ -264,13 +264,34 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_sign_empty_txes() {
+        // Contract creation (empty `to`), requires data.
+        // To test without the data field, we need to specify a `to` address.
         let trezor = TrezorEthereum::new(DerivationType::TrezorLive(0), 1).await.unwrap();
         {
-            let tx_req = Eip1559TransactionRequest::new().into();
+            let tx_req = Eip1559TransactionRequest::new()
+                .to("2ed7afa17473e17ac59908f088b4371d28585476".parse::<Address>().unwrap())
+                .into();
             let tx = trezor.sign_transaction(&tx_req).await.unwrap();
         }
         {
-            let tx_req = TransactionRequest::new().into();
+            let tx_req = TransactionRequest::new()
+                .to("2ed7afa17473e17ac59908f088b4371d28585476".parse::<Address>().unwrap())
+                .into();
+            let tx = trezor.sign_transaction(&tx_req).await.unwrap();
+        }
+
+        let data = hex::decode("095ea7b30000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488dffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap();
+
+        // Contract creation (empty `to`, with data) should show on the trezor device as:
+        //  ` "0 Wei ETH
+        //  ` new contract?"
+        let trezor = TrezorEthereum::new(DerivationType::TrezorLive(0), 1).await.unwrap();
+        {
+            let tx_req = Eip1559TransactionRequest::new().data(data.clone()).into();
+            let tx = trezor.sign_transaction(&tx_req).await.unwrap();
+        }
+        {
+            let tx_req = TransactionRequest::new().data(data).into();
             let tx = trezor.sign_transaction(&tx_req).await.unwrap();
         }
     }

--- a/ethers-signers/src/trezor/app.rs
+++ b/ethers-signers/src/trezor/app.rs
@@ -291,7 +291,11 @@ mod tests {
             let tx = trezor.sign_transaction(&tx_req).await.unwrap();
         }
         {
-            let tx_req = TransactionRequest::new().data(data).into();
+            let tx_req = TransactionRequest::new().data(data.clone()).into();
+            let tx = trezor.sign_transaction(&tx_req).await.unwrap();
+        }
+        {
+            let tx_req = TransactionRequest::new().to("").data(data).into();
             let tx = trezor.sign_transaction(&tx_req).await.unwrap();
         }
     }

--- a/ethers-signers/src/trezor/types.rs
+++ b/ethers-signers/src/trezor/types.rs
@@ -4,7 +4,7 @@
 use std::fmt;
 use thiserror::Error;
 
-use ethers_core::types::{transaction::eip2718::TypedTransaction, NameOrAddress, H160, U256};
+use ethers_core::types::{transaction::eip2718::TypedTransaction, NameOrAddress, U256};
 use trezor_client::client::AccessListItem as Trezor_AccessListItem;
 
 #[derive(Clone, Debug)]
@@ -72,9 +72,12 @@ impl TrezorTransaction {
     }
 
     pub fn load(tx: &TypedTransaction) -> Result<Self, TrezorError> {
-        let to: String = match tx.to().unwrap_or(&NameOrAddress::Address(H160::from(&[0; 20]))) {
-            NameOrAddress::Name(_) => unimplemented!(),
-            NameOrAddress::Address(value) => format!("0x{}", hex::encode(value)),
+        let to: String = match tx.to() {
+            Some(v) => match v {
+                NameOrAddress::Name(_) => unimplemented!(),
+                NameOrAddress::Address(value) => format!("0x{}", hex::encode(value)),
+            },
+            None => "".to_string(),
         };
 
         let nonce = tx.nonce().map_or(vec![], Self::to_trimmed_big_endian);

--- a/ethers-signers/src/trezor/types.rs
+++ b/ethers-signers/src/trezor/types.rs
@@ -74,9 +74,17 @@ impl TrezorTransaction {
     pub fn load(tx: &TypedTransaction) -> Result<Self, TrezorError> {
         let to: String = match tx.to() {
             Some(v) => match v {
-                NameOrAddress::Name(_) => unimplemented!(),
+                NameOrAddress::Name(value) => {
+                    // Contract Creation
+                    if value.is_empty() {
+                        "".to_string()
+                    } else {
+                        unimplemented!()
+                    }
+                }
                 NameOrAddress::Address(value) => format!("0x{}", hex::encode(value)),
             },
+            // Contract Creation
             None => "".to_string(),
         };
 

--- a/ethers-signers/src/trezor/types.rs
+++ b/ethers-signers/src/trezor/types.rs
@@ -49,7 +49,7 @@ pub enum TrezorError {
     /// Error when signing EIP712 struct with not compatible Trezor ETH app
     #[error("Trezor ethereum app requires at least version: {0:?}")]
     UnsupportedFirmwareVersion(String),
-    #[error("Does not suport ENS.")]
+    #[error("Does not support ENS.")]
     NoENSSupport,
 }
 

--- a/ethers-signers/src/trezor/types.rs
+++ b/ethers-signers/src/trezor/types.rs
@@ -49,6 +49,8 @@ pub enum TrezorError {
     /// Error when signing EIP712 struct with not compatible Trezor ETH app
     #[error("Trezor ethereum app requires at least version: {0:?}")]
     UnsupportedFirmwareVersion(String),
+    #[error("Does not suport ENS.")]
+    NoENSSupport,
 }
 
 /// Trezor Transaction Struct
@@ -74,14 +76,7 @@ impl TrezorTransaction {
     pub fn load(tx: &TypedTransaction) -> Result<Self, TrezorError> {
         let to: String = match tx.to() {
             Some(v) => match v {
-                NameOrAddress::Name(value) => {
-                    // Contract Creation
-                    if value.is_empty() {
-                        "".to_string()
-                    } else {
-                        unimplemented!()
-                    }
-                }
+                NameOrAddress::Name(_) => return Err(TrezorError::NoENSSupport),
                 NameOrAddress::Address(value) => format!("0x{}", hex::encode(value)),
             },
             // Contract Creation


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
To create a contract, it's required to pass the `to` address  as an empty string.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* remove defaulting to the 0x0 address, if no address is passed
* handle `to` as an empty string

It should show on the device:
```
0 Wei ETH
new contract?"
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
