### PR TITLE
Implement RLP decoding for transactions

### DIFF
--- a/ethers-core/src/types/transaction/eip1559.rs
+++ b/ethers-core/src/types/transaction/eip1559.rs
@@ -3,7 +3,7 @@ use crate::{
     types::{Address, Bytes, NameOrAddress, Signature, H256, U256, U64},
     utils::keccak256,
 };
-use rlp::RlpStream;
+use rlp::{Decodable, DecoderError, RlpStream};
 
 /// EIP-1559 transactions have 9 fields
 const NUM_TX_FIELDS: usize = 9;
@@ -57,6 +57,10 @@ pub struct Eip1559TransactionRequest {
     /// baseFeePerGas and maxPriorityFeePerGas). The difference between maxFeePerGas and
     /// baseFeePerGas + maxPriorityFeePerGas is “refunded” to the user.
     pub max_fee_per_gas: Option<U256>,
+
+    #[serde(rename = "chainId", default, skip_serializing_if = "Option::is_none")]
+    /// Chain ID (None for mainnet)
+    pub chain_id: Option<U64>,
 }
 
 impl Eip1559TransactionRequest {
@@ -131,24 +135,26 @@ impl Eip1559TransactionRequest {
     }
 
     /// Hashes the transaction's data with the provided chain id
-    pub fn sighash<T: Into<U64>>(&self, chain_id: T) -> H256 {
-        keccak256(self.rlp(chain_id).as_ref()).into()
+    pub fn sighash(&self) -> H256 {
+        keccak256(self.rlp().as_ref()).into()
     }
 
     /// Gets the unsigned transaction's RLP encoding
-    pub fn rlp<T: Into<U64>>(&self, chain_id: T) -> Bytes {
+    pub fn rlp(&self) -> Bytes {
         let mut rlp = RlpStream::new();
         rlp.begin_list(NUM_TX_FIELDS);
-        self.rlp_base(chain_id, &mut rlp);
+        self.rlp_base(&mut rlp);
         rlp.out().freeze().into()
     }
 
     /// Produces the RLP encoding of the transaction with the provided signature
-    pub fn rlp_signed<T: Into<U64>>(&self, chain_id: T, signature: &Signature) -> Bytes {
+    pub fn rlp_signed(&self, signature: &Signature) -> Bytes {
         let mut rlp = RlpStream::new();
         rlp.begin_unbounded_list();
-        let chain_id = chain_id.into();
-        self.rlp_base(chain_id, &mut rlp);
+        self.rlp_base(&mut rlp);
+
+        // if the chain_id is none we assume mainnet and choose one
+        let chain_id = self.chain_id.unwrap_or_else(U64::one);
 
         // append the signature
         let v = normalize_v(signature.v, chain_id);
@@ -159,8 +165,8 @@ impl Eip1559TransactionRequest {
         rlp.out().freeze().into()
     }
 
-    pub(crate) fn rlp_base<T: Into<U64>>(&self, chain_id: T, rlp: &mut RlpStream) {
-        rlp.append(&chain_id.into());
+    pub(crate) fn rlp_base(&self, rlp: &mut RlpStream) {
+        rlp_opt(rlp, &self.chain_id);
         rlp_opt(rlp, &self.nonce);
         rlp_opt(rlp, &self.max_priority_fee_per_gas);
         rlp_opt(rlp, &self.max_fee_per_gas);
@@ -169,6 +175,44 @@ impl Eip1559TransactionRequest {
         rlp_opt(rlp, &self.value);
         rlp_opt(rlp, &self.data.as_ref().map(|d| d.as_ref()));
         rlp.append(&self.access_list);
+    }
+
+    /// Decodes fields of the request starting at the RLP offset passed. Increments the offset for
+    /// each element parsed.
+    #[inline]
+    fn decode_base_rlp(&mut self, rlp: &rlp::Rlp, offset: &mut usize) -> Result<(), DecoderError> {
+        self.chain_id = Some(rlp.val_at(*offset)?);
+        *offset += 1;
+        self.nonce = Some(rlp.val_at(*offset)?);
+        *offset += 1;
+        self.max_priority_fee_per_gas = Some(rlp.val_at(*offset)?);
+        *offset += 1;
+        self.max_fee_per_gas = Some(rlp.val_at(*offset)?);
+        *offset += 1;
+        self.gas = Some(rlp.val_at(*offset)?);
+        *offset += 1;
+        self.to = Some(rlp.val_at(*offset)?);
+        *offset += 1;
+        self.value = Some(rlp.val_at(*offset)?);
+        *offset += 1;
+        let data = rlp::Rlp::new(rlp.at(*offset)?.as_raw()).data()?;
+        self.data = match data.len() {
+            0 => None,
+            _ => Some(Bytes::from(data.to_vec())),
+        };
+        *offset += 1;
+        self.access_list = rlp.val_at(*offset)?;
+        *offset += 1;
+        Ok(())
+    }
+}
+
+impl Decodable for Eip1559TransactionRequest {
+    fn decode(rlp: &rlp::Rlp) -> Result<Self, rlp::DecoderError> {
+        let mut txn = Eip1559TransactionRequest::new();
+        let mut offset = 0;
+        txn.decode_base_rlp(rlp, &mut offset)?;
+        Ok(txn)
     }
 }
 
@@ -188,6 +232,7 @@ impl From<Eip1559TransactionRequest> for super::request::TransactionRequest {
             gateway_fee_recipient: None,
             #[cfg(feature = "celo")]
             gateway_fee: None,
+            chain_id: tx.chain_id,
         }
     }
 }

--- a/ethers-core/src/types/transaction/eip1559.rs
+++ b/ethers-core/src/types/transaction/eip1559.rs
@@ -134,6 +134,13 @@ impl Eip1559TransactionRequest {
         self
     }
 
+    /// Sets the `chain_id` field in the transaction to the provided value
+    #[must_use]
+    pub fn chain_id<T: Into<U64>>(mut self, chain_id: T) -> Self {
+        self.chain_id = Some(chain_id.into());
+        self
+    }
+
     /// Hashes the transaction's data with the provided chain id
     pub fn sighash(&self) -> H256 {
         keccak256(self.rlp().as_ref()).into()

--- a/ethers-core/src/types/transaction/mod.rs
+++ b/ethers-core/src/types/transaction/mod.rs
@@ -33,3 +33,44 @@ pub(crate) fn normalize_v(v: u64, chain_id: crate::types::U64) -> u64 {
         v
     }
 }
+
+/// extracts the chainid from the signature v value based on EIP-155
+pub(crate) fn extract_chain_id(v: u64) -> Option<crate::types::U64> {
+    // https://eips.ethereum.org/EIPS/eip-155
+    // if chainid is available, v = {0, 1} + CHAIN_ID * 2 + 35
+    if v >= 35 {
+        return Some(crate::types::U64::from((v - 35) >> 1))
+    }
+    None
+}
+
+/// Decodes the signature portion of the RLP encoding based on the RLP offset passed.
+/// Increments the offset for each element parsed.
+#[inline]
+fn decode_signature(
+    rlp: &rlp::Rlp,
+    offset: &mut usize,
+) -> Result<super::Signature, rlp::DecoderError> {
+    let sig = super::Signature {
+        v: rlp.val_at(*offset)?,
+        r: rlp.val_at(*offset + 1)?,
+        s: rlp.val_at(*offset + 2)?,
+    };
+    *offset += 3;
+    Ok(sig)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::{transaction::rlp_opt, U64};
+    use rlp::RlpStream;
+
+    #[test]
+    fn test_rlp_opt_none() {
+        let mut stream = RlpStream::new_list(1);
+        let empty_chainid: Option<U64> = None;
+        rlp_opt(&mut stream, &empty_chainid);
+        let out = stream.out();
+        assert_eq!(out, vec![0xc1, 0x80]);
+    }
+}

--- a/ethers-core/src/types/transaction/request.rs
+++ b/ethers-core/src/types/transaction/request.rs
@@ -1,11 +1,11 @@
 //! Transaction types
-use super::{rlp_opt, NUM_TX_FIELDS};
+use super::{extract_chain_id, rlp_opt, NUM_TX_FIELDS};
 use crate::{
     types::{Address, Bytes, NameOrAddress, Signature, H256, U256, U64},
     utils::keccak256,
 };
 
-use rlp::RlpStream;
+use rlp::{Decodable, RlpStream};
 use serde::{Deserialize, Serialize};
 
 /// Parameters for sending a transaction
@@ -40,6 +40,10 @@ pub struct TransactionRequest {
     /// Transaction nonce (None for next available nonce)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nonce: Option<U256>,
+
+    /// Chain ID (None for mainnet)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chain_id: Option<U64>,
 
     /////////////////  Celo-specific transaction fields /////////////////
     /// The currency fees are paid in (None for native currency)
@@ -123,22 +127,41 @@ impl TransactionRequest {
         self
     }
 
-    /// Hashes the transaction's data with the provided chain id
-    pub fn sighash<T: Into<U64>>(&self, chain_id: T) -> H256 {
-        keccak256(self.rlp(chain_id).as_ref()).into()
+    /// Sets the `chain_id` field in the transaction to the provided value
+    #[must_use]
+    pub fn chain_id<T: Into<U64>>(mut self, chain_id: T) -> Self {
+        self.chain_id = Some(chain_id.into());
+        self
     }
 
-    /// Gets the unsigned transaction's RLP encoding
-    pub fn rlp<T: Into<U64>>(&self, chain_id: T) -> Bytes {
+    /// Hashes the transaction's data with the provided chain id
+    pub fn sighash(&self) -> H256 {
+        match self.chain_id {
+            Some(_) => keccak256(self.rlp().as_ref()).into(),
+            None => keccak256(self.rlp_unsigned().as_ref()).into(),
+        }
+    }
+
+    /// Gets the transaction's RLP encoding, prepared with the chain_id and extra fields for
+    /// signing. Assumes the chainid exists.
+    pub fn rlp(&self) -> Bytes {
         let mut rlp = RlpStream::new();
         rlp.begin_list(NUM_TX_FIELDS);
         self.rlp_base(&mut rlp);
 
         // Only hash the 3 extra fields when preparing the
         // data to sign if chain_id is present
-        rlp.append(&chain_id.into());
+        rlp_opt(&mut rlp, &self.chain_id);
         rlp.append(&0u8);
         rlp.append(&0u8);
+        rlp.out().freeze().into()
+    }
+
+    /// Gets the unsigned transaction's RLP encoding
+    pub fn rlp_unsigned(&self) -> Bytes {
+        let mut rlp = RlpStream::new();
+        rlp.begin_list(NUM_TX_FIELDS - 3);
+        self.rlp_base(&mut rlp);
         rlp.out().freeze().into()
     }
 
@@ -146,6 +169,7 @@ impl TransactionRequest {
     pub fn rlp_signed(&self, signature: &Signature) -> Bytes {
         let mut rlp = RlpStream::new();
         rlp.begin_list(NUM_TX_FIELDS);
+
         self.rlp_base(&mut rlp);
 
         // append the signature
@@ -166,6 +190,86 @@ impl TransactionRequest {
         rlp_opt(rlp, &self.to.as_ref());
         rlp_opt(rlp, &self.value);
         rlp_opt(rlp, &self.data.as_ref().map(|d| d.as_ref()));
+    }
+
+    /// Decodes the unsigned rlp, returning the transaction request and incrementing the counter
+    /// passed as we are traversing the rlp list.
+    fn decode_unsigned_rlp_base(
+        rlp: &rlp::Rlp,
+        offset: &mut usize,
+    ) -> Result<Self, rlp::DecoderError> {
+        let mut txn = TransactionRequest::new();
+        txn.nonce = Some(rlp.at(*offset)?.as_val()?);
+        *offset += 1;
+        txn.gas_price = Some(rlp.at(*offset)?.as_val()?);
+        *offset += 1;
+        txn.gas = Some(rlp.at(*offset)?.as_val()?);
+        *offset += 1;
+
+        #[cfg(feature = "celo")]
+        {
+            txn.fee_currency = Some(rlp.at(*offset)?.as_val()?);
+            *offset += 1;
+            txn.gateway_fee_recipient = Some(rlp.at(*offset)?.as_val()?);
+            *offset += 1;
+            txn.gateway_fee = Some(rlp.at(*offset)?.as_val()?);
+            *offset += 1;
+        }
+
+        txn.to = Some(rlp.at(*offset)?.as_val()?);
+        *offset += 1;
+        txn.value = Some(rlp.at(*offset)?.as_val()?);
+        *offset += 1;
+
+        // finally we need to extract the data which will be encoded as another rlp
+        let txndata = rlp::Rlp::new(rlp.at(*offset)?.as_raw()).data()?;
+        txn.data = match txndata.len() {
+            0 => None,
+            _ => Some(Bytes::from(txndata.to_vec())),
+        };
+        *offset += 1;
+        Ok(txn)
+    }
+
+    /// Decodes RLP into a transaction.
+    pub fn decode_unsigned_rlp(rlp: &rlp::Rlp) -> Result<Self, rlp::DecoderError> {
+        let mut offset = 0;
+        let mut txn = Self::decode_unsigned_rlp_base(rlp, &mut offset)?;
+
+        // If a signed transaction is passed to this method, the chainid would be set to the v value
+        // of the signature.
+        if let Ok(chainid) = rlp.at(offset)?.as_val() {
+            txn.chain_id = Some(chainid);
+        }
+
+        // parse the last two elements so we return an error if a signed transaction is passed
+        let _first_zero: u8 = rlp.at(offset + 1)?.as_val()?;
+        let _second_zero: u8 = rlp.at(offset + 2)?.as_val()?;
+        Ok(txn)
+    }
+
+    /// Decodes the given RLP into a transaction, attempting to decode its signature as well.
+    pub fn decode_signed_rlp(rlp: &rlp::Rlp) -> Result<(Self, Signature), rlp::DecoderError> {
+        let mut offset = 0;
+        let mut txn = Self::decode_unsigned_rlp_base(rlp, &mut offset)?;
+
+        let v = rlp.at(offset)?.as_val()?;
+        // populate chainid from v
+        txn.chain_id = extract_chain_id(v);
+        offset += 1;
+        let r = rlp.at(offset)?.as_val()?;
+        offset += 1;
+        let s = rlp.at(offset)?.as_val()?;
+
+        let sig = Signature { r, s, v };
+        Ok((txn, sig))
+    }
+}
+
+impl Decodable for TransactionRequest {
+    /// Decodes the given RLP into a transaction request, ignoring the signature if populated
+    fn decode(rlp: &rlp::Rlp) -> Result<Self, rlp::DecoderError> {
+        TransactionRequest::decode_unsigned_rlp(rlp)
     }
 }
 
@@ -207,8 +311,46 @@ impl TransactionRequest {
 #[cfg(test)]
 #[cfg(not(feature = "celo"))]
 mod tests {
-    use super::*;
+    use crate::types::Signature;
+    use rlp::{Decodable, Rlp};
 
+    use super::{Address, TransactionRequest, U256, U64};
+
+    #[test]
+    fn encode_decode_rlp() {
+        let tx = TransactionRequest::new()
+            .nonce(3)
+            .gas_price(1)
+            .gas(25000)
+            .to("b94f5374fce5edbc8e2a8697c15331677e6ebf0b".parse::<Address>().unwrap())
+            .value(10)
+            .data(vec![0x55, 0x44])
+            .chain_id(1);
+
+        // turn the rlp bytes encoding into a rlp stream and check that the decoding returns the
+        // same struct
+        let rlp_bytes = &tx.rlp().to_vec()[..];
+        let got_rlp = Rlp::new(rlp_bytes);
+        let txn_request = TransactionRequest::decode(&got_rlp).unwrap();
+
+        // We compare the sighash rather than the specific struct
+        assert_eq!(tx.sighash(), txn_request.sighash());
+    }
+
+    #[test]
+    // test data from https://github.com/ethereum/go-ethereum/blob/b1e72f7ea998ad662166bcf23705ca59cf81e925/core/types/transaction_test.go#L40
+    fn empty_sighash_check() {
+        let tx = TransactionRequest::new()
+            .nonce(0)
+            .to("095e7baea6a6c7c4c2dfeb977efac326af552d87".parse::<Address>().unwrap())
+            .value(0)
+            .gas(0)
+            .gas_price(0);
+
+        let expected_sighash = "c775b99e7ad12f50d819fcd602390467e28141316969f4b57f0626f74fe3b386";
+        let got_sighash = hex::encode(tx.sighash().as_bytes());
+        assert_eq!(expected_sighash, got_sighash);
+    }
     #[test]
     fn decode_unsigned_transaction() {
         let _res: TransactionRequest = serde_json::from_str(
@@ -225,5 +367,82 @@ mod tests {
   }"#,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn decode_known_rlp_goerli() {
+        let tx = TransactionRequest::new()
+            .nonce(70272)
+            .from("fab2b4b677a4e104759d378ea25504862150256e".parse::<Address>().unwrap())
+            .to("d1f23226fb4d2b7d2f3bcdd99381b038de705a64".parse::<Address>().unwrap())
+            .value(0)
+            .gas_price(1940000007)
+            .gas(21000);
+
+        let expected_rlp = hex::decode("f866830112808473a20d0782520894d1f23226fb4d2b7d2f3bcdd99381b038de705a6480801ca04bc89d41c954168afb4cbd01fe2e0f9fe12e3aa4665eefcee8c4a208df044b5da05d410fd85a2e31870ea6d6af53fafc8e3c1ae1859717c863cac5cff40fee8da4").unwrap();
+        let (got_tx, _signature) =
+            TransactionRequest::decode_signed_rlp(&Rlp::new(&expected_rlp)).unwrap();
+
+        // intialization of TransactionRequests using new() uses the Default trait, so we just
+        // compare the sighash and signed encoding instead.
+        assert_eq!(got_tx.sighash(), tx.sighash());
+    }
+
+    #[test]
+    fn test_eip155_encode() {
+        let tx = TransactionRequest::new()
+            .nonce(9)
+            .to("3535353535353535353535353535353535353535".parse::<Address>().unwrap())
+            .value(1000000000000000000u64)
+            .gas_price(20000000000u64)
+            .gas(21000)
+            .chain_id(1);
+
+        let expected_rlp = hex::decode("ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080018080").unwrap();
+        assert_eq!(expected_rlp, tx.rlp().to_vec());
+
+        let expected_sighash =
+            hex::decode("daf5a779ae972f972197303d7b574746c7ef83eadac0f2791ad23db92e4c8e53")
+                .unwrap();
+
+        assert_eq!(expected_sighash, tx.sighash().as_bytes().to_vec());
+    }
+
+    #[test]
+    fn test_eip155_decode() {
+        let tx = TransactionRequest::new()
+            .nonce(9)
+            .to("3535353535353535353535353535353535353535".parse::<Address>().unwrap())
+            .value(1000000000000000000u64)
+            .gas_price(20000000000u64)
+            .gas(21000)
+            .chain_id(1);
+
+        let expected_hex = hex::decode("ec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080018080").unwrap();
+        let expected_rlp = rlp::Rlp::new(expected_hex.as_slice());
+        let decoded_transaction = TransactionRequest::decode(&expected_rlp).unwrap();
+        assert_eq!(tx, decoded_transaction);
+    }
+
+    #[test]
+    fn test_eip155_decode_signed() {
+        let expected_signed_bytes = hex::decode("f86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83").unwrap();
+        let expected_signed_rlp = rlp::Rlp::new(expected_signed_bytes.as_slice());
+        let (decoded_tx, decoded_sig) =
+            TransactionRequest::decode_signed_rlp(&expected_signed_rlp).unwrap();
+
+        let expected_sig = Signature {
+            v: 37,
+            r: U256::from_dec_str(
+                "18515461264373351373200002665853028612451056578545711640558177340181847433846",
+            )
+            .unwrap(),
+            s: U256::from_dec_str(
+                "46948507304638947509940763649030358759909902576025900602547168820602576006531",
+            )
+            .unwrap(),
+        };
+        assert_eq!(expected_sig, decoded_sig);
+        assert_eq!(decoded_tx.chain_id, Some(U64::from(1)));
     }
 }

--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -94,6 +94,9 @@ pub enum SignerMiddlewareError<M: Middleware, S: Signer> {
     /// Thrown if a signature is requested from a different address
     #[error("specified from address is not signer")]
     WrongSigner,
+    /// Thrown if the signer's chain_id is different than the chain_id of the transaction
+    #[error("specified chain_id is different than the signer's chain_id")]
+    DifferentChainID,
 }
 
 // Helper functions for locally signing transactions
@@ -113,6 +116,20 @@ where
         &self,
         tx: TypedTransaction,
     ) -> Result<Bytes, SignerMiddlewareError<M, S>> {
+        // compare chain_id and use signer's chain_id if the tranasaction's chain_id is None,
+        // return an error if they are not consistent
+        let chain_id = self.signer.chain_id();
+        match tx.chain_id() {
+            Some(id) if id.as_u64() != chain_id => {
+                return Err(SignerMiddlewareError::DifferentChainID)
+            }
+            None => {
+                let mut tx = tx.clone();
+                tx.set_chain_id(chain_id);
+            }
+            _ => {}
+        }
+
         let signature =
             self.signer.sign_transaction(&tx).await.map_err(SignerMiddlewareError::SignerError)?;
 
@@ -189,6 +206,12 @@ where
             self.address
         };
         tx.set_from(from);
+
+        // get the signer's chain_id if the transaction does not set it
+        let chain_id = self.signer.chain_id();
+        if tx.chain_id().is_none() {
+            tx.set_chain_id(chain_id);
+        }
 
         let nonce = maybe(tx.nonce().cloned(), self.get_transaction_count(from, block)).await?;
         tx.set_nonce(nonce);

--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -117,7 +117,7 @@ where
             self.signer.sign_transaction(&tx).await.map_err(SignerMiddlewareError::SignerError)?;
 
         // Return the raw rlp-encoded signed transaction
-        Ok(tx.rlp_signed(self.signer.chain_id(), &signature))
+        Ok(tx.rlp_signed(&signature))
     }
 
     /// Returns the client's address
@@ -266,6 +266,7 @@ mod tests {
             nonce: Some(0.into()),
             gas_price: Some(21_000_000_000u128.into()),
             data: None,
+            chain_id: None,
         }
         .into();
         let chain_id = 1u64;

--- a/ethers-middleware/tests/nonce_manager.rs
+++ b/ethers-middleware/tests/nonce_manager.rs
@@ -36,7 +36,10 @@ async fn nonce_manager() {
     let mut tx_hashes = Vec::new();
     for _ in 0..10 {
         let tx = provider
-            .send_transaction(Eip1559TransactionRequest::new().to(address).value(100u64), None)
+            .send_transaction(
+                Eip1559TransactionRequest::new().to(address).value(100u64).chain_id(chain_id),
+                None,
+            )
             .await
             .unwrap();
         tx_hashes.push(*tx);

--- a/ethers-middleware/tests/signer.rs
+++ b/ethers-middleware/tests/signer.rs
@@ -39,7 +39,7 @@ async fn send_eth() {
     let provider = SignerMiddleware::new(provider, wallet);
 
     // craft the transaction
-    let tx = TransactionRequest::new().to(wallet2.address()).value(10000);
+    let tx = TransactionRequest::new().to(wallet2.address()).value(10000).chain_id(chain_id);
 
     let balance_before = provider.get_balance(provider.address(), None).await.unwrap();
 

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -168,6 +168,7 @@ pub trait Middleware: Sync + Send + Debug {
     /// 4. Estimate gas usage _with_ access lists
     /// 5. Enable access lists IFF they are cheaper
     /// 6. Poll and set legacy or 1559 gas prices
+    /// 7. Set the chain_id with the provider's, if not already set
     ///
     /// It does NOT set the nonce by default.
     /// It MAY override the gas amount set by the user, if access lists are

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -223,7 +223,6 @@ pub trait Middleware: Sync + Send + Debug {
         }
 
         let gas_price = original.gas_price().expect("filled");
-        let chain_id = self.get_chainid().await?.low_u64();
         let sign_futs: Vec<_> = (0..escalations)
             .map(|i| {
                 let new_price = policy(gas_price, i);
@@ -234,7 +233,7 @@ pub trait Middleware: Sync + Send + Debug {
             .map(|req| async move {
                 self.sign_transaction(&req, self.default_sender().unwrap_or_default())
                     .await
-                    .map(|sig| req.rlp_signed(chain_id, &sig))
+                    .map(|sig| req.rlp_signed(&sig))
             })
             .collect();
 

--- a/ethers-signers/src/aws/mod.rs
+++ b/ethers-signers/src/aws/mod.rs
@@ -235,7 +235,7 @@ impl<'a> super::Signer for AwsSigner<'a> {
 
     #[instrument(err)]
     async fn sign_transaction(&self, tx: &TypedTransaction) -> Result<EthSig, Self::Error> {
-        let sighash = tx.sighash(self.chain_id);
+        let sighash = tx.sighash();
         self.sign_digest_with_eip155(sighash).await
     }
 

--- a/ethers-signers/src/ledger/app.rs
+++ b/ethers-signers/src/ledger/app.rs
@@ -118,7 +118,7 @@ impl LedgerEthereum {
     /// Signs an Ethereum transaction (requires confirmation on the ledger)
     pub async fn sign_tx(&self, tx: &TypedTransaction) -> Result<Signature, LedgerError> {
         let mut payload = Self::path_to_bytes(&self.derivation);
-        payload.extend_from_slice(tx.rlp(self.chain_id).as_ref());
+        payload.extend_from_slice(tx.rlp().as_ref());
         self.sign_payload(INS::SIGN, payload).await
     }
 


### PR DESCRIPTION
## Motivation

Currently there is no way to decode a transaction from bytes, only encode to bytes.

## Solution

Implemented the [`Decodable`](https://docs.rs/rlp/latest/rlp/trait.Decodable.html) trait for:
 - `TypedTransaction`
   - `TransactionRequest`
   - `Eip2930TransactionRequest`
   - `Eip1559TransactionRequest`
 - `NameOrAddress`
 - `Transaction`

This change uses `rlp_derive` for the `Decodable` implementation on `AccessListItem` and `AccessList`.

This also adjusts each variant of `TypedTransaction` to contain the `chain_id`, and removes `chain_id` it from the `rlp_signed` and `sighash` functions.

Fixes #561 

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
