### PR TITLE
fix(ws): propagate deserialization errors upstream + infura quickfix

### DIFF
--- a/ethers-providers/src/transports/common.rs
+++ b/ethers-providers/src/transports/common.rs
@@ -39,6 +39,7 @@ pub struct Request<'a, T> {
 #[derive(Serialize, Deserialize, Debug)]
 /// A JSON-RPC Notifcation
 pub struct Notification<R> {
+    #[serde(alias = "JSONRPC")]
     jsonrpc: String,
     method: String,
     pub params: Subscription<R>,

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -310,7 +310,7 @@ where
     async fn handle_text(&mut self, inner: String) -> Result<(), ClientError> {
         match serde_json::from_str::<Incoming>(&inner) {
             Err(err) => {
-                return Err(ClientError::JsonError(err));
+                return Err(ClientError::JsonError(err))
             }
 
             Ok(Incoming::Response(resp)) => {

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -112,7 +112,6 @@ impl Ws {
         S: Send + Sync + Stream<Item = WsStreamItem> + Sink<Message, Error = WsError> + Unpin,
     {
         let (sink, stream) = mpsc::unbounded();
-
         // Spawn the server
         WsServer::new(ws, stream).spawn();
 
@@ -310,7 +309,10 @@ where
 
     async fn handle_text(&mut self, inner: String) -> Result<(), ClientError> {
         match serde_json::from_str::<Incoming>(&inner) {
-            Err(_) => {}
+            Err(err) => {
+                return Err(ClientError::JsonError(err));
+            }
+
             Ok(Incoming::Response(resp)) => {
                 if let Some(request) = self.pending.remove(&resp.id) {
                     if !request.is_canceled() {
@@ -490,5 +492,15 @@ mod tests {
 
         assert_eq!(sub_id, 1.into());
         assert_eq!(blocks, vec![1, 2, 3])
+    }
+
+    #[tokio::test]
+    async fn deserialization_fails() {
+        let ganache = Ganache::new().block_time(1u64).spawn();
+        let (ws, _) = tokio_tungstenite::connect_async(ganache.ws_endpoint()).await.unwrap();
+        let malformed_data = String::from("not a valid message");
+        let (_, stream) = mpsc::unbounded();
+        let resp = WsServer::new(ws, stream).handle_text(malformed_data).await;
+        assert!(resp.is_err(), "Deserialization should not fail silently");
     }
 }

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -309,9 +309,7 @@ where
 
     async fn handle_text(&mut self, inner: String) -> Result<(), ClientError> {
         match serde_json::from_str::<Incoming>(&inner) {
-            Err(err) => {
-                return Err(ClientError::JsonError(err))
-            }
+            Err(err) => return Err(ClientError::JsonError(err)),
 
             Ok(Incoming::Response(resp)) => {
                 if let Some(request) = self.pending.remove(&resp.id) {

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -117,14 +117,14 @@ mod celo_tests {
         let provider =
             Provider::<Http>::try_from("https://alfajores-forno.celo-testnet.org").unwrap();
 
-        let tx_hash = "d3d27aa4517124d9ff3ac6f1d8f248e0fe47b6f841b625722546162672ac24c7"
+        let tx_hash = "a8e1d4b9e245a67fafc7c516ff844c2615cc6419d53560e7f358b124e4ce5e1d"
             .parse::<H256>()
             .unwrap();
         let tx = provider.get_transaction(tx_hash).await.unwrap().unwrap();
         assert!(tx.gateway_fee_recipient.is_none());
         assert_eq!(tx.gateway_fee.unwrap(), 0.into());
         assert_eq!(tx.hash, tx_hash);
-        assert_eq!(tx.block_number.unwrap(), 9401421.into())
+        assert_eq!(tx.block_number.unwrap(), 9534852.into())
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

Deserializing a poorly formatted `Incoming` message over websocket fails silently. This is why #684 was mysteriously failing when using a `wss` provider from Infura. Infura streams back messages with an all capitalized `JSONRPC` field which serde chokes over when deserializing into a `Notification`. 

## Solution

Propagate deserialization errors through `ClientError`.

I think it's fair to support Infura idiosyncrasies considering they're such a prominent provider. With that said, the stable solution is probably using something like `#[serde(case_insensitive)]` (see https://github.com/serde-rs/serde/pull/1902) although this should come with an overhead. In the meantime, this fixes the issue for Infura wss users. 

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
