### PR TITLE
MultiAbigen recursively read json files under given directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,6 +1111,7 @@ dependencies = [
  "syn",
  "tempfile",
  "url",
+ "walkdir",
 ]
 
 [[package]]

--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -25,6 +25,7 @@ reqwest = { version = "0.11.3", default-features = false, features = ["blocking"
 once_cell = "1.8.0"
 cfg-if = "1.0.0"
 dunce = "1.0.2"
+walkdir = "2.3.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # NOTE: this enables wasm compatibility for getrandom indirectly

--- a/ethers-contract/ethers-contract-abigen/src/lib.rs
+++ b/ethers-contract/ethers-contract-abigen/src/lib.rs
@@ -247,7 +247,7 @@ impl MultiAbigen {
         Ok(Self::from_abigen(abis))
     }
 
-    /// Reads all json files contained in the given `dir` and use the file name for the name of the
+    /// Reads all json files contained under the given `dir` and use the file name for the name of the
     /// `ContractBindings`.
     /// This is equivalent to calling `MultiAbigen::new` with all the json files and their filename.
     ///
@@ -255,7 +255,8 @@ impl MultiAbigen {
     ///
     /// ```text
     /// abi
-    /// ├── ERC20.json
+    /// ├── ERC20.sol
+    ///     ├── ERC20.json
     /// ├── Contract1.json
     /// ├── Contract2.json
     /// ...

--- a/ethers-contract/ethers-contract-abigen/src/lib.rs
+++ b/ethers-contract/ethers-contract-abigen/src/lib.rs
@@ -32,6 +32,7 @@ use std::{
     io::Write,
     path::Path,
 };
+use walkdir::{WalkDir, DirEntry};
 
 /// Builder struct for generating type-safe bindings from a contract's ABI
 ///
@@ -266,10 +267,10 @@ impl MultiAbigen {
     /// ```
     pub fn from_json_files(dir: impl AsRef<Path>) -> Result<Self> {
         let mut abis = Vec::new();
-        for file in fs::read_dir(dir)?.into_iter().filter_map(std::io::Result::ok).filter(|p| {
+        for file in WalkDir::new(dir).into_iter().filter_map(Result::ok).filter(|p| {
             p.path().is_file() && p.path().extension().and_then(|ext| ext.to_str()) == Some("json")
         }) {
-            let file: fs::DirEntry = file;
+            let file: DirEntry = file;
             if let Some(file_name) = file.path().file_stem().and_then(|s| s.to_str()) {
                 let content = fs::read_to_string(file.path())?;
                 abis.push((file_name.to_string(), content));


### PR DESCRIPTION
## Motivation

Easier integration when working `abi` generated from `forge build` which `json` files are stored under the folders. 

## Solution

Use `walkdir` to recursively read files (following pattern from this module https://github.com/gakonst/ethers-rs/blob/master/ethers-solc/src/utils.rs#L54).

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
