### PR TITLE
add deploy_tokens to ContractFactory

### DIFF
--- a/ethers-contract/src/factory.rs
+++ b/ethers-contract/src/factory.rs
@@ -1,7 +1,7 @@
 use crate::{Contract, ContractError};
 
 use ethers_core::{
-    abi::{Abi, Tokenize},
+    abi::{Abi, Token, Tokenize},
     types::{transaction::eip2718::TypedTransaction, BlockNumber, Bytes, TransactionRequest},
 };
 use ethers_providers::Middleware;
@@ -148,17 +148,8 @@ impl<M: Middleware> ContractFactory<M> {
         Self { client, abi, bytecode }
     }
 
-    /// Constructs the deployment transaction based on the provided constructor
-    /// arguments and returns a `Deployer` instance. You must call `send()` in order
-    /// to actually deploy the contract.
-    ///
-    /// Notes:
-    /// 1. If there are no constructor arguments, you should pass `()` as the argument.
-    /// 1. The default poll duration is 7 seconds.
-    /// 1. The default number of confirmations is 1 block.
-    pub fn deploy<T: Tokenize>(self, constructor_args: T) -> Result<Deployer<M>, ContractError<M>> {
+    pub fn deploy_tokens(self, params: Vec<Token>) -> Result<Deployer<M>, ContractError<M>> {
         // Encode the constructor args & concatenate with the bytecode if necessary
-        let params = constructor_args.into_tokens();
         let data: Bytes = match (self.abi.constructor(), params.is_empty()) {
             (None, false) => return Err(ContractError::ConstructorError),
             (None, true) => self.bytecode.clone(),
@@ -183,5 +174,17 @@ impl<M: Middleware> ContractFactory<M> {
             confs: 1,
             block: BlockNumber::Latest,
         })
+    }
+
+    /// Constructs the deployment transaction based on the provided constructor
+    /// arguments and returns a `Deployer` instance. You must call `send()` in order
+    /// to actually deploy the contract.
+    ///
+    /// Notes:
+    /// 1. If there are no constructor arguments, you should pass `()` as the argument.
+    /// 1. The default poll duration is 7 seconds.
+    /// 1. The default number of confirmations is 1 block.
+    pub fn deploy<T: Tokenize>(self, constructor_args: T) -> Result<Deployer<M>, ContractError<M>> {
+        self.deploy_tokens(constructor_args.into_tokens())
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
It's more of a proposal, which i believe would ease things up when deploying from a ContractFactory.

Right now, `deploy()` seems to assume that the `constructor_args` passed are of the exact type that the constructor expects. So if one passes `deploy((1, "string".to_string()))`   to a constructor that accepts `constructor(uint256 a, string memory b)`, it will fail because it will tokenize `1` as `Int` instead of `Uint`. 

This way, we maintain the method, but add a new one which receives an already ready `Vec<Token>`. Other libs have more freedom on doing their own parsing, and makes things easier if one requires to parse arguments from string. (eg. https://github.com/gakonst/foundry/blob/master/utils/src/lib.rs#L119-L125)

Another option would be  to bring over the code from the above link, taking `Vec<String` as `constructor_args`, and parsing it internally.

 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Adds `pub fn deploy_tokens(params: Vec<Token>)` 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
