### PR TITLE
feat: support abi generated from forge

### DIFF
--- a/ethers-contract/tests/abigen.rs
+++ b/ethers-contract/tests/abigen.rs
@@ -26,6 +26,11 @@ fn can_gen_human_readable() {
 }
 
 #[test]
+fn can_gen_not_human_readable() {
+    abigen!(VerifierAbiHardhatContract, "./tests/solidity-contracts/verifier_abi_hardhat.json");
+}
+
+#[test]
 fn can_gen_human_readable_multiple() {
     abigen!(
         SimpleContract1,


### PR DESCRIPTION
## Motivation

Binding generated by AbiGen which bind output of `forge build`  throws this error #683 

But it work If I change the format of ABI json to only be the content of `abi`

## Solution



## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
