### PR TITLE
fix: make evm bytecode optional

### DIFF
--- a/ethers-solc/src/artifacts.rs
+++ b/ethers-solc/src/artifacts.rs
@@ -635,7 +635,7 @@ impl From<Contract> for CompactContract {
     fn from(c: Contract) -> Self {
         let (bin, bin_runtime) = if let Some(evm) = c.evm {
             (
-                Some(evm.bytecode.object),
+                evm.bytecode.map(|c| c.object),
                 evm.deployed_bytecode.and_then(|deployed| deployed.bytecode.map(|evm| evm.object)),
             )
         } else {
@@ -688,7 +688,7 @@ impl<'a> From<&'a Contract> for CompactContractRef<'a> {
     fn from(c: &'a Contract) -> Self {
         let (bin, bin_runtime) = if let Some(ref evm) = c.evm {
             (
-                Some(&evm.bytecode.object),
+                evm.bytecode.as_ref().map(|c| &c.object),
                 evm.deployed_bytecode
                     .as_ref()
                     .and_then(|deployed| deployed.bytecode.as_ref().map(|evm| &evm.object)),
@@ -738,7 +738,7 @@ pub struct Evm {
     pub assembly: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub legacy_assembly: Option<serde_json::Value>,
-    pub bytecode: Bytecode,
+    pub bytecode: Option<Bytecode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deployed_bytecode: Option<DeployedBytecode>,
     /// The list of function hashes

--- a/ethers-solc/src/hh.rs
+++ b/ethers-solc/src/hh.rs
@@ -25,7 +25,7 @@ pub struct HardhatArtifact {
     pub abi: Abi,
     /// A "0x"-prefixed hex string of the unlinked deployment bytecode. If the contract is not
     /// deployable, this has the string "0x"
-    pub bytecode: BytecodeObject,
+    pub bytecode: Option<BytecodeObject>,
     /// A "0x"-prefixed hex string of the unlinked runtime/deployed bytecode. If the contract is
     /// not deployable, this has the string "0x"
     pub deployed_bytecode: Option<BytecodeObject>,
@@ -43,7 +43,7 @@ impl From<HardhatArtifact> for CompactContract {
     fn from(artifact: HardhatArtifact) -> Self {
         CompactContract {
             abi: Some(artifact.abi),
-            bin: Some(artifact.bytecode),
+            bin: artifact.bytecode,
             bin_runtime: artifact.deployed_bytecode,
         }
     }
@@ -90,12 +90,13 @@ impl ArtifactOutput for HardhatArtifacts {
                         (None, Default::default())
                     };
 
-                (
-                    evm.bytecode.object,
-                    evm.bytecode.link_references,
-                    deployed_bytecode,
-                    deployed_link_references,
-                )
+                let (bytecode, link_ref) = if let Some(bc) = evm.bytecode {
+                    (Some(bc.object), bc.link_references)
+                } else {
+                    (None, Default::default())
+                };
+
+                (bytecode, link_ref, deployed_bytecode, deployed_link_references)
             } else {
                 (Default::default(), Default::default(), None, Default::default())
             };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Fix https://github.com/gakonst/foundry/issues/301

The reason this happened is because solc omits the bytecode if its encountered a stack too deep error, but our `Evm` requires it so it fails to decode and the error gets lost.

now if solc encounters a stack too deep, foundry will display the error correctly:

```console
Error: 
   0: 
      CompilerError: Stack too deep, try removing local variables.
         --> /Users/Matthias/git/rust/foundry-integration-tests/testdata/juice-contracts-v2/./contracts/JBETHPaymentTerminalStore.sol:243:10:
          |
      243 |         (_preferClaimedTokensAndBeneficiary & 1) == 0,
          |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

      
   0: 

Location:
   cli/src/cmd/build.rs:91
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Make `Evm::bytecode` optional, this is the only sound solution, since the compiler output also depends on the compiler input's settings, which can tell solc to omit the bytecode entirely anyways.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
