### PR TITLE
add fn settings on CompilerInput

### DIFF
--- a/ethers-solc/src/artifacts.rs
+++ b/ethers-solc/src/artifacts.rs
@@ -39,6 +39,13 @@ impl CompilerInput {
         Self { language: "Solidity".to_string(), sources, settings: Default::default() }
     }
 
+    /// Sets the settings for compilation
+    #[must_use]
+    pub fn settings(mut self, settings: Settings) -> Self {
+        self.settings = settings;
+        self
+    }
+
     /// Sets the EVM version for compilation
     #[must_use]
     pub fn evm_version(mut self, version: EvmVersion) -> Self {

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -335,6 +335,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
                     paths.extend(map);
 
                     let input = CompilerInput::with_sources(sources)
+                        .settings(self.solc_config.settings.clone())
                         .normalize_evm_version(&solc.version()?)
                         .with_remappings(self.paths.remappings.clone());
 
@@ -397,7 +398,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
         let sources = paths.set_source_names(sources);
 
         let input = CompilerInput::with_sources(sources)
-            .evm_version(self.solc_config.settings.evm_version.unwrap_or_default())
+            .settings(self.solc_config.settings.clone())
             .normalize_evm_version(&solc.version()?)
             .with_remappings(self.paths.remappings.clone());
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Settings weren't being passed properly into the compiler. For example, the optimization flags were set on the project and cache files, but the actual bytecode was not optimized.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Passed `Settings` into the `CompilerInput` first.

I tried looking into passing `&Settings` instead, but then, the more lifetimes I added, the more it required. If someone has a better way, it's highly appreciated.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
