### PR TITLE
chore(solc): use svm global_version if it exists and no SOLC_PATH is set

### DIFF
--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -209,7 +209,9 @@ impl Remapping {
     //   ├─ protocol-v2/
     //   │  ├─ contracts/
     ///
-    /// which would be multiple rededications according to our rules ("governance", "protocol-v2"), are unified into `@aave` by looking at their common ancestor, the root of this subdirectory (`@aavee`)
+    /// which would be multiple rededications according to our rules ("governance", "protocol-v2"),
+    /// are unified into `@aave` by looking at their common ancestor, the root of this subdirectory
+    /// (`@aavee`)
     pub fn find_all(root: impl AsRef<Path>) -> Vec<Remapping> {
         /// prioritize ("a", "1/2") over ("a", "1/2/3")
         fn insert_higher_path(mappings: &mut HashMap<String, PathBuf>, key: String, path: PathBuf) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
consider `~/svm/.global_version` in `Solc::default`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
