### PR TITLE
fix: derive serde Ser and De for log metadata

### DIFF
--- a/ethers-contract/src/log.rs
+++ b/ethers-contract/src/log.rs
@@ -3,6 +3,7 @@ use ethers_core::{
     abi::{Error, RawLog},
     types::{Address, Log, TxHash, H256, U256, U64},
 };
+use serde::{Deserialize, Serialize};
 
 /// A trait for types (events) that can be decoded from a `RawLog`
 pub trait EthLogDecode: Send + Sync {
@@ -18,7 +19,7 @@ pub fn decode_logs<T: EthLogDecode>(logs: &[RawLog]) -> Result<Vec<T>, Error> {
 }
 
 /// Metadata inside a log
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct LogMeta {
     /// Address from which this log originated
     pub address: Address,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Serde `Serialize` and `Deserialize` was not implemented for `LogMeta`. This means, if one queries events with metadata, they cannot dump a serialized form.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Derive `Serialize` and `Deserialize` for `LogMeta`.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
