### PR TITLE
remove unofficial testnet dai

### DIFF
--- a/ethers-addressbook/src/contracts/contracts.json
+++ b/ethers-addressbook/src/contracts/contracts.json
@@ -2,7 +2,7 @@
 	"dai": {
 		"addresses": {
 			"mainnet": "0x6b175474e89094c44da98b954eedeac495271d0f",
-			"rinkeby": "0x8ad3aa5d5ff084307d28c8f514d7a193b2bfe725"
+			"goerli": "0x11fE4B6AE13d2a6055C8D9cF65c55bac32B5d844"
 		}
 	},
 	"usdc": {


### PR DESCRIPTION
Official rinkeby support for MCD has been deprecated a long time ago. Furthermore the rinkeby address in this library is not even a dai.sol implementation - not sure who deployed or maintains this instance.
Instead I would encourage users to utilize the official goerli MCD instance, and the related Dai token for testing, which I have added in this commit.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
