### PR TITLE
reexport MultiAbigen

### DIFF
--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -31,7 +31,7 @@ pub mod builders {
 
 #[cfg(any(test, feature = "abigen"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "abigen")))]
-pub use ethers_contract_abigen::Abigen;
+pub use ethers_contract_abigen::{Abigen, MultiAbigen};
 
 #[cfg(any(test, feature = "abigen"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "abigen")))]


### PR DESCRIPTION
## Motivation

Can not use `MultiAbigen` from `ethers::contract`

## Solution

export `MultiAbigen` in `ethers-contract/src/lib.rs`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
