### PR TITLE
feat: save compiler version + runs

### DIFF
--- a/ethers-solc/src/error.rs
+++ b/ethers-solc/src/error.rs
@@ -33,6 +33,8 @@ pub enum SolcError {
     /// General purpose message
     #[error("{0}")]
     Message(String),
+    #[error(transparent)]
+    IoError(#[from] io::Error),
 
     #[cfg(feature = "project-util")]
     #[error(transparent)]

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -343,7 +343,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
                 // skips the platform from the compiler version string
                 let trimmed = &version.build.as_str()[..15];
                 version.build = semver::BuildMetadata::new(trimmed)?;
-                Ok((version.to_string(), sources.keys().collect::<Vec<_>>()))
+                Ok((format!("v{}", version), sources.keys().collect::<Vec<_>>()))
             })
             .collect::<Result<BTreeMap<_, _>>>()?;
         let versions_file_path = self.artifacts_path().join(SOLIDITY_VERSIONS);

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -332,6 +332,15 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
         Ok(compiled)
     }
 
+    /// Returns the `solidity-versions.json` file under the artifacts directory
+    /// which contains the Solidity compiler versions which were used to compile
+    /// each file.
+    pub fn source_versions(&self) -> Result<BTreeMap<String, Vec<PathBuf>>> {
+        let versions_file_path = self.artifacts_path().join(SOLIDITY_VERSIONS);
+        let versions_file = File::open(versions_file_path)?;
+        Ok(serde_json::from_reader(versions_file)?)
+    }
+
     fn write_source_versions(
         &self,
         sources_by_version: BTreeMap<Solc, BTreeMap<PathBuf, Source>>,

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -2,10 +2,9 @@
 
 use ethers_solc::{
     cache::SOLIDITY_FILES_CACHE_FILENAME, project_util::*, MinimalCombinedArtifacts, Project,
-    ProjectPathsConfig, SOLIDITY_VERSIONS,
+    ProjectPathsConfig, SourceVersions, SOLIDITY_VERSIONS,
 };
 use std::{
-    collections::BTreeMap,
     io,
     path::{Path, PathBuf},
 };
@@ -55,7 +54,7 @@ fn can_compile_dapp_sample() {
 
     let solc_versions_path = project.project().artifacts_path().join(SOLIDITY_VERSIONS);
     let reader = std::fs::File::open(solc_versions_path).unwrap();
-    let _: BTreeMap<String, Vec<PathBuf>> = serde_json::from_reader(reader).unwrap();
+    let _: SourceVersions = serde_json::from_reader(reader).unwrap();
 
     // delete artifacts
     std::fs::remove_dir_all(&project.paths().artifacts).unwrap();

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -2,9 +2,10 @@
 
 use ethers_solc::{
     cache::SOLIDITY_FILES_CACHE_FILENAME, project_util::*, MinimalCombinedArtifacts, Project,
-    ProjectPathsConfig,
+    ProjectPathsConfig, SOLIDITY_VERSIONS,
 };
 use std::{
+    collections::BTreeMap,
     io,
     path::{Path, PathBuf},
 };
@@ -51,6 +52,10 @@ fn can_compile_dapp_sample() {
     let compiled = project.compile().unwrap();
     assert!(compiled.find("Dapp").is_some());
     assert!(compiled.is_unchanged());
+
+    let solc_versions_path = project.project().artifacts_path().join(SOLIDITY_VERSIONS);
+    let reader = std::fs::File::open(solc_versions_path).unwrap();
+    let _: BTreeMap<String, Vec<PathBuf>> = serde_json::from_reader(reader).unwrap();
 
     // delete artifacts
     std::fs::remove_dir_all(&project.paths().artifacts).unwrap();


### PR DESCRIPTION
Saves the compiler version + paths used under `$ARTIFACTS/solidity-versions.json`.

TODO:
- [x] Save the compiler runs.

We need this to do etherscan verification.