### PR TITLE
Add authorization for http and websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@
   [640](https://github.com/gakonst/ethers-rs/pull/640)
 
 ### Unreleased
+- Add support for basic and bearer authentication in http and non-wasm websockets.
+  [829](https://github.com/gakonst/ethers-rs/pull/829)
 
 ### 0.5.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,6 +1274,7 @@ version = "0.6.0"
 dependencies = [
  "async-trait",
  "auto_impl",
+ "base64 0.13.0",
  "bytes",
  "ethers-core",
  "futures-channel",
@@ -1281,6 +1282,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hex",
+ "http",
  "parking_lot",
  "pin-project",
  "reqwest",

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -24,6 +24,8 @@ serde_json = { version = "1.0.64", default-features = false }
 thiserror = { version = "1.0.30", default-features = false }
 url = { version = "2.2.2", default-features = false }
 auto_impl = { version = "0.5.0", default-features = false }
+http = { version = "0.2", optional = true }
+base64 = { version = "0.13", optional = true }
 
 # required for implementing stream on the filters
 futures-core = { version = "0.3.16", default-features = false }
@@ -60,7 +62,7 @@ tempfile = "3.3.0"
 [features]
 default = ["ws", "rustls"]
 celo = ["ethers-core/celo"]
-ws = ["tokio", "tokio-tungstenite"]
+ws = ["tokio", "tokio-tungstenite", "http", "base64"]
 ipc = ["tokio", "tokio/io-util", "tokio-util", "bytes"]
 
 openssl = ["tokio-tungstenite/native-tls", "reqwest/native-tls"]

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = { version = "1.0.30", default-features = false }
 url = { version = "2.2.2", default-features = false }
 auto_impl = { version = "0.5.0", default-features = false }
 http = { version = "0.2", optional = true }
-base64 = { version = "0.13", optional = true }
+base64 = "0.13"
 
 # required for implementing stream on the filters
 futures-core = { version = "0.3.16", default-features = false }
@@ -62,7 +62,7 @@ tempfile = "3.3.0"
 [features]
 default = ["ws", "rustls"]
 celo = ["ethers-core/celo"]
-ws = ["tokio", "tokio-tungstenite", "http", "base64"]
+ws = ["tokio", "tokio-tungstenite", "http"]
 ipc = ["tokio", "tokio/io-util", "tokio-util", "bytes"]
 
 openssl = ["tokio-tungstenite/native-tls", "reqwest/native-tls"]

--- a/ethers-providers/src/transports/common.rs
+++ b/ethers-providers/src/transports/common.rs
@@ -112,11 +112,13 @@ impl Authorization {
     pub fn bearer(token: impl Into<String>) -> Self {
         Self::Bearer(token.into())
     }
+}
 
-    pub(crate) fn into_auth_string(self) -> String {
+impl fmt::Display for Authorization {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Authorization::Basic(auth_secret) => format!("Basic {}", auth_secret),
-            Authorization::Bearer(token) => format!("Bearer {}", token),
+            Authorization::Basic(auth_secret) => write!(f, "Basic {}", auth_secret),
+            Authorization::Bearer(token) => write!(f, "Bearer {}", token),
         }
     }
 }

--- a/ethers-providers/src/transports/common.rs
+++ b/ethers-providers/src/transports/common.rs
@@ -2,7 +2,7 @@
 use ethers_core::types::U256;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::fmt;
+use std::{fmt, string::ToString};
 use thiserror::Error;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Error)]
@@ -101,6 +101,16 @@ impl ResponseData<serde_json::Value> {
 pub enum Authorization {
     Basic(String, String),
     Bearer(String),
+}
+
+impl Authorization {
+    pub fn basic(username: impl ToString, password: impl ToString) -> Self {
+        Self::Basic(username.to_string(), password.to_string())
+    }
+
+    pub fn bearer(token: impl ToString) -> Self {
+        Self::Bearer(token.to_string())
+    }
 }
 
 #[cfg(test)]

--- a/ethers-providers/src/transports/common.rs
+++ b/ethers-providers/src/transports/common.rs
@@ -94,6 +94,15 @@ impl ResponseData<serde_json::Value> {
     }
 }
 
