### PR TITLE
Ignore SPDX and contract size for tests

### DIFF
--- a/ethers-solc/src/artifacts.rs
+++ b/ethers-solc/src/artifacts.rs
@@ -537,18 +537,17 @@ impl CompilerOutput {
     }
 
     /// Whether the output contains a compiler warning
-    pub fn has_warning<'a>(&self, ignored_error_codes: &'a [u64]) -> bool {
+    pub fn has_warning(&self, ignored_error_codes: &[u64]) -> bool {
         self.errors.iter().any(|err| {
-            let is_ignored = err.error_code.as_ref().map_or(false, |code| {
-                !ignored_error_codes.contains(code)
-            });
+            let is_ignored =
+                err.error_code.as_ref().map_or(false, |code| !ignored_error_codes.contains(code));
 
             err.severity.is_warning() && !is_ignored
         })
     }
 
     pub fn diagnostics<'a>(&'a self, ignored_error_codes: &'a [u64]) -> OutputDiagnostics {
-        OutputDiagnostics { compiler_output: &self, ignored_error_codes }
+        OutputDiagnostics { compiler_output: self, ignored_error_codes }
     }
 
     /// Finds the _first_ contract with the given name
@@ -701,20 +700,17 @@ impl<'a> OutputDiagnostics<'a> {
 
     /// Returns true if there is at least one warning
     pub fn has_warning(&self) -> bool {
-        self.compiler_output.has_warning(&self.ignored_error_codes)
+        self.compiler_output.has_warning(self.ignored_error_codes)
     }
 
     fn is_test<T: AsRef<str>>(&self, contract_path: T) -> bool {
         if contract_path.as_ref().ends_with(".t.sol") {
-            return true;
+            return true
         }
 
-        self.compiler_output.find(&contract_path)
-            .map_or(false, |contract| {
-                contract.abi.map_or(false, |abi| {
-                    abi.functions.contains_key("IS_TEST")
-                })
-            })
+        self.compiler_output.find(&contract_path).map_or(false, |contract| {
+            contract.abi.map_or(false, |abi| abi.functions.contains_key("IS_TEST"))
+        })
     }
 }
 
@@ -733,13 +729,12 @@ impl<'a> fmt::Display for OutputDiagnostics<'a> {
                     // we ignore spdx and contract size warnings in test
                     // files. if we are looking at one of these warnings
                     // from a test file we skip
-                    if self.is_test(&source_location.file)
-                        && (*code == 1878 || *code == 5574) {
-                        return true;
+                    if self.is_test(&source_location.file) && (*code == 1878 || *code == 5574) {
+                        return true
                     }
                 }
 
-                self.ignored_error_codes.contains(&code)
+                self.ignored_error_codes.contains(code)
             });
 
             if !is_ignored {

--- a/ethers-solc/src/artifacts.rs
+++ b/ethers-solc/src/artifacts.rs
@@ -537,8 +537,14 @@ impl CompilerOutput {
     }
 
     /// Whether the output contains a compiler warning
-    pub fn has_warning(&self) -> bool {
-        self.errors.iter().any(|err| err.severity.is_warning())
+    pub fn has_warning<'a>(&self, ignored_error_codes: &'a [u64]) -> bool {
+        self.errors.iter().any(|err| {
+            let is_ignored = err.error_code.as_ref().map_or(false, |code| {
+                !ignored_error_codes.contains(code)
+            });
+
+            err.severity.is_warning() && !is_ignored
+        })
     }
 
     pub fn diagnostics<'a>(&'a self, ignored_error_codes: &'a [u64]) -> OutputDiagnostics {

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -221,7 +221,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
         #[cfg(all(feature = "svm", feature = "async"))]
         if self.auto_detect {
             tracing::trace!("using solc auto detection to compile sources");
-            return self.svm_compile(sources);
+            return self.svm_compile(sources)
         }
 
         let mut solc = self.solc.clone();
@@ -387,7 +387,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
             return Ok(ProjectCompileOutput::from_compiler_output(
                 output,
                 self.ignored_error_codes.clone(),
-            ));
+            ))
         }
 
         if self.cached {
@@ -456,7 +456,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
                     "unchanged source files, reusing artifacts {:?}",
                     cached_artifacts.keys()
                 );
-                return Ok(PreprocessedJob::Unchanged(cached_artifacts));
+                return Ok(PreprocessedJob::Unchanged(cached_artifacts))
             }
             // There are changed files and maybe some cached files
             (changed_files, cached_artifacts)
@@ -792,7 +792,7 @@ impl<T: ArtifactOutput> ProjectCompileOutput<T> {
             if let contract @ Some(_) = output.contracts.iter_mut().find_map(|(file, c)| {
                 c.remove(contract_name).map(|c| T::contract_to_artifact(file, contract_name, c))
             }) {
-                return contract;
+                return contract
             }
         }
         let key = self
@@ -820,7 +820,7 @@ where
                     .map(|c| T::contract_to_artifact(file, contract_name, c.clone()))
                     .map(Cow::Owned)
             }) {
-                return contract;
+                return contract
             }
         }
         self.artifacts.iter().find_map(|(path, art)| {

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -221,7 +221,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
         #[cfg(all(feature = "svm", feature = "async"))]
         if self.auto_detect {
             tracing::trace!("using solc auto detection to compile sources");
-            return self.svm_compile(sources)
+            return self.svm_compile(sources);
         }
 
         let mut solc = self.solc.clone();
@@ -387,7 +387,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
             return Ok(ProjectCompileOutput::from_compiler_output(
                 output,
                 self.ignored_error_codes.clone(),
-            ))
+            ));
         }
 
         if self.cached {
@@ -456,7 +456,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
                     "unchanged source files, reusing artifacts {:?}",
                     cached_artifacts.keys()
                 );
-                return Ok(PreprocessedJob::Unchanged(cached_artifacts))
+                return Ok(PreprocessedJob::Unchanged(cached_artifacts));
             }
             // There are changed files and maybe some cached files
             (changed_files, cached_artifacts)
@@ -779,7 +779,10 @@ impl<T: ArtifactOutput> ProjectCompileOutput<T> {
 
     /// Whether there were warnings
     pub fn has_compiler_warnings(&self) -> bool {
-        self.compiler_output.as_ref().map(|o| o.has_warning()).unwrap_or_default()
+        self.compiler_output
+            .as_ref()
+            .map(|o| o.has_warning(&self.ignored_error_codes))
+            .unwrap_or_default()
     }
 
     /// Finds the first contract with the given name and removes it from the set
@@ -789,7 +792,7 @@ impl<T: ArtifactOutput> ProjectCompileOutput<T> {
             if let contract @ Some(_) = output.contracts.iter_mut().find_map(|(file, c)| {
                 c.remove(contract_name).map(|c| T::contract_to_artifact(file, contract_name, c))
             }) {
-                return contract
+                return contract;
             }
         }
         let key = self
@@ -817,7 +820,7 @@ where
                     .map(|c| T::contract_to_artifact(file, contract_name, c.clone()))
                     .map(Cow::Owned)
             }) {
-                return contract
+                return contract;
             }
         }
         self.artifacts.iter().find_map(|(path, art)| {


### PR DESCRIPTION
## Motivation

Following discussion in https://github.com/gakonst/foundry/pull/399 we want to be able to ignore some errors for tests and dependencies, but not for source.

## Solution

This PR just ignores 2 errors for both tests and dependencies by default: the SPDX and contract size warnings.
