### PR TITLE
Change artifact naming conventions

### DIFF
--- a/ethers-solc/src/artifacts.rs
+++ b/ethers-solc/src/artifacts.rs
@@ -180,7 +180,6 @@ impl Settings {
             "*".to_string(),
             vec![
                 "abi".to_string(),
-                "metadata".to_string(),
                 "evm.bytecode".to_string(),
                 "evm.deployedBytecode".to_string(),
                 "evm.methodIdentifiers".to_string(),

--- a/ethers-solc/src/artifacts.rs
+++ b/ethers-solc/src/artifacts.rs
@@ -180,6 +180,7 @@ impl Settings {
             "*".to_string(),
             vec![
                 "abi".to_string(),
+                "metadata".to_string(),
                 "evm.bytecode".to_string(),
                 "evm.deployedBytecode".to_string(),
                 "evm.methodIdentifiers".to_string(),

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -141,7 +141,7 @@ impl SolFilesCache {
         sources: Sources,
         config: Option<&'a SolcConfig>,
         paths: &ProjectPathsConfig,
-        content_hashes: HashMap<PathBuf, String>
+        content_hashes: HashMap<PathBuf, String>,
     ) -> Sources {
         sources
             .into_iter()
@@ -273,10 +273,13 @@ impl SolFilesCache {
     }
 
     /// Get metadata for artifacts related to source path
-    pub fn metadata_for_source(&self, path: impl AsRef<Path>) -> Option<(SolcConfig, BTreeMap<PathBuf, String>)> {
-        self.files.get(path.as_ref()).map(|entry| {
-            (entry.solc_config.clone(), entry.artifact_paths.clone())
-        })
+    pub fn metadata_for_source(
+        &self,
+        path: impl AsRef<Path>,
+    ) -> Option<(SolcConfig, BTreeMap<PathBuf, String>)> {
+        self.files
+            .get(path.as_ref())
+            .map(|entry| (entry.solc_config.clone(), entry.artifact_paths.clone()))
     }
 }
 

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -49,6 +49,13 @@ impl SolFilesCache {
         SolFilesCacheBuilder::default()
     }
 
+    /// This returns a `SolFilesCache` that has read the cache file located
+    /// at the default cache location as provided by `ProjectPathsConfig`
+    pub fn cache_populated_from_defaults() -> Result<Self> {
+        let paths = ProjectPathsConfig::builder().build()?;
+        SolFilesCache::read(paths.cache)
+    }
+
     /// Whether this cache's format is the hardhat format identifier
     pub fn is_hardhat_format(&self) -> bool {
         self.format == HH_FORMAT_VERSION
@@ -263,6 +270,13 @@ impl SolFilesCache {
     /// Get source name for cache entry matching source path
     pub fn source_name_for_source(&self, src_path: &String) -> Option<PathBuf> {
         self.files.get(&PathBuf::from(src_path)).map(|entry| entry.source_name.clone())
+    }
+
+    /// Get metadata for artifacts related to source path
+    pub fn metadata_for_source(&self, path: impl AsRef<Path>) -> Option<(SolcConfig, BTreeMap<PathBuf, String>)> {
+        self.files.get(path.as_ref()).map(|entry| {
+            (entry.solc_config.clone(), entry.artifact_paths.clone())
+        })
     }
 }
 

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -172,7 +172,11 @@ impl SolFilesCache {
             }
 
             // checks whether an artifact this file depends on was removed
-            if entry.artifacts.iter().any(|name| !T::output_exists(file, name, &paths.artifacts, &paths.root)) {
+            if entry
+                .artifacts
+                .iter()
+                .any(|name| !T::output_exists(file, name, &paths.artifacts, &paths.root))
+            {
                 tracing::trace!(
                     "missing linked artifacts for cached artifact \"{}\"",
                     file.display()

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -172,7 +172,7 @@ impl SolFilesCache {
             }
 
             // checks whether an artifact this file depends on was removed
-            if entry.artifacts.iter().any(|name| !T::output_exists(file, name, &paths.artifacts)) {
+            if entry.artifacts.iter().any(|name| !T::output_exists(file, name, &paths.artifacts, &paths.root)) {
                 tracing::trace!(
                     "missing linked artifacts for cached artifact \"{}\"",
                     file.display()
@@ -226,9 +226,9 @@ impl SolFilesCache {
     }
 
     /// Checks if all artifact files exist
-    pub fn all_artifacts_exist<T: ArtifactOutput>(&self, artifacts_root: &Path) -> bool {
+    pub fn all_artifacts_exist<T: ArtifactOutput>(&self, artifacts: &Path, root: &Path) -> bool {
         self.files.iter().all(|(file, entry)| {
-            entry.artifacts.iter().all(|name| T::output_exists(file, name, artifacts_root))
+            entry.artifacts.iter().all(|name| T::output_exists(file, name, artifacts, root))
         })
     }
 

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -236,11 +236,12 @@ impl SolFilesCache {
     pub fn read_artifacts<T: ArtifactOutput>(
         &self,
         artifacts_root: &Path,
+        root: &Path,
     ) -> Result<BTreeMap<PathBuf, T::Artifact>> {
         let mut artifacts = BTreeMap::default();
         for (file, entry) in &self.files {
             for artifact in &entry.artifacts {
-                let artifact_file = artifacts_root.join(T::output_file(file, artifact));
+                let artifact_file = artifacts_root.join(T::output_file(file, artifact, root));
                 let artifact = T::read_cached_artifact(&artifact_file)?;
                 artifacts.insert(artifact_file, artifact);
             }

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -21,7 +21,7 @@ const HH_FORMAT_VERSION: &str = "hh-sol-cache-2";
 /// `ethers-solc` uses a different format version id, but the actual format is consistent with
 /// hardhat This allows ethers-solc to detect if the cache file was written by hardhat or
 /// `ethers-solc`
-const ETHERS_FORMAT_VERSION: &str = "ethers-rs-sol-cache-1";
+const ETHERS_FORMAT_VERSION: &str = "ethers-rs-sol-cache-2";
 
 /// The file name of the default cache file
 pub const SOLIDITY_FILES_CACHE_FILENAME: &str = "solidity-files-cache.json";
@@ -63,7 +63,8 @@ impl SolFilesCache {
 
     /// Whether this cache's format is our custom format identifier
     pub fn is_ethers_format(&self) -> bool {
-        self.format == ETHERS_FORMAT_VERSION // TODO: Should we test prefix here?
+        // TODO: It may be preferable to test prefix here since we've bumped ETHERS_FORMAT_VERSION
+        self.format == ETHERS_FORMAT_VERSION
     }
 
     /// Reads the cache json file from the given path

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -249,6 +249,21 @@ impl SolFilesCache {
         }
         Ok(artifacts)
     }
+
+    /// Get source name for cache entry matching artifact name
+    pub fn source_name_for_artifact(&self, name: &String) -> Option<PathBuf> {
+        for (_, entry) in &self.files {
+            if entry.artifacts.iter().any(|art_name| art_name == name) {
+                return Some(entry.source_name.clone())
+            }
+        }
+        return None
+    }
+
+    /// Get source name for cache entry matching source path
+    pub fn source_name_for_source(&self, src_path: &String) -> Option<PathBuf> {
+        self.files.get(&PathBuf::from(src_path)).map(|entry| entry.source_name.clone())
+    }
 }
 
 // async variants for read and write

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -247,7 +247,7 @@ impl SolFilesCache {
         artifacts_root: &Path,
     ) -> Result<BTreeMap<PathBuf, T::Artifact>> {
         let mut artifacts = BTreeMap::default();
-        for (_, entry) in &self.files {
+        for entry in self.files.values() {
             for artifact in entry.artifact_paths.keys() {
                 let artifact_file = artifacts_root.join(artifact);
                 let artifact = T::read_cached_artifact(&artifact_file)?;
@@ -258,17 +258,17 @@ impl SolFilesCache {
     }
 
     /// Get source name for cache entry matching artifact name
-    pub fn source_name_for_artifact(&self, name: &String) -> Option<PathBuf> {
-        for (_, entry) in &self.files {
+    pub fn source_name_for_artifact(&self, name: &str) -> Option<PathBuf> {
+        for entry in self.files.values() {
             if entry.artifacts.iter().any(|art_name| art_name == name) {
                 return Some(entry.source_name.clone())
             }
         }
-        return None
+        None
     }
 
     /// Get source name for cache entry matching source path
-    pub fn source_name_for_source(&self, src_path: &String) -> Option<PathBuf> {
+    pub fn source_name_for_source(&self, src_path: &str) -> Option<PathBuf> {
         self.files.get(&PathBuf::from(src_path)).map(|entry| entry.source_name.clone())
     }
 

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -56,7 +56,7 @@ impl SolFilesCache {
 
     /// Whether this cache's format is our custom format identifier
     pub fn is_ethers_format(&self) -> bool {
-        self.format == ETHERS_FORMAT_VERSION
+        self.format == ETHERS_FORMAT_VERSION // TODO: Should we test prefix here?
     }
 
     /// Reads the cache json file from the given path
@@ -345,6 +345,7 @@ impl SolFilesCacheBuilder {
                 imports,
                 version_pragmas,
                 artifacts: vec![],
+                artifact_paths: BTreeMap::new(),
             };
             files.insert(file, entry);
         }
@@ -380,6 +381,7 @@ pub struct CacheEntry {
     pub imports: Vec<String>,
     pub version_pragmas: Vec<String>,
     pub artifacts: Vec<String>,
+    pub artifact_paths: BTreeMap<PathBuf, String>,
 }
 
 impl CacheEntry {

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -500,28 +500,6 @@ pub trait ArtifactOutput {
             .unwrap_or_else(|| Self::output_file_name(name))
     }
 
-    // TODO: Rename this
-    // this should output `src/path[/version]/contract.sol/contract.json`
-    // returns `contract.json` by default
-    fn output_file2(
-        source_file: impl AsRef<Path>,
-        version: Option<impl AsRef<str>>,
-        name: impl AsRef<str>,
-        root: impl AsRef<Path>,
-    ) -> PathBuf {
-        let mut path = PathBuf::new();
-        if let Some(src_path) =
-            source_file.as_ref().strip_prefix(root).ok().and_then(|p| p.parent())
-        {
-            path.push(src_path);
-        }
-        if let Some(version) = version {
-            path.push(version.as_ref());
-        }
-        path.push(Self::output_file_name(name));
-        path
-    }
-
     /// The inverse of `contract_file_name`
     ///
     /// Expected to return the solidity contract's name derived from the file path
@@ -578,7 +556,11 @@ pub trait ArtifactOutput {
             .collect()
     }
 
-    /// TODO: doc
+    /// This returns a maybe versioned artifact path, e.g., either
+    /// `Greeter.sol/Greeter.json` or `Greeter.sol/Greeter.version-string-xxxx.json`
+    /// depending on whether or not `version` is passed in. This also retuns
+    /// the same with the relative source path preserved.
+    /// Defaults to `Greeter.json` if there are any errors.
     fn versioned_artifact_path(
         source_path: impl AsRef<Path>,
         version: Option<impl AsRef<str>>,
@@ -601,7 +583,10 @@ pub trait ArtifactOutput {
         (rel_path.join(art_path.clone()), contract_name.join(art_path))
     }
 
-    /// TODO: doc
+    /// This returns a set of maybe versioned artifact path, e.g., either
+    /// `Greeter.sol/Greeter.json` or `Greeter.sol/Greeter.version-string-xxxx.json`
+    /// depending on whether or not multiple versions exist for an artifact.
+    /// Defaults to `Greeter.json` if there are any errors.
     fn versioned_artifact_paths(
         outputs: Vec<(&CompilerOutput, String)>,
         source_dir: impl AsRef<Path>,

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -533,12 +533,10 @@ pub trait ArtifactOutput {
 
     /// Whether the corresponding artifact of the given contract file and name exists
     fn output_exists(
-        contract_file: impl AsRef<Path>,
-        name: impl AsRef<str>,
-        artifacts: impl AsRef<Path>,
-        root: impl AsRef<Path>,
+        artifact: impl AsRef<Path>,
+        artifacts_dir: impl AsRef<Path>
     ) -> bool {
-        artifacts.as_ref().join(Self::output_file(contract_file, name, &root)).exists()
+        artifacts_dir.as_ref().join(artifact).exists()
     }
 
     fn read_cached_artifact(path: impl AsRef<Path>) -> Result<Self::Artifact> {

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -415,7 +415,7 @@ pub trait ArtifactOutput {
 
     /// Returns the path to the contract's artifact location based on the contract's file and name
     ///
-    /// This returns `src/path/contract.sol/contract.json` by default
+    /// This returns `src/path/contract.sol/contract.json` or `contract.json` by default
     fn output_file(
         contract_file: impl AsRef<Path>,
         name: impl AsRef<str>,

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -443,9 +443,10 @@ pub trait ArtifactOutput {
     fn output_exists(
         contract_file: impl AsRef<Path>,
         name: impl AsRef<str>,
+        artifacts: impl AsRef<Path>,
         root: impl AsRef<Path>,
     ) -> bool {
-        root.as_ref().join(Self::output_file(contract_file, name, &root)).exists()
+        artifacts.as_ref().join(Self::output_file(contract_file, name, &root)).exists()
     }
 
     fn read_cached_artifact(path: impl AsRef<Path>) -> Result<Self::Artifact> {

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -18,7 +18,7 @@ use std::{
 };
 
 /// Where to find all files or where to write them
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ProjectPathsConfig {
     /// Project root
     pub root: PathBuf,

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -415,7 +415,7 @@ pub trait ArtifactOutput {
 
     /// Returns the path to the contract's artifact location based on the contract's file and name
     ///
-    /// This returns `/src/path/contract.sol/contract.json` by default
+    /// This returns `src/path/contract.sol/contract.json` by default
     fn output_file(
         contract_file: impl AsRef<Path>,
         name: impl AsRef<str>,

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -631,7 +631,7 @@ pub trait ArtifactOutput {
                         path.clone(),
                         if vers.len() > 1 { Some(ver) } else { None },
                         name,
-                        source_dir.clone(),
+                        source_dir,
                     );
                     ((path.clone(), ver.clone(), name.clone()), art_paths)
                 })

--- a/ethers-solc/src/hh.rs
+++ b/ethers-solc/src/hh.rs
@@ -60,14 +60,15 @@ impl ArtifactOutput for HardhatArtifacts {
         output: &CompilerOutput,
         version: String,
         artifact_paths: ArtifactPaths,
-        layout: &ProjectPathsConfig
+        layout: &ProjectPathsConfig,
     ) -> Result<()> {
         fs::create_dir_all(&layout.artifacts)
             .map_err(|err| SolcError::msg(format!("Failed to create artifacts dir: {}", err)))?;
         for (file, contracts) in output.contracts.iter() {
             for (name, contract) in contracts {
                 // Should be impossible for this get to fail
-                let (_, artifact) = artifact_paths.get(&(file.clone(), version.clone(), name.clone())).unwrap();
+                let (_, artifact) =
+                    artifact_paths.get(&(file.clone(), version.clone(), name.clone())).unwrap();
                 let artifact_file = layout.artifacts.join(artifact);
                 if let Some(parent) = artifact_file.parent() {
                     fs::create_dir_all(parent).map_err(|err| {

--- a/ethers-solc/src/hh.rs
+++ b/ethers-solc/src/hh.rs
@@ -61,7 +61,7 @@ impl ArtifactOutput for HardhatArtifacts {
             .map_err(|err| SolcError::msg(format!("Failed to create artifacts dir: {}", err)))?;
         for (file, contracts) in output.contracts.iter() {
             for (name, contract) in contracts {
-                let artifact = Self::output_file(file, name);
+                let artifact = Self::output_file(file, name, &layout.root);
                 let artifact_file = layout.artifacts.join(artifact);
                 if let Some(parent) = artifact_file.parent() {
                     fs::create_dir_all(parent).map_err(|err| {

--- a/ethers-solc/src/hh.rs
+++ b/ethers-solc/src/hh.rs
@@ -61,7 +61,8 @@ impl ArtifactOutput for HardhatArtifacts {
             .map_err(|err| SolcError::msg(format!("Failed to create artifacts dir: {}", err)))?;
         for (file, contracts) in output.contracts.iter() {
             for (name, contract) in contracts {
-                let artifact = Self::output_file(file, name, &layout.root);
+                let version = contract.metadata.as_ref().map(|m| m.compiler.version.clone());
+                let artifact = Self::output_file2(file, version, name, &layout.root);
                 let artifact_file = layout.artifacts.join(artifact);
                 if let Some(parent) = artifact_file.parent() {
                     fs::create_dir_all(parent).map_err(|err| {

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -876,6 +876,7 @@ impl<T: ArtifactOutput + 'static> ProjectCompileOutput<T> {
     pub fn into_artifacts(mut self) -> Box<dyn Iterator<Item = (String, T::Artifact)>> {
         let artifacts = self.artifacts.into_iter().filter_map(|(path, art)| {
             T::contract_name(&path).map(|name| {
+                println!("A: {:?}", path);
                 (format!("{}:{}", path.file_name().unwrap().to_string_lossy(), name), art)
             })
         });
@@ -885,6 +886,7 @@ impl<T: ArtifactOutput + 'static> ProjectCompileOutput<T> {
         {
             Box::new(artifacts.chain(T::output_to_artifacts(output).into_values().flatten().map(
                 |(name, artifact)| {
+                    println!("B: {:?}", name);
                     (format!("{}:{}", T::output_file_name(&name).display(), name), artifact)
                 },
             )))

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -383,7 +383,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
                 }
 
                 if !self.no_artifacts {
-                    Artifacts::on_output(&output, version, art_paths.clone(), &self.paths)?;
+                    Artifacts::on_output(output, version, art_paths.clone(), &self.paths)?;
                 }
             }
             compiled.extend_output(output.clone());
@@ -964,12 +964,12 @@ impl<T: ArtifactOutput + 'static> ProjectCompileOutput<T> {
     /// let contracts: BTreeMap<String, CompactContract> = project.compile().unwrap().into_artifacts().collect();
     /// ```
     pub fn into_artifacts(mut self) -> Box<dyn Iterator<Item = (String, T::Artifact)>> {
-        let cache = self.cache_path.map(|path| SolFilesCache::read(path).ok()).flatten();
+        let cache = self.cache_path.and_then(|path| SolFilesCache::read(path).ok());
         let mut out_artifacts = Vec::new();
         for (path, art) in self.artifacts {
             if let Some(name) = T::contract_name(&path) {
                 if let Some(src_name) =
-                    cache.clone().map(|cache| cache.source_name_for_artifact(&name)).flatten()
+                    cache.clone().and_then(|cache| cache.source_name_for_artifact(&name))
                 {
                     out_artifacts.push((format!("{}:{}", src_name.display(), name), art))
                 }
@@ -979,7 +979,7 @@ impl<T: ArtifactOutput + 'static> ProjectCompileOutput<T> {
             for (file, artifacts) in T::output_to_artifacts(output) {
                 for (name, artifact) in artifacts {
                     if let Some(src_name) =
-                        cache.clone().map(|cache| cache.source_name_for_source(&file)).flatten()
+                        cache.clone().and_then(|cache| cache.source_name_for_source(&file))
                     {
                         out_artifacts.push((format!("{}:{}", src_name.display(), name), artifact))
                     }

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -373,9 +373,9 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
                         .map(|(file, names)| {
                             let art_paths = names
                                 .iter()
-                                .map(|name| {
+                                .filter_map(|name| {
                                     let f = file.to_string_lossy().into_owned();
-                                    art_paths.get(&(f, version.clone(), name.clone())).unwrap() // TODO: Is this safe? No, it's not
+                                    art_paths.get(&(f, version.clone(), name.clone()))
                                 })
                                 .map(|(_, art_path)| {
                                     (art_path.clone(), version.clone())
@@ -490,16 +490,15 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
         if self.cached {
             // reapply to disk paths
             let sources = paths.set_disk_paths(input.sources);
-            // get all contract names of the files and map them to the disk file
             let artifacts = paths
                 .get_artifacts(&output.contracts)
                 .iter()
                 .map(|(file, names)| {
                     let art_paths = names
                         .iter()
-                        .map(|name| {
+                        .filter_map(|name| {
                             let f = file.to_string_lossy().into_owned();
-                            art_paths.get(&(f, version.clone(), name.clone())).unwrap() // TODO: Is this safe?
+                            art_paths.get(&(f, version.clone(), name.clone()))
                         })
                         .map(|(_, art_path)| {
                             (art_path.clone(), version.clone())

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -101,6 +101,11 @@ impl Project {
 }
 
 impl<Artifacts: ArtifactOutput> Project<Artifacts> {
+    /// Returns the path to the root directory
+    pub fn root_path(&self) -> &PathBuf {
+        &self.paths.root
+    }
+
     /// Returns the path to the artifacts directory
     pub fn artifacts_path(&self) -> &PathBuf {
         &self.paths.artifacts
@@ -469,7 +474,7 @@ impl<Artifacts: ArtifactOutput> Project<Artifacts> {
 
             let cached_artifacts = if self.paths.artifacts.exists() {
                 tracing::trace!("reading artifacts from cache..");
-                let artifacts = cache.read_artifacts::<Artifacts>(&self.paths.artifacts)?;
+                let artifacts = cache.read_artifacts::<Artifacts>(&self.paths.artifacts, &self.paths.root)?;
                 tracing::trace!("read {} artifacts from cache", artifacts.len());
                 artifacts
             } else {


### PR DESCRIPTION
Will address #791 

- [x] Fix downstream issue of ambiguous contract naming
- [x] Handle collision of artifacts compiled with different version
- [x] Add convenience methods so the cache can be queried for artifact compile info (optim. runs, comp. version)
- [ ] ~~Support foundry config file~~

Currently this changes `ProjectCompileOutput::into_artifacts` to return dapptools-style contract names. Example:

`Greet.json:Greet`

becomes:

`src/test/Greeter.t.sol:Greet`

This fixes [this issue](https://github.com/gakonst/foundry/issues/392) w/o any material changes on the foundry side.

Internally this does two main things:

1. Changes how output contract paths are created
2. Preserves relative paths within the artifacts directory

#\2 is to be able to re-map artifact paths to source paths. During compilation, source paths are discarded and since artifacts don't carry metadata, there's no clean way to carry them around. Keeping relative paths in the artifacts dir solves this.

@mattsse let me know if you think #\2 is problematic. The flat structure of the artifacts dir seems unnecessary to me, but I may be missing something.

We could also add compiler versions to paths to avoid the related collision issue.

WIP

