### PR TITLE
fix: configure rustls & openssl via feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,5 +269,6 @@ jobs:
         run: |
           rustc -Vv
           cargo -V
-          cargo check --all-features
+          # we test without --all-features on Windows so that sha2-asm is not activated.
+          cargo check
         shell: cmd

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,9 +1788,9 @@ checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
  "hyper",
- "rustls 0.20.2",
+ "rustls",
  "tokio",
- "tokio-rustls 0.23.1",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -2719,19 +2719,19 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.20.2",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.23.1",
+ "tokio-rustls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.21.1",
  "winreg",
 ]
 
@@ -2898,39 +2898,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64 0.13.0",
- "log",
- "ring",
- "sct 0.6.1",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "rustls"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d37e5e2290f3e040b594b1a9e04377c2c671f1a1cfd9bfdef82106ac1c113f84"
 dependencies = [
  "log",
  "ring",
- "sct 0.7.0",
+ "sct",
  "webpki 0.22.0",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
-dependencies = [
- "openssl-probe",
- "rustls 0.19.1",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -3000,16 +2975,6 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2 0.9.8",
-]
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -3540,43 +3505,31 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
-dependencies = [
- "rustls 0.19.1",
- "tokio",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4baa378e417d780beff82bf54ceb0d195193ea6a00c14e22359e7f39456b5689"
 dependencies = [
- "rustls 0.20.2",
+ "rustls",
  "tokio",
  "webpki 0.22.0",
 ]
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
+checksum = "e80b39df6afcc12cdf752398ade96a6b9e99c903dfdc36e53ad10b9c366bca72"
 dependencies = [
  "futures-util",
  "log",
  "native-tls",
- "pin-project",
- "rustls 0.19.1",
+ "rustls",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.22.0",
+ "tokio-rustls",
  "tungstenite",
- "webpki 0.21.4",
- "webpki-roots",
+ "webpki 0.22.0",
+ "webpki-roots 0.22.1",
 ]
 
 [[package]]
@@ -3698,9 +3651,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
+checksum = "6ad3713a14ae247f22a728a0456a545df14acf3867f905adff84be99e23b3ad1"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
@@ -3710,13 +3663,12 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.8.4",
- "rustls 0.19.1",
- "rustls-native-certs",
+ "rustls",
  "sha-1",
  "thiserror",
  "url",
  "utf-8",
- "webpki 0.21.4",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -3999,6 +3951,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c475786c6f47219345717a043a37ec04cb4bc185e28853adcc4fa0a947eba630"
+dependencies = [
+ "webpki 0.22.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,8 +3292,8 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svm-rs"
-version = "0.2.0"
-source = "git+https://github.com/gakonst/svm-rs?branch=fix/trim-deps#ee59db1f60ce4532e276ad41bf4d8c2d09812b60"
+version = "0.2.1"
+source = "git+https://github.com/gakonst/svm-rs?branch=fix/trim-deps#a14ebf75665fbcebdb93a526193e721e97d79d1f"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3293,7 +3293,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "svm-rs"
 version = "0.2.1"
-source = "git+https://github.com/gakonst/svm-rs?branch=fix/trim-deps#a14ebf75665fbcebdb93a526193e721e97d79d1f"
+source = "git+https://github.com/roynalnaruto/svm-rs#4dd8d3f93a6383ff660899899b4dc43c73a14f97"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3327,9 +3327,8 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svm-rs"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8733662d7e2c4bc2bdc5ca4102c7f8b13d1c3c12fb767089de07c2c3df3cd03d"
+version = "0.2.0"
+source = "git+https://github.com/gakonst/svm-rs?branch=fix/trim-deps#ee59db1f60ce4532e276ad41bf4d8c2d09812b60"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ eip712 = ["ethers-contract/eip712", "ethers-core/eip712"]
 ## providers
 ws = ["ethers-providers/ws"]
 ipc = ["ethers-providers/ipc"]
-rustls = ["ethers-providers/rustls"]
-openssl = ["ethers-providers/openssl"]
+rustls = ["ethers-providers/rustls", "ethers-etherscan/rustls", "ethers-contract/rustls", "ethers-solc/rustls"]
+openssl = ["ethers-providers/openssl", "ethers-etherscan/openssl", "ethers-contract/openssl", "ethers-solc/openssl"]
 dev-rpc = ["ethers-providers/dev-rpc"]
 ## signers
 ledger = ["ethers-signers/ledger"]
@@ -95,8 +95,6 @@ ethers-providers = { version = "^0.6.0", default-features = false, path = "./eth
 
 [target.'cfg(target_family = "unix")'.dev-dependencies]
 ethers-providers = { version = "^0.6.0", default-features = false, path = "./ethers-providers", features = ["ws", "ipc"] }
-
-
 anyhow = "1.0.39"
 rand = "0.8.4"
 serde = { version = "1.0.124", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,7 @@ abigen-offline = ["ethers-contract/abigen-offline"]
 solc-async = ["ethers-solc/async"]
 solc-full = ["ethers-solc/full"]
 solc-tests = ["ethers-solc/tests"]
-
-
+solc-sha2-asm = ["ethers-solc/asm"]
 
 [dependencies]
 ethers-contract = { version = "^0.6.0", default-features = false, path = "./ethers-contract" }

--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -38,11 +38,15 @@ ethers-solc = { version = "^0.1.0", path = "../ethers-solc", default-features = 
 tokio = { version = "1.5", default-features = false, features = ["macros"] }
 
 [features]
+default = ["rustls"]
 eip712 = ["ethers-derive-eip712", "ethers-core/eip712"]
 abigen = ["ethers-contract-abigen/reqwest", "ethers-contract-derive"]
 abigen-offline = ["ethers-contract-abigen", "ethers-contract-derive"]
 celo = ["legacy", "ethers-core/celo", "ethers-core/celo", "ethers-providers/celo"]
 legacy = []
+
+rustls = ["ethers-contract-abigen/rustls"]
+openssl = ["ethers-contract-abigen/openssl"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -21,7 +21,7 @@ url = "2.1"
 serde_json = "1.0.61"
 serde = { version = "1.0.124", features = ["derive"] }
 hex = { version = "0.4.2", default-features = false, features = ["std"] }
-reqwest = { version = "0.11.3", features = ["blocking"] , optional = true }
+reqwest = { version = "0.11.3", default-features = false, features = ["blocking"] , optional = true }
 once_cell = "1.8.0"
 cfg-if = "1.0.0"
 
@@ -29,9 +29,11 @@ cfg-if = "1.0.0"
 # NOTE: this enables wasm compatibility for getrandom indirectly
 getrandom = { version = "0.2", features = ["js"] }
 
-[features]
-default = ["reqwest"]
-
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = ["reqwest", "rustls"]
+openssl = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls-tls"]

--- a/ethers-etherscan/Cargo.toml
+++ b/ethers-etherscan/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["ethereum", "web3", "etherscan", "ethers"]
 
 [dependencies]
 ethers-core = { version = "^0.6.0", path = "../ethers-core", default-features = false }
-reqwest = { version = "0.11.7", features = ["json"] }
+reqwest = { version = "0.11.7", default-features = false, features = ["json"] }
 serde = { version = "1.0.124", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.64", default-features = false }
 serde-aux = { version = "3.0.1", default-features = false }
@@ -28,3 +28,8 @@ serial_test = "0.5.1"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+default = ["rustls"]
+openssl = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls-tls"]

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -42,7 +42,7 @@ bytes = { version  = "1.1.0", default-features = false, optional = true }
 # tokio
 tokio-util = { version = "0.6.9", default-features = false, features = ["io"], optional = true }
 tokio = { version = "1.5", default-features = false, optional = true }
-tokio-tungstenite = { version = "0.15.0", default-features = false, features = ["connect"], optional = true }
+tokio-tungstenite = { version = "0.16.1", default-features = false, features = ["connect"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 ws_stream_wasm = "0.7"
@@ -64,5 +64,7 @@ ws = ["tokio", "tokio-tungstenite"]
 ipc = ["tokio", "tokio/io-util", "tokio-util", "bytes"]
 
 openssl = ["tokio-tungstenite/native-tls", "reqwest/native-tls"]
-rustls = ["tokio-tungstenite/rustls-tls", "reqwest/rustls-tls"]
+# we use the webpki roots so we can build static binaries w/o any root cert dependencies
+# on the host
+rustls = ["tokio-tungstenite/rustls-tls-webpki-roots", "reqwest/rustls-tls"]
 dev-rpc = []

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -39,7 +39,7 @@ sha2 = { version = "0.9.8", default-features = false }
 home = "0.5.3"
 # SVM is not WASM compatible yet.
 # svm = { package = "svm-rs", default-features = false, version = "0.2.1", optional = true }
-svm = { package = "svm-rs", git = "https://github.com/gakonst/svm-rs", branch = "fix/trim-deps", default-features = false, optional = true }
+svm = { package = "svm-rs", git = "https://github.com/roynalnaruto/svm-rs", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # NOTE: this enables wasm compatibility for getrandom indirectly

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -27,7 +27,8 @@ md-5 = "0.10.0"
 thiserror = "1.0.30"
 hex = "0.4.3"
 colored = "2.0.0"
-svm = { package = "svm-rs", version = "0.2.1", optional = true }
+# svm = { package = "svm-rs", default-features = false, version = "0.2.1", optional = true }
+svm = { package = "svm-rs", git = "https://github.com/gakonst/svm-rs", branch = "fix/trim-deps", default-features = false, optional = true }
 glob = "0.3.0"
 tracing = "0.1.29"
 num_cpus = "1.13.0"
@@ -63,8 +64,11 @@ path = "tests/project.rs"
 required-features = ["project-util"]
 
 [features]
+default = ["rustls"]
 async = ["tokio", "futures-util"]
 full = ["async", "svm"]
 # Utilities for creating and testing project workspaces
 project-util = ["tempdir", "fs_extra"]
 tests = []
+openssl = ["svm/openssl"]
+rustls = ["svm/rustls"]

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -27,8 +27,6 @@ md-5 = "0.10.0"
 thiserror = "1.0.30"
 hex = "0.4.3"
 colored = "2.0.0"
-# svm = { package = "svm-rs", default-features = false, version = "0.2.1", optional = true }
-svm = { package = "svm-rs", git = "https://github.com/gakonst/svm-rs", branch = "fix/trim-deps", default-features = false, optional = true }
 glob = "0.3.0"
 tracing = "0.1.29"
 num_cpus = "1.13.0"
@@ -39,6 +37,9 @@ sha2 = { version = "0.9.8", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 home = "0.5.3"
+# SVM is not WASM compatible yet.
+# svm = { package = "svm-rs", default-features = false, version = "0.2.1", optional = true }
+svm = { package = "svm-rs", git = "https://github.com/gakonst/svm-rs", branch = "fix/trim-deps", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # NOTE: this enables wasm compatibility for getrandom indirectly

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -35,12 +35,7 @@ num_cpus = "1.13.0"
 tiny-keccak = { version = "2.0.2", default-features = false }
 tempdir = { version = "0.3.7", optional = true }
 fs_extra = { version = "1.2.0", optional = true }
-
-[target.'cfg(any(not(any(target_arch = "x86", target_arch = "x86_64")), target_env = "msvc"))'.dependencies]
 sha2 = { version = "0.9.8", default-features = false }
-
-[target.'cfg(all(any(target_arch = "x86", target_arch = "x86_64"), not(target_env = "msvc")))'.dependencies]
-sha2 = { version = "0.9.8", default-features = false, features = ["asm"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 home = "0.5.3"
@@ -64,7 +59,7 @@ path = "tests/project.rs"
 required-features = ["project-util"]
 
 [features]
-default = ["rustls"]
+default = ["rustls", "asm"]
 async = ["tokio", "futures-util"]
 full = ["async", "svm"]
 # Utilities for creating and testing project workspaces
@@ -72,3 +67,4 @@ project-util = ["tempdir", "fs_extra"]
 tests = []
 openssl = ["svm/openssl"]
 rustls = ["svm/rustls"]
+asm = ["sha2/asm"]

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -59,7 +59,7 @@ path = "tests/project.rs"
 required-features = ["project-util"]
 
 [features]
-default = ["rustls", "asm"]
+default = ["rustls"]
 async = ["tokio", "futures-util"]
 full = ["async", "svm"]
 # Utilities for creating and testing project workspaces


### PR DESCRIPTION
Some downstream foundry users (https://github.com/gakonst/foundry/issues/229) are experiencing issues installing on different platforms. I suspect it MIGHT be related to the openssl dependency which was being pulled in by `reqwest`. 

We can maybe resolve it by feature gating reqwest's SSL provider everywhere, and importing ethers with the `reqwest/rustls` backend.

Depends on https://github.com/roynalnaruto/svm-rs/pull/11

Also, once https://github.com/seanmonstar/reqwest/pull/1396 is released we should bump reqwest to de-duplicate our certs deps

---

So this seems to address the issues around
1. openssl being pulled in
2. sha2 being pulled in

Open problems:
* <s>For some reason it triggered WASM to start failing, which is odd given the svm-rs PR above does not change much? Maybe it's the checking-in of the cargo lockfile, in which case it..was already broken?</s> Fixed in https://github.com/gakonst/ethers-rs/pull/703/commits/952ac61cd4e15181e4c4966b19b92b46289d4398
* The feature gate-ing of sha2 means that we can no longer run our windows pipelines with `--all-features`. Is that OK? Might be? Maybe there's a mix between the platform-based configuration that gets us what we need? @mattsse bumped on https://github.com/rust-lang/cargo/issues/8302 and https://github.com/rust-lang/cargo/issues/7753 while trying to resolve this, to no success



