### PR TITLE
feat(chain): add BSC and BSC testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Unreleased
 
+- Add BSC mainnet and testnet to the list of known chains
+  [831](https://github.com/gakonst/ethers-rs/pull/831)
 - Returns error on invalid type conversion instead of panicking
   [691](https://github.com/gakonst/ethers-rs/pull/691/files)
 - Change types mapping for solidity `bytes` to rust `ethers::core::Bytes` and

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -32,6 +32,8 @@ pub enum Chain {
     Moonriver = 1285,
     Optimism = 10,
     OptimismKovan = 69,
+    BinanceSmartChain = 56,
+    BinanceSmartChainTestnet = 97,
 }
 
 impl fmt::Display for Chain {
@@ -79,6 +81,8 @@ impl TryFrom<u64> for Chain {
             1285 => Chain::Moonriver,
             10 => Chain::Optimism,
             69 => Chain::OptimismKovan,
+            56 => Chain::BinanceSmartChain,
+            97 => Chain::BinanceSmartChainTestnet,
             _ => return Err(ParseChainError(chain.to_string())),
         })
     }
@@ -106,6 +110,8 @@ impl FromStr for Chain {
             "optimism-kovan" => Chain::OptimismKovan,
             "fantom" => Chain::Fantom,
             "fantom-testnet" => Chain::FantomTestnet,
+            "bsc" => Chain::BinanceSmartChain,
+            "bsc-testnet" => Chain::BinanceSmartChainTestnet,
             _ => return Err(ParseChainError(chain.to_owned())),
         })
     }

--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -73,6 +73,13 @@ impl Client {
                 Url::parse("https://api-testnet.ftmscan.com"),
                 Url::parse("https://testnet.ftmscan.com"),
             ),
+            Chain::BinanceSmartChain => {
+                (Url::parse("https://api.bscscan.com/api"), Url::parse("https://bscscan.com"))
+            }
+            Chain::BinanceSmartChainTestnet => (
+                Url::parse("https://api-testnet.bscscan.com/api"),
+                Url::parse("https://testnet.bscscan.com"),
+            ),
             chain => return Err(EtherscanError::ChainNotSupported(chain)),
         };
 
@@ -90,15 +97,17 @@ impl Client {
         let api_key = match chain {
             Chain::Avalanche | Chain::AvalancheFuji => std::env::var("SNOWTRACE_API_KEY")?,
             Chain::Polygon | Chain::PolygonMumbai => std::env::var("POLYGONSCAN_API_KEY")?,
-            Chain::Mainnet |
-            Chain::Ropsten |
-            Chain::Kovan |
-            Chain::Rinkeby |
-            Chain::Goerli |
-            Chain::Optimism |
-            Chain::OptimismKovan |
-            Chain::Fantom |
-            Chain::FantomTestnet => std::env::var("ETHERSCAN_API_KEY")?,
+            Chain::Mainnet
+            | Chain::Ropsten
+            | Chain::Kovan
+            | Chain::Rinkeby
+            | Chain::Goerli
+            | Chain::Optimism
+            | Chain::OptimismKovan
+            | Chain::Fantom
+            | Chain::FantomTestnet
+            | Chain::BinanceSmartChain
+            | Chain::BinanceSmartChainTestnet => std::env::var("ETHERSCAN_API_KEY")?,
 
             Chain::XDai | Chain::Sepolia => String::default(),
             Chain::Moonbeam | Chain::MoonbeamDev | Chain::Moonriver => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
As noted in gakonst/foundry#579, BSC mainnet and testnet are missing from the list of networks that do not support EIP-1559 yet. Thus, sending transactions to those networks using [`cast`](https://github.com/gakonst/foundry/tree/master/cast) fails because currently [`Eip1559TransactionRequest` is used to create and submit transactions.](https://github.com/gakonst/foundry/blob/9de25d1928da362cd3b185ebaccc0e3d00aee2c8/cast/src/lib.rs#L234)
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Add BinanceSmartChain and BinanceSmartChainTestnet to the `Chain` enum in ethers-core types.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
