### PR TITLE
fix: parse_units was generating an error on some values 

### DIFF
--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -138,11 +138,11 @@ where
 pub fn parse_units<K, S>(amount: S, units: K) -> Result<U256, ConversionError>
 where
     S: ToString,
-    K: TryInto<Units, Error = ConversionError>,
+    K: TryInto<Units, Error = ConversionError> + Copy,
 {
     let float_n: f64 =
         amount.to_string().parse::<f64>()? * 10u64.pow(units.try_into()?.as_num()) as f64;
-    let u256_n: U256 = U256::from_dec_str(&float_n.to_string())?;
+    let u256_n: U256 = U256::from_dec_str(&float_n.round().to_string())?;
     Ok(u256_n)
 }
 /// The address for an Ethereum contract is deterministically computed from the
@@ -429,6 +429,9 @@ mod tests {
     fn test_parse_units() {
         let gwei = parse_units(1.5, 9).unwrap();
         assert_eq!(gwei.as_u64(), 15e8 as u64);
+
+        let token = parse_units(1163.56926418, 8).unwrap();
+        assert_eq!(token.as_u64(), 116356926418);
 
         let eth_dec_float = parse_units(1.39563324, "ether").unwrap();
         assert_eq!(eth_dec_float, U256::from_dec_str("1395633240000000000").unwrap());


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

parse_units was generating an error on some values because of extra decimal places when multiplying by 10^decimals 

## Solution

added round before converting to U256 to prevent error


## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
