### PR TITLE
feat: add FromStr impl for Chain

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -1,16 +1,13 @@
 use std::fmt;
+use thiserror::Error;
 
 use crate::types::U256;
 use std::str::FromStr;
 
-#[derive(Debug, Clone)]
-pub struct ParseChainError;
+#[derive(Debug, Clone, Error)]
+#[error("Failed to parse chain: {0}")]
+pub struct ParseChainError(String);
 
-impl fmt::Display for ParseChainError {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "Failed to parse: {:?}", self)
-    }
-}
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Chain {
     Mainnet,
@@ -83,16 +80,16 @@ impl FromStr for Chain {
             "kovan" => Chain::Kovan,
             "xdai" => Chain::XDai,
             "polygon" => Chain::Polygon,
-            "polygonMumbai" => Chain::PolygonMumbai,
+            "polygon-mumbai" => Chain::PolygonMumbai,
             "avalanche" => Chain::Avalanche,
-            "avalancheFuji" => Chain::AvalancheFuji,
+            "avalanche-fuji" => Chain::AvalancheFuji,
             "sepolia" => Chain::Sepolia,
             "moonbeam" => Chain::Moonbeam,
-            "moonbeamDev" => Chain::MoonbeamDev,
+            "moonbeam-dev" => Chain::MoonbeamDev,
             "moonriver" => Chain::Moonriver,
             "optimism" => Chain::Optimism,
-            "optimismKovan" => Chain::OptimismKovan,
-            _ => Chain::Mainnet,
+            "optimism-kovan" => Chain::OptimismKovan,
+            _ => return Err(ParseChainError(chain.to_owned())),
         })
     }
 }

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -1,7 +1,16 @@
 use std::fmt;
 
 use crate::types::U256;
+use std::str::FromStr;
 
+#[derive(Debug, Clone)]
+pub struct ParseChainError;
+
+impl fmt::Display for ParseChainError {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "Failed to parse: {:?}", self)
+    }
+}
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Chain {
     Mainnet,
@@ -60,5 +69,30 @@ impl From<Chain> for U256 {
 impl From<Chain> for u64 {
     fn from(chain: Chain) -> Self {
         u32::from(chain).into()
+    }
+}
+
+impl FromStr for Chain {
+    type Err = ParseChainError;
+    fn from_str(chain: &str) -> Result<Self, Self::Err> {
+        Ok(match chain {
+            "mainnet" => Chain::Mainnet,
+            "ropsten" => Chain::Ropsten,
+            "rinkeby" => Chain::Rinkeby,
+            "goerli" => Chain::Goerli,
+            "kovan" => Chain::Kovan,
+            "xdai" => Chain::XDai,
+            "polygon" => Chain::Polygon,
+            "polygonMumbai" => Chain::PolygonMumbai,
+            "avalanche" => Chain::Avalanche,
+            "avalancheFuji" => Chain::AvalancheFuji,
+            "sepolia" => Chain::Sepolia,
+            "moonbeam" => Chain::Moonbeam,
+            "moonbeamDev" => Chain::MoonbeamDev,
+            "moonriver" => Chain::Moonriver,
+            "optimism" => Chain::Optimism,
+            "optimismKovan" => Chain::OptimismKovan,
+            _ => Chain::Mainnet,
+        })
     }
 }


### PR DESCRIPTION
Enables https://github.com/gakonst/foundry/pull/357

Ideally, I would prefer that the default case of the `match` statement is sth like `Chain::UnknownChain`, but I added mainnet for compatibility.

Should we add that to the enum?