### PR TITLE
fix: use lib for parsing paths correctly in windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "ecdsa"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1347,7 @@ version = "0.1.0"
 dependencies = [
  "colored",
  "criterion",
+ "dunce",
  "ethers-core",
  "fs_extra",
  "futures-util",

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -34,6 +34,7 @@ tiny-keccak = { version = "2.0.2", default-features = false }
 tempdir = { version = "0.3.7", optional = true }
 fs_extra = { version = "1.2.0", optional = true }
 sha2 = { version = "0.9.8", default-features = false }
+dunce = "1.0.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 home = "0.5.3"

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -104,7 +104,7 @@ pub enum PathStyle {
 impl PathStyle {
     pub fn paths(&self, root: impl AsRef<Path>) -> Result<ProjectPathsConfig> {
         let root = root.as_ref();
-        let root = std::fs::canonicalize(root).map_err(|err| SolcError::io(err, root))?;
+        let root = dunce::canonicalize(root).map_err(|err| SolcError::io(err, root))?;
 
         Ok(match self {
             PathStyle::Dapptools => ProjectPathsConfig::builder()
@@ -215,7 +215,7 @@ impl ProjectPathsConfigBuilder {
             .map(Ok)
             .unwrap_or_else(std::env::current_dir)
             .map_err(|err| SolcIoError::new(err, "."))?;
-        let root = std::fs::canonicalize(&root).map_err(|err| SolcIoError::new(err, &root))?;
+        let root = dunce::canonicalize(&root).map_err(|err| SolcIoError::new(err, &root))?;
         Ok(self.build_with_root(root))
     }
 }
@@ -484,8 +484,7 @@ impl<T: Into<PathBuf>> TryFrom<Vec<T>> for AllowedLibPaths {
             .into_iter()
             .map(|lib| {
                 let path: PathBuf = lib.into();
-                let lib =
-                    std::fs::canonicalize(&path).map_err(|err| SolcIoError::new(err, path))?;
+                let lib = dunce::canonicalize(&path).map_err(|err| SolcIoError::new(err, path))?;
                 Ok(lib)
             })
             .collect::<std::result::Result<Vec<_>, _>>()?;

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -908,7 +908,7 @@ mod tests {
     fn test_build_many_libs() {
         use super::*;
 
-        let root = std::fs::canonicalize("./test-data/test-contract-libs").unwrap();
+        let root = dunce::canonicalize("./test-data/test-contract-libs").unwrap();
 
         let paths = ProjectPathsConfig::builder()
             .root(&root)
@@ -935,7 +935,7 @@ mod tests {
     fn test_build_remappings() {
         use super::*;
 
-        let root = std::fs::canonicalize("./test-data/test-contract-remappings").unwrap();
+        let root = dunce::canonicalize("./test-data/test-contract-remappings").unwrap();
         let paths = ProjectPathsConfig::builder()
             .root(&root)
             .sources(root.join("src"))


### PR DESCRIPTION
First observed in this https://github.com/gakonst/foundry/pull/265 PR, related to https://github.com/rust-lang/rust/issues/42869. In the issue's discussion, it was recommended to use https://gitlab.com/kornelski/dunce