+/// Basic or bearer authentication in http or websocket transport
+///
+/// Use to inject username and password or an auth token into requests
+#[derive(Clone, Debug)]
+pub enum Authorization {
+    Basic(String, String),
+    Bearer(String),
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -111,7 +111,7 @@ impl Provider {
         url: impl Into<Url>,
         auth: Authorization,
     ) -> Result<Self, HttpClientError> {
-        let mut auth_value = HeaderValue::from_str(&auth.into_auth_string())?;
+        let mut auth_value = HeaderValue::from_str(&auth.to_string())?;
         auth_value.set_sensitive(true);
 
         let mut headers = reqwest::header::HeaderMap::new();

--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -116,7 +116,7 @@ impl Provider {
     /// use url::Url;
     ///
     /// let url = Url::parse("http://localhost:8545").unwrap();
-    /// let provider = Http::new_with_auth(url, Authorization::Basic("admin".into(), "good_password".into()));
+    /// let provider = Http::new_with_auth(url, Authorization::basic("admin", "good_password"));
     /// ```
     pub fn new_with_auth(url: impl Into<Url>, auth: Authorization) -> Self {
         let mut provider = Self::new(url);

--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -112,11 +112,11 @@ impl Provider {
     /// # Example
     ///
     /// ```
-    /// use ethers_providers::{Http, Auth};
+    /// use ethers_providers::{Authorization, Http};
     /// use url::Url;
     ///
     /// let url = Url::parse("http://localhost:8545").unwrap();
-    /// let provider = Http::new_with_auth(url, Auth::Basic("admin", "good_password"));
+    /// let provider = Http::new_with_auth(url, Authorization::Basic("admin".into(), "good_password".into()));
     /// ```
     pub fn new_with_auth(url: impl Into<Url>, auth: Authorization) -> Self {
         let mut provider = Self::new(url);

--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -116,7 +116,7 @@ impl Provider {
     /// use url::Url;
     ///
     /// let url = Url::parse("http://localhost:8545").unwrap();
-    /// let provider = Http::new(url, Auth::Basic("admin", "good_password"));
+    /// let provider = Http::new_with_auth(url, Auth::Basic("admin", "good_password"));
     /// ```
     pub fn new_with_auth(url: impl Into<Url>, auth: Authorization) -> Self {
         let mut provider = Self::new(url);

--- a/ethers-providers/src/transports/mod.rs
+++ b/ethers-providers/src/transports/mod.rs
@@ -1,4 +1,5 @@
 mod common;
+pub use common::Authorization;
 
 // only used with WS
 #[cfg(feature = "ws")]
@@ -24,7 +25,7 @@ mod ipc;
 pub use ipc::Ipc;
 
 mod http;
-pub use http::{ClientError as HttpClientError, Provider as Http};
+pub use self::http::{ClientError as HttpClientError, Provider as Http};
 
 #[cfg(feature = "ws")]
 mod ws;

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use ethers_core::types::U256;
 
-use super::Authorization;
 use async_trait::async_trait;
 use futures_channel::{mpsc, oneshot};
 use futures_util::{
@@ -60,6 +59,7 @@ if_not_wasm! {
     type Message = tungstenite::protocol::Message;
     type WsError = tungstenite::Error;
     type WsStreamItem = Result<Message, WsError>;
+    use super::Authorization;
     use tracing::{debug, error, warn};
     use http::Request as HttpRequest;
     use http::Uri;

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -152,15 +152,11 @@ impl Ws {
     ) -> Result<Self, ClientError> {
         let mut request: HttpRequest<()> =
             HttpRequest::builder().method("GET").uri(Uri::from_str(uri.as_ref())?).body(())?;
-        let auth_header = match auth {
-            Authorization::Basic(username, password) => {
-                String::from("Basic ") + base64::encode(username + ":" + &password).as_str()
-            }
-            Authorization::Bearer(token) => String::from("Bearer ") + &token,
-        };
-        request
-            .headers_mut()
-            .insert(http::header::AUTHORIZATION, http::HeaderValue::from_str(&auth_header)?);
+
+        let mut auth_value = http::HeaderValue::from_str(&auth.into_auth_string())?;
+        auth_value.set_sensitive(true);
+
+        request.headers_mut().insert(http::header::AUTHORIZATION, auth_value);
         Self::connect(request).await
     }
 

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -153,7 +153,7 @@ impl Ws {
         let mut request: HttpRequest<()> =
             HttpRequest::builder().method("GET").uri(Uri::from_str(uri.as_ref())?).body(())?;
 
-        let mut auth_value = http::HeaderValue::from_str(&auth.into_auth_string())?;
+        let mut auth_value = http::HeaderValue::from_str(&auth.to_string())?;
         auth_value.set_sensitive(true);
 
         request.headers_mut().insert(http::header::AUTHORIZATION, auth_value);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->
## Summary
This pull request adds basic and bearer authentication for http and non-wasm websockets transport.

## Motivation
Some people operate their node behind a reverse-proxy which uses some form of authentication. This pull request makes it possible to use ethers-rs  in this case.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
The solution is to inject auth headers into http requests and the websocket handshake request.

## PR Checklist

- [ ] Added Tests (Is that necessary in this, case? If yes, how would you do that?
- [x] Added Documentation
- [x] Updated the changelog
