### PR TITLE
write `CompactContractBytecode` instead of `CompactContract`

### DIFF
--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -1,5 +1,5 @@
 use crate::{
-    artifacts::{CompactContract, CompactContractRef, Contract, Settings},
+    artifacts::{CompactContract, CompactContractBytecode, Contract, Settings},
     cache::SOLIDITY_FILES_CACHE_FILENAME,
     error::{Result, SolcError, SolcIoError},
     hh::HardhatArtifact,
@@ -448,20 +448,30 @@ pub trait Artifact {
     /// Returns the artifact's `Abi` and bytecode
     fn into_inner(self) -> (Option<Abi>, Option<Bytes>);
 
-    /// Turns the artifact into a container type for abi, bytecode and deployed bytecode
+    /// Turns the artifact into a container type for abi, compact bytecode and deployed bytecode
     fn into_compact_contract(self) -> CompactContract;
+
+    /// Turns the artifact into a container type for abi, full bytecode and deployed bytecode
+    fn into_contract_bytecode(self) -> CompactContractBytecode;
 
     /// Returns the contents of this type as a single tuple of abi, bytecode and deployed bytecode
     fn into_parts(self) -> (Option<Abi>, Option<Bytes>, Option<Bytes>);
 }
 
-impl<T: Into<CompactContract>> Artifact for T {
+impl<T> Artifact for T
+where
+    T: Into<CompactContractBytecode> + Into<CompactContract>,
+{
     fn into_inner(self) -> (Option<Abi>, Option<Bytes>) {
         let artifact = self.into_compact_contract();
         (artifact.abi, artifact.bin.and_then(|bin| bin.into_bytes()))
     }
 
     fn into_compact_contract(self) -> CompactContract {
+        self.into()
+    }
+
+    fn into_contract_bytecode(self) -> CompactContractBytecode {
         self.into()
     }
 
@@ -570,7 +580,7 @@ pub trait ArtifactOutput {
 pub struct MinimalCombinedArtifacts;
 
 impl ArtifactOutput for MinimalCombinedArtifacts {
-    type Artifact = CompactContract;
+    type Artifact = CompactContractBytecode;
 
     fn on_output(output: &CompilerOutput, layout: &ProjectPathsConfig) -> Result<()> {
         fs::create_dir_all(&layout.artifacts)
@@ -588,7 +598,7 @@ impl ArtifactOutput for MinimalCombinedArtifacts {
                         ))
                     })?;
                 }
-                let min = CompactContractRef::from(contract);
+                let min = CompactContractBytecode::from(contract.clone());
                 fs::write(&file, serde_json::to_vec_pretty(&min)?)
                     .map_err(|err| SolcError::io(err, file))?
             }
@@ -607,7 +617,7 @@ impl ArtifactOutput for MinimalCombinedArtifacts {
 pub struct MinimalCombinedArtifactsHardhatFallback;
 
 impl ArtifactOutput for MinimalCombinedArtifactsHardhatFallback {
-    type Artifact = CompactContract;
+    type Artifact = CompactContractBytecode;
 
     fn on_output(output: &CompilerOutput, layout: &ProjectPathsConfig) -> Result<()> {
         MinimalCombinedArtifacts::on_output(output, layout)
@@ -623,7 +633,7 @@ impl ArtifactOutput for MinimalCombinedArtifactsHardhatFallback {
             tracing::trace!("Fallback to hardhat artifact deserialization");
             let artifact = serde_json::from_str::<HardhatArtifact>(&content)?;
             tracing::trace!("successfully deserialized hardhat artifact");
-            Ok(artifact.into_compact_contract())
+            Ok(artifact.into_contract_bytecode())
         }
     }
 

--- a/ethers-solc/src/hh.rs
+++ b/ethers-solc/src/hh.rs
@@ -1,7 +1,10 @@
 //! Hardhat support
 
 use crate::{
-    artifacts::{BytecodeObject, CompactContract, Contract, Offsets},
+    artifacts::{
+        Bytecode, BytecodeObject, CompactContract, CompactContractBytecode, Contract,
+        ContractBytecode, DeployedBytecode, Offsets,
+    },
     error::{Result, SolcError},
     ArtifactOutput, CompilerOutput, ProjectPathsConfig,
 };
@@ -46,6 +49,32 @@ impl From<HardhatArtifact> for CompactContract {
             bin: artifact.bytecode,
             bin_runtime: artifact.deployed_bytecode,
         }
+    }
+}
+
+impl From<HardhatArtifact> for ContractBytecode {
+    fn from(artifact: HardhatArtifact) -> Self {
+        let bytecode: Option<Bytecode> = artifact.bytecode.as_ref().map(|t| {
+            let mut bcode: Bytecode = t.clone().into();
+            bcode.link_references = artifact.link_references.clone();
+            bcode
+        });
+
+        let deployed_bytecode: Option<DeployedBytecode> = artifact.bytecode.as_ref().map(|t| {
+            let mut bcode: Bytecode = t.clone().into();
+            bcode.link_references = artifact.deployed_link_references.clone();
+            bcode.into()
+        });
+
+        ContractBytecode { abi: Some(artifact.abi), bytecode, deployed_bytecode }
+    }
+}
+
+impl From<HardhatArtifact> for CompactContractBytecode {
+    fn from(artifact: HardhatArtifact) -> Self {
+        let c: ContractBytecode = artifact.into();
+
+        c.into()
     }
 }
 

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -918,11 +918,11 @@ impl<T: ArtifactOutput + 'static> ProjectCompileOutput<T> {
     ///
     /// ```no_run
     /// use std::collections::BTreeMap;
-    /// use ethers_solc::artifacts::CompactContract;
+    /// use ethers_solc::artifacts::CompactContractBytecode;
     /// use ethers_solc::Project;
     ///
     /// let project = Project::builder().build().unwrap();
-    /// let contracts: BTreeMap<String, CompactContract> = project.compile().unwrap().into_artifacts().collect();
+    /// let contracts: BTreeMap<String, CompactContractBytecode> = project.compile().unwrap().into_artifacts().collect();
     /// ```
     pub fn into_artifacts(mut self) -> Box<dyn Iterator<Item = (String, T::Artifact)>> {
         let artifacts = self.artifacts.into_iter().filter_map(|(path, art)| {


### PR DESCRIPTION
## Motivation
The existing `CompactContract` doesn't have enough information for our needs in foundry. So we write out `CompactContractBytecode` instead which is a slightly stripped down version of `ContractBytecode`. The reason to strip it down is because we lose a decent amount of performance if we write all the other things in `ContractBytecode`. This is a compromise between speed and the needed information.

## Solution

Write `CompactContractBytecode` instead of `CompactContract`

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
