### PR TITLE
fix(solc): handle more remapping edge cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,6 +838,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ctr"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +916,12 @@ dependencies = [
  "tempfile",
  "zeroize",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "digest"
@@ -1359,6 +1375,7 @@ dependencies = [
  "md-5 0.10.0",
  "num_cpus",
  "once_cell",
+ "pretty_assertions",
  "regex",
  "semver",
  "serde",
@@ -2221,6 +2238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "p256"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,6 +2439,18 @@ name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0cfe1b2403f172ba0f234e500906ee0a3e493fb81092dac23ebefe129301cc"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "primitive-types"

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -48,6 +48,7 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["async_tokio"] }
+pretty_assertions = "1.0.0"
 tempdir = "0.3.7"
 tokio = { version = "1.12.0", features = ["full"] }
 

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -401,10 +401,6 @@ mod tests {
             "repo1/lib/ds-math/lib/ds-test/src/test.sol",
             "repo1/lib/guni-lev/src",
             "repo1/lib/guni-lev/src/contract.sol",
-            "repo1/lib/guni-lev/lib/ds-test/src/",
-            "repo1/lib/guni-lev/lib/ds-test/src/test.sol",
-            "repo1/lib/guni-lev/lib/ds-test/demo/",
-            "repo1/lib/guni-lev/lib/ds-test/demo/demo.sol",
             "repo1/lib/solmate/src/auth",
             "repo1/lib/solmate/src/auth/contract.sol",
             "repo1/lib/solmate/src/tokens",
@@ -465,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn remappings2() {
+    fn remappings() {
         let tmp_dir = tempdir::TempDir::new("tmp").unwrap();
         let tmp_dir_path = tmp_dir.path().join("lib");
         let repo1 = tmp_dir_path.join("src_repo");
@@ -551,12 +547,5 @@ mod tests {
         ];
         expected.sort_unstable();
         pretty_assertions::assert_eq!(remappings, expected);
-    }
-
-    #[test]
-    fn git_remappings() {
-        dbg!(Remapping::find_many(
-            "/Users/Matthias/git/rust/foundry-integration-tests/testdata/geb/lib"
-        ));
     }
 }

--- a/ethers-solc/src/utils.rs
+++ b/ethers-solc/src/utils.rs
@@ -151,7 +151,6 @@ pub fn library_hash(name: impl AsRef<[u8]>) -> [u8; 17] {
     output
 }
 
-
 /// Find the common ancestor, if any, between the given paths
 ///
 /// # Example
@@ -169,27 +168,17 @@ pub fn library_hash(name: impl AsRef<[u8]>) -> [u8; 17] {
 /// # }
 /// ```
 pub fn common_ancestor_all<I, P>(paths: I) -> Option<PathBuf>
-    where
-        I: IntoIterator<Item = P>,
-        P: AsRef<Path>,
-{
-    common_ancestor_all_skip(paths, |_| false)
-}
-
-/// Find the common ancestor, if any, between the given paths while ignoreing certain components
-pub fn common_ancestor_all_skip<I, P, F>(paths: I, skip: F ) -> Option<PathBuf>
-    where
-        I: IntoIterator<Item = P>,
-        P: AsRef<Path>,
-        F: Fn(&Component) -> bool
+where
+    I: IntoIterator<Item = P>,
+    P: AsRef<Path>,
 {
     let mut iter = paths.into_iter();
     let mut ret = iter.next()?.as_ref().to_path_buf();
     for path in iter {
-        if let Some(r) = common_ancestor_skip(ret, path.as_ref(), |c| (skip)(c)) {
+        if let Some(r) = common_ancestor(ret, path.as_ref()) {
             ret = r;
         } else {
-            return None;
+            return None
         }
     }
     Some(ret)
@@ -211,21 +200,16 @@ pub fn common_ancestor_all_skip<I, P, F>(paths: I, skip: F ) -> Option<PathBuf>
 /// # }
 /// ```
 pub fn common_ancestor(a: impl AsRef<Path>, b: impl AsRef<Path>) -> Option<PathBuf> {
-    common_ancestor_skip(a,b, |_| false)
-}
-
-/// Finds the common ancestor of the paths, while ignoring certain components
-pub fn common_ancestor_skip(a: impl AsRef<Path>, b: impl AsRef<Path>, skip: impl Fn(&Component) -> bool) -> Option<PathBuf> {
     let a = a.as_ref().components();
     let b = b.as_ref().components();
     let mut ret = PathBuf::new();
     let mut found = false;
     for (c1, c2) in a.zip(b) {
-        if  c1 == c2 || (skip)(&c1) || (skip)(&c2) {
+        if c1 == c2 {
             ret.push(c1);
             found = true;
         } else {
-            break;
+            break
         }
     }
     if found {
@@ -319,27 +303,11 @@ pragma solidity ^0.8.0;
 
     #[test]
     fn can_find_all_ancestor() {
-            let a = Path::new("/foo/bar/foo/example.txt");
-            let b = Path::new("/foo/bar/foo/test.txt");
-            let c = Path::new("/foo/bar/bar/foo/bar");
-            let expected = Path::new("/foo/bar");
-            let paths = vec![a, b, c];
-            assert_eq!(common_ancestor_all(paths).unwrap(), expected.to_path_buf())
+        let a = Path::new("/foo/bar/foo/example.txt");
+        let b = Path::new("/foo/bar/foo/test.txt");
+        let c = Path::new("/foo/bar/bar/foo/bar");
+        let expected = Path::new("/foo/bar");
+        let paths = vec![a, b, c];
+        assert_eq!(common_ancestor_all(paths).unwrap(), expected.to_path_buf())
     }
-
-    #[test]
-    fn can_find_dapptools_ancestor() {
-        let paths = [
-            "lib/solmate/src",
-            "lib/solmate/src/contract.sol",
-            "lib/solmate/lib/ds-test/src/",
-            "lib/solmate/lib/ds-test/src/test.sol",
-            "lib/solmate/lib/ds-test/demo/",
-            "lib/solmate/lib/ds-test/demo/demo.sol",
-        ].iter().map(|p|Path::new(p).to_path_buf()).collect::<Vec<_>>();
-
-        dbg!(common_ancestor_all(paths));
-
-    }
-
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Better remapping auto detection for both hardhat and dapp
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
There are quite a few edge cases with certain assumptions based on the dir structure.
Finding remappings works as follows:

1. scan all sub dirs (every dir in a lib like (lib/*, node_modules/*)) for candidates
2. simplify all candidates by looking at their most common ancestor and their surrounding dirs, this has various edge cases, especially in hardhat layouts with `contracts`. This tries its best to anticipate to what dir the remapping should actually point

`dependency/contracts/s.sol` -> `dependency/contracts`
`dependency/contracts/nested/s.sol` -> `dependency/contracts`
`dependency/nested/contracts/s.sol` -> `dependency`

there is probably an easier way to determine this, but for most common cases this should work even though this looks a bit horrible...

Ref https://github.com/gakonst/foundry/pull/273

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
