### PR TITLE
chore: remove libudev-dev dependency  [WIP]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,6 @@ jobs:
             export PATH=$HOME/bin:$PATH
             geth version
 
-      - name: Install libusb (for Ledger)
-        run: sudo apt update && sudo apt install pkg-config libudev-dev
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -121,8 +119,6 @@ jobs:
           profile: minimal
           components: rustfmt, clippy
           override: true
-      - name: Install Dependencies
-        run: sudo apt-get install libudev-dev
       - uses: Swatinem/rust-cache@v1
         with:
           cache-on-failure: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,21 +13,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,15 +41,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "anomaly"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550632e31568ae1a5f47998c3aa48563030fc49b9ec91913ca337cf64fbc5ccb"
-dependencies = [
- "backtrace",
 ]
 
 [[package]]
@@ -150,21 +126,6 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
-name = "backtrace"
-version = "0.3.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base58"
@@ -452,7 +413,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
  "winapi",
 ]
 
@@ -497,7 +457,7 @@ dependencies = [
  "coins-core",
  "digest 0.9.0",
  "hmac",
- "k256",
+ "k256 0.9.6",
  "lazy_static",
  "serde",
  "sha2 0.9.8",
@@ -515,7 +475,7 @@ dependencies = [
  "getrandom 0.2.3",
  "hex",
  "hmac",
- "pbkdf2",
+ "pbkdf2 0.8.0",
  "rand 0.8.4",
  "sha2 0.9.8",
  "thiserror",
@@ -976,6 +936,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ae02c7618ee05108cd86a0be2f5586d1f0d965bede7ecfd46815f1b860227"
+dependencies = [
+ "der 0.5.1",
+ "elliptic-curve 0.11.5",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "ed25519"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,10 +983,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
 dependencies = [
  "crypto-bigint 0.2.11",
- "ff",
+ "ff 0.10.1",
  "generic-array 0.14.4",
- "group",
- "pkcs8",
+ "group 0.10.0",
+ "pkcs8 0.7.6",
  "rand_core 0.6.3",
  "subtle",
  "zeroize",
@@ -1028,8 +1000,11 @@ checksum = "1f01ff20862362c34074072c8be2de97399633d6b1d2114afa56bf77a8b7f0a4"
 dependencies = [
  "crypto-bigint 0.3.2",
  "der 0.5.1",
+ "ff 0.11.0",
  "generic-array 0.14.4",
+ "group 0.11.0",
  "rand_core 0.6.3",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -1060,7 +1035,7 @@ dependencies = [
  "digest 0.9.0",
  "hex",
  "hmac",
- "pbkdf2",
+ "pbkdf2 0.8.0",
  "rand 0.8.4",
  "scrypt",
  "serde",
@@ -1197,14 +1172,14 @@ dependencies = [
  "bytes",
  "cargo_metadata",
  "convert_case",
- "ecdsa",
+ "ecdsa 0.12.4",
  "elliptic-curve 0.11.5",
  "ethabi",
  "futures-util",
  "generic-array 0.14.4",
  "hex",
  "hex-literal",
- "k256",
+ "k256 0.9.6",
  "once_cell",
  "proc-macro2",
  "quote",
@@ -1331,7 +1306,7 @@ dependencies = [
  "semver",
  "serde_json",
  "sha2 0.9.8",
- "spki",
+ "spki 0.4.1",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1401,6 +1376,16 @@ name = "ff"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+dependencies = [
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -1611,12 +1596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
-
-[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,7 +1607,18 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
 dependencies = [
- "ff",
+ "ff 0.10.1",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+dependencies = [
+ "ff 0.11.0",
  "rand_core 0.6.3",
  "subtle",
 ]
@@ -1657,12 +1647,6 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
-name = "harp"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bf12c625ed5e96f81609ae4377c34e9fa3e4d1fada392404322daeace511ab"
 
 [[package]]
 name = "hashbrown"
@@ -1709,6 +1693,18 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "hidapi-rusb"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99e0b15c35f9c35cbadd0c388197364e8ff3feffd23b69cd45524a014932f5f1"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "rusb",
 ]
 
 [[package]]
@@ -1940,8 +1936,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
 dependencies = [
  "cfg-if 1.0.0",
- "ecdsa",
+ "ecdsa 0.12.4",
  "elliptic-curve 0.10.6",
+ "sha2 0.9.8",
+ "sha3",
+]
+
+[[package]]
+name = "k256"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58e786b08b1c90389266b21e238894b88c03296b44db6c6a797484c6fb3e6e5a"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa 0.13.3",
+ "elliptic-curve 0.11.5",
+ "sec1",
  "sha2 0.9.8",
  "sha3",
 ]
@@ -1966,9 +1976,9 @@ checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libusb1-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22e89d08bbe6816c6c5d446203b859eba35b8fa94bf1b7edb2f6d25d43f023f"
+checksum = "b8772b7e8d4d988e19684aec5a3f5e470ecaf5c705cf0303da3973508e873027"
 dependencies = [
  "cc",
  "libc",
@@ -2046,16 +2056,6 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
 
 [[package]]
 name = "mio"
@@ -2155,15 +2155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "object"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,23 +2213,25 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
+checksum = "d0e0c5310031b5d4528ac6534bccc1446c289ac45c47b277d5aa91089c5f74fa"
 dependencies = [
- "ecdsa",
- "elliptic-curve 0.10.6",
+ "ecdsa 0.13.3",
+ "elliptic-curve 0.11.5",
+ "sec1",
  "sha2 0.9.8",
 ]
 
 [[package]]
 name = "p384"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23bc88c404ccc881c8a1ad62ba5cd7d336a64ecbf46de4874f2ad955f67b157"
+checksum = "755d8266e41f57bd8562ed9b6e93cdcf73ead050e1e8c3a27ea3871b6643a20c"
 dependencies = [
- "ecdsa",
- "elliptic-curve 0.10.6",
+ "ecdsa 0.13.3",
+ "elliptic-curve 0.11.5",
+ "sec1",
 ]
 
 [[package]]
@@ -2317,6 +2310,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05894bce6a1ba4be299d0c5f29563e08af2bc18bb7d48313113bed71e904739"
+dependencies = [
+ "crypto-mac 0.11.1",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2371,7 +2373,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
 dependencies = [
  "der 0.4.5",
- "spki",
+ "spki 0.4.1",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+dependencies = [
+ "der 0.5.1",
+ "spki 0.5.3",
+ "zeroize",
 ]
 
 [[package]]
@@ -2744,6 +2757,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+dependencies = [
+ "crypto-bigint 0.3.2",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2792,9 +2816,9 @@ dependencies = [
 
 [[package]]
 name = "rusb"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a5084628cc5be77b1c750b3e5ee0cc519d2f2491b3f06b78b3aac3328b00ad"
+checksum = "83b454219aa5007af92a042ec13b2035325318a21d3c6be18bf592f841430794"
 dependencies = [
  "libc",
  "libusb1-sys",
@@ -2882,12 +2906,6 @@ dependencies = [
  "sha2 0.9.8",
  "tokio",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hex"
@@ -2980,7 +2998,7 @@ dependencies = [
  "base64ct",
  "hmac",
  "password-hash",
- "pbkdf2",
+ "pbkdf2 0.8.0",
  "salsa20",
  "sha2 0.9.8",
 ]
@@ -2993,6 +3011,19 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+dependencies = [
+ "der 0.5.1",
+ "generic-array 0.14.4",
+ "pkcs8 0.8.0",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3263,6 +3294,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964d3a6f8b7ef6d6d20887f4c30c4848f4ffa05f600c87277d30a5b4fe32cb4b"
+dependencies = [
+ "base64ct",
+ "der 0.5.1",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,12 +3469,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
  "libc",
- "winapi",
+ "serde",
 ]
 
 [[package]]
@@ -3638,13 +3679,13 @@ dependencies = [
 
 [[package]]
 name = "trezor-client"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff94fab279e0d429d762c289f9727f37a0f1b8207ea4795f09c11caad009046f"
+checksum = "7f18d3fc60e99a85219fcd5a95311e20fb05805aab70719992b09853d47cae09"
 dependencies = [
  "byteorder",
  "hex",
- "hidapi",
+ "hidapi-rusb",
  "log",
  "primitive-types",
  "protobuf",
@@ -4054,28 +4095,25 @@ checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "yubihsm"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c32cd8146a6966df8137f5dbb77010ae5253e6937b21d1fd6ed55213478b4d0"
+checksum = "6c7ba281142fd52beba6ed6e67752bdb93242dd7520908a1d93054bfb4dcc02d"
 dependencies = [
  "aes",
- "anomaly",
  "bitflags",
  "block-modes",
  "ccm",
- "chrono",
  "cmac",
  "digest 0.9.0",
- "ecdsa",
+ "ecdsa 0.13.3",
  "ed25519",
  "ed25519-dalek",
- "harp",
  "hmac",
- "k256",
+ "k256 0.10.0",
  "log",
  "p256",
  "p384",
- "pbkdf2",
+ "pbkdf2 0.9.0",
  "rand_core 0.6.3",
  "rusb",
  "serde",
@@ -4084,6 +4122,7 @@ dependencies = [
  "signature",
  "subtle",
  "thiserror",
+ "time",
  "uuid",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,16 +504,15 @@ dependencies = [
 
 [[package]]
 name = "coins-ledger"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2943c8f53555b1f2ab5c047520b9fd73e5b0b22d216375b5b0112a7d2ae2a1c"
+version = "0.4.3-alpha.0"
+source = "git+https://github.com/joshieDo/bitcoins-rs?branch=hidapi-rusb#d154b7ab5d258e887b87f6a7c73cb97651c473b7"
 dependencies = [
  "async-trait",
  "blake2b_simd",
  "byteorder",
  "cfg-if 0.1.10",
  "futures",
- "hidapi",
+ "hidapi-rusb",
  "js-sys",
  "lazy_static",
  "libc",
@@ -1683,17 +1682,6 @@ name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
-
-[[package]]
-name = "hidapi"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6f5e247bc66f3255d755e96d9d43f6b191f4e182072b811d55584ff58c510f"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
 
 [[package]]
 name = "hidapi-rusb"

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = { version = "0.1.50", default-features = false }
 elliptic-curve = { version = "0.11.5", default-features = false }
 sha2 = { version = "0.9.8", default-features = false }
 rand = { version = "0.8.4", default-features = false }
-yubihsm = { version = "0.39.0", features = ["secp256k1", "http", "usb"], optional = true }
+yubihsm = { version = "0.40.0", features = ["secp256k1", "http", "usb"], optional = true }
 futures-util = "^0.3"
 futures-executor = "^0.3"
 semver = "1.0.4"
@@ -45,10 +45,10 @@ ethers-contract = { version = "^0.6.0", path = "../ethers-contract", features = 
 ethers-derive-eip712 = { version = "0.2.0", path = "../ethers-core/ethers-derive-eip712" }
 serde_json = { version = "1.0.64" }
 tracing-subscriber = "0.3.3"
-yubihsm = { version = "0.39.0", features = ["secp256k1", "usb", "mockhsm"] }
+yubihsm = { version = "0.40.0", features = ["secp256k1", "usb", "mockhsm"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-yubihsm = { version = "0.39.0", features = ["secp256k1", "usb", "mockhsm"] }
+yubihsm = { version = "0.40.0", features = ["secp256k1", "usb", "mockhsm"] }
 tokio = { version = "1.5", default-features = false, features = ["macros", "rt"] }
 tempfile = "3.2.0"
 

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -28,7 +28,7 @@ yubihsm = { version = "0.39.0", features = ["secp256k1", "http", "usb"], optiona
 futures-util = "^0.3"
 futures-executor = "^0.3"
 semver = "1.0.4"
-trezor-client = { version = "0.0.3", optional = true, default-features = false, features = ["f_ethereum"] }
+trezor-client = { version = "0.0.4", optional = true, default-features = false, features = ["f_ethereum"] }
 
 # aws
 rusoto_core = { version = "0.47.0", optional = true }

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -18,7 +18,8 @@ ethers-core = { version = "^0.6.0", path = "../ethers-core", features = ["eip712
 thiserror = { version = "1.0.30", default-features = false }
 coins-bip32 = "0.3.0"
 coins-bip39 = "0.3.0"
-coins-ledger = { version = "0.4.2", default-features = false, optional = true }
+# coins-ledger = { version = "0.4.2", default-features = false, optional = true }
+coins-ledger = { git = "https://github.com/joshieDo/bitcoins-rs", branch = "hidapi-rusb", optional = true }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 async-trait = { version = "0.1.50", default-features = false }
 elliptic-curve = { version = "0.11.5", default-features = false }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Removes libudev-dev dependency.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Replaces `hidapi` for `hidapi-rusb` on both the [ledger](https://github.com/summa-tx/bitcoins-rs/pull/90) (PENDING) and [trezor](https://github.com/joshieDo/rust-trezor-api/pull/2). It makes the `hidapi` backend to be `libusb`, which gets built by `rusb`.

NOTE: Had to bump `yubihsm` version because of incompatibilities on `rusb` versions. It added quite a few dependencies on the lock file...

**The ledger dependency on the git repository is temporary.**

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
