### PR TITLE
feat(abigen): add EthAbiCodec proc macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 
 ### 0.6.0
 
+- add `EthAbiCodec` proc macro to derive `AbiEncode` `AbiDecode` implementation
+  [#704](https://github.com/gakonst/ethers-rs/pull/704)
 - move `AbiEncode` `AbiDecode` trait to ethers-core and implement for core types
   [#531](https://github.com/gakonst/ethers-rs/pull/531)
 - Add EIP-712 `sign_typed_data` signer method; add ethers-core type `Eip712`

--- a/ethers-contract/ethers-contract-abigen/src/contract/structs.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/structs.rs
@@ -129,7 +129,7 @@ impl Context {
         let ethers_contract = ethers_contract_crate();
         Ok(quote! {
             #abi_signature_doc
-            #[derive(Clone, Debug, Default, Eq, PartialEq, #ethers_contract::EthAbiType, #derives)]
+            #[derive(Clone, Debug, Default, Eq, PartialEq, #ethers_contract::EthAbiType, #ethers_contract::EthAbiCodec, #derives)]
             pub struct #name {
                 #( #fields ),*
             }
@@ -191,7 +191,7 @@ impl Context {
 
         Ok(quote! {
             #abi_signature_doc
-            #[derive(Clone, Debug, Default, Eq, PartialEq, #ethers_contract::EthAbiType, #derives)]
+            #[derive(Clone, Debug, Default, Eq, PartialEq, #ethers_contract::EthAbiType, #ethers_contract::EthAbiCodec, #derives)]
             pub struct #name {
                 #( #fields ),*
             }

--- a/ethers-contract/ethers-contract-derive/src/codec.rs
+++ b/ethers-contract/ethers-contract-derive/src/codec.rs
@@ -1,10 +1,9 @@
 //! Helper functions for deriving `EthAbiType`
 
-
 use ethers_core::macros::ethers_core_crate;
 
-use quote::{quote};
-use syn::{DeriveInput};
+use quote::quote;
+use syn::DeriveInput;
 
 /// Generates the `AbiEncode` + `AbiDecode` implementation
 pub fn derive_codec_impl(input: &DeriveInput) -> proc_macro2::TokenStream {

--- a/ethers-contract/ethers-contract-derive/src/codec.rs
+++ b/ethers-contract/ethers-contract-derive/src/codec.rs
@@ -1,0 +1,34 @@
+//! Helper functions for deriving `EthAbiType`
+
+
+use ethers_core::macros::ethers_core_crate;
+
+use quote::{quote};
+use syn::{DeriveInput};
+
+/// Generates the `AbiEncode` + `AbiDecode` implementation
+pub fn derive_codec_impl(input: &DeriveInput) -> proc_macro2::TokenStream {
+    let name = &input.ident;
+    let core_crate = ethers_core_crate();
+
+    quote! {
+        impl  #core_crate::abi::AbiDecode for #name {
+            fn decode(bytes: impl AsRef<[u8]>) -> Result<Self, #core_crate::abi::AbiError> {
+                if let #core_crate::abi::ParamType::Tuple(params) = <Self as #core_crate::abi::AbiType>::param_type() {
+                  let tokens = #core_crate::abi::decode(&params, bytes.as_ref())?;
+                  Ok(<Self as #core_crate::abi::Tokenizable>::from_token(#core_crate::abi::Token::Tuple(tokens))?)
+                } else {
+                    Err(
+                        #core_crate::abi::InvalidOutputType("Expected tuple".to_string()).into()
+                    )
+                }
+            }
+        }
+        impl #core_crate::abi::AbiEncode for #name {
+            fn encode(self) -> ::std::vec::Vec<u8> {
+                let tokens =  #core_crate::abi::Tokenize::into_tokens(self);
+                #core_crate::abi::encode(&tokens)
+            }
+        }
+    }
+}

--- a/ethers-contract/ethers-contract-derive/src/lib.rs
+++ b/ethers-contract/ethers-contract-derive/src/lib.rs
@@ -11,6 +11,7 @@ pub(crate) mod abi_ty;
 mod abigen;
 mod call;
 mod display;
+mod codec;
 mod event;
 mod spanned;
 pub(crate) mod utils;
@@ -43,7 +44,7 @@ pub(crate) mod utils;
 /// `ETHERSCAN_API_KEY` environment variable can be set. If it is, it will use
 /// that API key when retrieving the contract ABI.
 ///
-/// Currently the proc macro accepts additional parameters to configure some
+/// Currently, the proc macro accepts additional parameters to configure some
 /// aspects of the code generation. Specifically it accepts:
 /// - `methods`: A list of mappings from method signatures to method names allowing methods names to
 ///   be explicitely set for contract methods. This also provides a workaround for generating code
@@ -94,7 +95,7 @@ pub fn abigen(input: TokenStream) -> TokenStream {
     contracts.expand().unwrap_or_else(|err| err.to_compile_error()).into()
 }
 
-/// Derives the `Tokenizable` trait for the labeled type.
+/// Derives the `AbiType` and all `Tokenizable` traits for the labeled type.
 ///
 /// This derive macro automatically adds a type bound `field: Tokenizable` for
 /// each field type.
@@ -102,6 +103,34 @@ pub fn abigen(input: TokenStream) -> TokenStream {
 pub fn derive_abi_type(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     TokenStream::from(abi_ty::derive_tokenizeable_impl(&input))
+}
+
+/// Derives the `AbiEncode`, `AbiDecode` and traits for the labeled type.
+///
+/// This is an addition to `EthAbiType` that lacks the `AbiEncode`, `AbiDecode` implementation.
+///
+/// The reason why this is a separate macro is the `AbiEncode` / `AbiDecode` are `ethers` generalized codec traits used for types, calls, etc. However, encoding/decoding a call differs from the basic encoding/decoding, (`[selector + encode(self)]`)
+///
+/// # Example
+///
+/// ```ignore
+/// use ethers_contract::{EthAbiCodec, EthAbiType};
+/// use ethers_core::types::*;
+///
+/// #[derive(Debug, Clone, EthAbiType, EthAbiCodec)]
+/// struct MyStruct {
+///     addr: Address,
+///     old_value: String,
+///     new_value: String,
+/// }
+/// let val = MyStruct {..};
+/// let bytes = val.encode();
+/// let val = MyStruct::decode(&bytes).unwrap();
+/// ```
+#[proc_macro_derive(EthAbiCodec)]
+pub fn derive_abi_codec(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(codec::derive_codec_impl(&input))
 }
 
 /// Derives `fmt::Display` trait and generates a convenient format for all the
@@ -113,7 +142,7 @@ pub fn derive_abi_type(input: TokenStream) -> TokenStream {
 /// # Example
 ///
 /// ```ignore
-/// use ethers_contract::EthDisplay;
+/// use ethers_contract::{EthDisplay, EthAbiType};
 /// use ethers_core::types::*;
 ///
 /// #[derive(Debug, Clone, EthAbiType, EthDisplay)]

--- a/ethers-contract/ethers-contract-derive/src/lib.rs
+++ b/ethers-contract/ethers-contract-derive/src/lib.rs
@@ -10,8 +10,8 @@ use abigen::Contracts;
 pub(crate) mod abi_ty;
 mod abigen;
 mod call;
-mod display;
 mod codec;
+mod display;
 mod event;
 mod spanned;
 pub(crate) mod utils;
@@ -109,7 +109,9 @@ pub fn derive_abi_type(input: TokenStream) -> TokenStream {
 ///
 /// This is an addition to `EthAbiType` that lacks the `AbiEncode`, `AbiDecode` implementation.
 ///
-/// The reason why this is a separate macro is the `AbiEncode` / `AbiDecode` are `ethers` generalized codec traits used for types, calls, etc. However, encoding/decoding a call differs from the basic encoding/decoding, (`[selector + encode(self)]`)
+/// The reason why this is a separate macro is the `AbiEncode` / `AbiDecode` are `ethers`
+/// generalized codec traits used for types, calls, etc. However, encoding/decoding a call differs
+/// from the basic encoding/decoding, (`[selector + encode(self)]`)
 ///
 /// # Example
 ///

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -35,7 +35,7 @@ pub use ethers_contract_abigen::Abigen;
 
 #[cfg(any(test, feature = "abigen"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "abigen")))]
-pub use ethers_contract_derive::{abigen, EthAbiType, EthCall, EthDisplay, EthEvent};
+pub use ethers_contract_derive::{abigen, EthAbiCodec, EthAbiType, EthCall, EthDisplay, EthEvent};
 
 // Hide the Lazy re-export, it's just for convenience
 #[doc(hidden)]

--- a/ethers-contract/tests/common/derive.rs
+++ b/ethers-contract/tests/common/derive.rs
@@ -1,6 +1,8 @@
-use ethers_contract::{abigen, EthAbiType, EthCall, EthDisplay, EthEvent, EthLogDecode};
+use ethers_contract::{
+    abigen, EthAbiCodec, EthAbiType, EthCall, EthDisplay, EthEvent, EthLogDecode,
+};
 use ethers_core::{
-    abi::{RawLog, Tokenizable},
+    abi::{AbiDecode, AbiEncode, RawLog, Tokenizable},
     types::{Address, H160, H256, I256, U128, U256},
 };
 
@@ -477,4 +479,19 @@ fn can_derive_for_enum() {
 
     let token = ActionChoices::GoLeft.into_token();
     assert_eq!(ActionChoices::GoLeft, ActionChoices::from_token(token).unwrap());
+}
+
+#[test]
+fn can_derive_abi_codec() {
+    #[derive(Debug, Clone, PartialEq, EthAbiType, EthAbiCodec)]
+    pub struct SomeType {
+        inner: Address,
+        msg: String,
+    }
+
+    let val = SomeType { inner: Default::default(), msg: "hello".to_string() };
+
+    let encoded = val.clone().encode();
+    let other = SomeType::decode(&encoded).unwrap();
+    assert_eq!(val, other);
 }

--- a/ethers-contract/tests/common/derive.rs
+++ b/ethers-contract/tests/common/derive.rs
@@ -495,3 +495,68 @@ fn can_derive_abi_codec() {
     let other = SomeType::decode(&encoded).unwrap();
     assert_eq!(val, other);
 }
+
+#[test]
+fn can_derive_abi_codec_single_field() {
+    #[derive(Debug, Clone, PartialEq, EthAbiType, EthAbiCodec)]
+    pub struct SomeType {
+        inner: Vec<U256>,
+    }
+
+    let val = SomeType { inner: Default::default() };
+
+    let encoded = val.clone().encode();
+    let decoded = SomeType::decode(&encoded).unwrap();
+    assert_eq!(val, decoded);
+
+    let encoded_tuple = (Vec::<U256>::default(),).encode();
+
+    assert_eq!(encoded_tuple, encoded);
+    let decoded_tuple = SomeType::decode(&encoded_tuple).unwrap();
+    assert_eq!(decoded_tuple, decoded);
+
+    let tuple = (val,);
+    let encoded = tuple.clone().encode();
+    let decoded = <(SomeType,)>::decode(&encoded).unwrap();
+    assert_eq!(tuple, decoded);
+
+    let wrapped =
+        ethers_core::abi::encode(&ethers_core::abi::Tokenize::into_tokens(tuple.clone())).to_vec();
+    assert_eq!(wrapped, encoded);
+    let decoded_wrapped = <(SomeType,)>::decode(&wrapped).unwrap();
+
+    assert_eq!(decoded_wrapped, tuple);
+}
+
+#[test]
+fn can_derive_abi_codec_two_field() {
+    #[derive(Debug, Clone, PartialEq, EthAbiType, EthAbiCodec)]
+    pub struct SomeType {
+        inner: Vec<U256>,
+        addr: Address,
+    }
+
+    let val = SomeType { inner: Default::default(), addr: Default::default() };
+
+    let encoded = val.clone().encode();
+    let decoded = SomeType::decode(&encoded).unwrap();
+    assert_eq!(val, decoded);
+
+    let encoded_tuple = (Vec::<U256>::default(), Address::default()).encode();
+
+    assert_eq!(encoded_tuple, encoded);
+    let decoded_tuple = SomeType::decode(&encoded_tuple).unwrap();
+    assert_eq!(decoded_tuple, decoded);
+
+    let tuple = (val,);
+    let encoded = tuple.clone().encode();
+    let decoded = <(SomeType,)>::decode(&encoded).unwrap();
+    assert_eq!(tuple, decoded);
+
+    let wrapped =
+        ethers_core::abi::encode(&ethers_core::abi::Tokenize::into_tokens(tuple.clone())).to_vec();
+    assert_eq!(wrapped, encoded);
+    let decoded_wrapped = <(SomeType,)>::decode(&wrapped).unwrap();
+
+    assert_eq!(decoded_wrapped, tuple);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Add AbiEncode + AbiDecode implementation for custom structs.
Currently, those get derived for EthCall only.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add `EthAbiCodec` as a complementary proc macro to `EthAbiType` that derives encode/decode.
The reason why this needs to be separate and not included in `EthAbiType` is because in EthCall we have an additional leading 4byte selector, so `EthCall` needs to implement the codec traits but requires all the tokenized support that `EthAbiType` provides.
So we simply add an additional `EthAbiCodec` derive when we generate AbiEncoderV2 structs within abigen!
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
