### PR TITLE
[draft] Add Optimism & OptimismKovan chains

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -18,6 +18,8 @@ pub enum Chain {
     Moonbeam,
     MoonbeamDev,
     Moonriver,
+    Optimism,
+    OptimismKovan,
 }
 
 impl fmt::Display for Chain {
@@ -43,6 +45,8 @@ impl From<Chain> for u32 {
             Chain::Moonbeam => 1287,
             Chain::MoonbeamDev => 1281,
             Chain::Moonriver => 1285,
+            Chain::Optimism => 10,
+            Chain::OptimismKovan => 69,
         }
     }
 }

--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -58,6 +58,14 @@ impl Client {
                 Url::parse("https://api-testnet.snowtrace.io/api"),
                 Url::parse("https://testnet.snowtrace.io"),
             ),
+            Chain::Optimism => (
+                Url::parse("https://api-optimistic.etherscan.io/api"),
+                Url::parse("https://optimistic.etherscan.io"),
+            ),
+            Chain::OptimismKovan => (
+                Url::parse("https://api-kovan-optimistic.etherscan.io/api"),
+                Url::parse("https://kovan-optimistic.etherscan.io"),
+            ),
             chain => return Err(EtherscanError::ChainNotSupported(chain)),
         };
 
@@ -75,9 +83,13 @@ impl Client {
         let api_key = match chain {
             Chain::Avalanche | Chain::AvalancheFuji => std::env::var("SNOWTRACE_API_KEY")?,
             Chain::Polygon | Chain::PolygonMumbai => std::env::var("POLYGONSCAN_API_KEY")?,
-            Chain::Mainnet | Chain::Ropsten | Chain::Kovan | Chain::Rinkeby | Chain::Goerli => {
-                std::env::var("ETHERSCAN_API_KEY")?
-            }
+            Chain::Mainnet
+            | Chain::Ropsten
+            | Chain::Kovan
+            | Chain::Rinkeby
+            | Chain::Goerli
+            | Chain::Optimism
+            | Chain::OptimismKovan => std::env::var("ETHERSCAN_API_KEY")?,
 
             Chain::XDai | Chain::Sepolia => String::default(),
             Chain::Moonbeam | Chain::MoonbeamDev | Chain::Moonriver => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

I want to add Optimism verification support for [foundry](https://github.com/gakonst/foundry), but it turns out foundry depends on this package and optimism is not supported yet. This PR add support for Optimism network.

More information about Optimism:

1. [What is Optimism?](https://help.optimism.io/hc/en-us/articles/4411921295899-What-is-Optimism-)
2. [Optimism Networks and Public RPC Endpoints](https://community.optimism.io/docs/infra/networks.html)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

There are two packages that need to be updated:
1. Core: Add chain types
2. Etherscan: add support for `ETHERSCAN_API_KEY` on optimism

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
