### PR TITLE
feat/trezor: cache session on filesystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1264,6 +1264,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "hex",
+ "home",
  "rand 0.8.4",
  "rusoto_core",
  "rusoto_kms",

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -39,6 +39,7 @@ spki = { version = "0.5.2", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 eth-keystore = { version = "0.3.0" }
+home = "0.5.3"
 
 [dev-dependencies]
 ethers-contract = { version = "^0.6.0", path = "../ethers-contract", features = ["eip712", "abigen"]}

--- a/ethers-signers/src/trezor/app.rs
+++ b/ethers-signers/src/trezor/app.rs
@@ -47,7 +47,7 @@ impl TrezorEthereum {
         chain_id: u64,
         cache_dir: Option<PathBuf>,
     ) -> Result<Self, TrezorError> {
-        let cache_dir = (match cache_dir.or_else(|| home::home_dir()) {
+        let cache_dir = (match cache_dir.or_else(home::home_dir) {
             Some(path) => path,
             None => match env::current_dir() {
                 Ok(path) => path,
@@ -264,7 +264,10 @@ mod tests {
     // Replace this with your ETH addresses.
     async fn test_get_address() {
         // Instantiate it with the default trezor derivation path
-        let trezor = TrezorEthereum::new(DerivationType::TrezorLive(1), 1, Some(PathBuf::from("randomdir"))).await.unwrap();
+        let trezor =
+            TrezorEthereum::new(DerivationType::TrezorLive(1), 1, Some(PathBuf::from("randomdir")))
+                .await
+                .unwrap();
         assert_eq!(
             trezor.get_address().await.unwrap(),
             "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".parse().unwrap()

--- a/ethers-signers/src/trezor/types.rs
+++ b/ethers-signers/src/trezor/types.rs
@@ -52,7 +52,7 @@ pub enum TrezorError {
     #[error("Does not support ENS.")]
     NoENSSupport,
     #[error("Unable to access trezor cached session.")]
-    CacheError,
+    CacheError(String),
 }
 
 /// Trezor Transaction Struct

--- a/ethers-signers/src/trezor/types.rs
+++ b/ethers-signers/src/trezor/types.rs
@@ -51,6 +51,8 @@ pub enum TrezorError {
     UnsupportedFirmwareVersion(String),
     #[error("Does not support ENS.")]
     NoENSSupport,
+    #[error("Unable to access trezor cached session.")]
+    CacheError,
 }
 
 /// Trezor Transaction Struct


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Sessions are used to "keep" the  passphrase on the device in-between different calls. And while it was being reused inside the same `TrezorEthereum` object, once we instantiated a new one, we would lose the session.

For example, different `forge` or `cast` calls would always request the user to insert their passphrase again and again. With this change, it won't.

Relevant information from  [sessions @ docs.trezor.io](https://docs.trezor.io/trezor-firmware/common/communication/sessions.html) :
* `Sessions only exist in RAM and are lost when Trezor is disconnected.`
* `New session is started by calling Initialize with no arguments. The response is a Features message, which contains a 32-byte session_id. All subsequent commands happen within the given session.`
* `To resume a previous session (after creating a new one), call Initialize with a stored session_id as an argument. Attempt to resume an unknown session ID will transparently allocate a new session ID.`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Read/write `session_id` to `./cache/trezor.session`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
