### PR TITLE
fix: change versions to compile for worker-rs, wasm target

### DIFF
--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -36,9 +36,9 @@ cargo_metadata = { version = "0.14.1", optional = true }
 
 # eip712 feature enabled dependencies
 convert_case = { version = "0.5.0", optional = true }
-syn = { version = "1.0.86", optional = true }
-quote = { version = "1.0.15", optional = true }
-proc-macro2 = { version = "1.0.36", optional = true }
+syn = { version = "1.0.75", optional = true }
+quote = { version = "1.0.9", optional = true }
+proc-macro2 = { version = "1.0.29", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # async

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -20,7 +20,7 @@ ethers-etherscan = { version = "^0.2.0", path = "../ethers-etherscan", default-f
 ethers-providers = { version = "^0.6.0", path = "../ethers-providers", default-features = false }
 ethers-signers = { version = "^0.6.0", path = "../ethers-signers", default-features = false }
 
-async-trait = { version = "0.1.50", default-features = false }
+async-trait = { version = "0.1.51", default-features = false }
 serde = { version = "1.0.124", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30", default-features = false }
 futures-util = { version = "^0.3" }

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 ethers-core = { version = "^0.6.0", path = "../ethers-core", default-features = false }
 
-async-trait = { version = "0.1.50", default-features = false }
+async-trait = { version = "0.1.51", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 reqwest = { version = "0.11.9", default-features = false, features = ["json"] }
 serde = { version = "1.0.124", default-features = false, features = ["derive"] }

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -20,7 +20,7 @@ coins-bip32 = "0.6.0"
 coins-bip39 = "0.6.0"
 coins-ledger = { version = "0.6.0", default-features = false, optional = true }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
-async-trait = { version = "0.1.50", default-features = false }
+async-trait = { version = "0.1.51", default-features = false }
 elliptic-curve = { version = "0.11.9", default-features = false }
 sha2 = { version = "0.9.8", default-features = false }
 rand = { version = "0.8.4", default-features = false }

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["ethereum", "web3", "solc", "solidity", "ethers"]
 
 [dependencies]
 ethers-core = { version = "^0.6.0", path = "../ethers-core", default-features = false }
-serde_json = "1.0.68"
+serde_json = "1.0.67"
 serde = { version = "1.0.130", features = ["derive"] }
 semver = "1.0.4"
 walkdir = "2.3.2"


### PR DESCRIPTION
This pr has 2 changes:
- Update async-trait to latest version
- Fix dependency errors that I got with WASM target (used in Cloudflare workers)
- Used in https://github.com/odyslam/ethsig-rs
```bash
Error: Error during execution of `cargo metadata`:     Blocking waiting for file lock on package cache
    Updating git repository `https://github.com/gakonst/ethers-rs`
    Updating crates.io index
error: failed to select a version for `proc-macro2`.
    ... required by package `ethers-core v0.6.0 (https://github.com/gakonst/ethers-rs#80e1b4f0)`
    ... which satisfies git dependency `ethers-core` of package `ethers v0.6.0 (https://github.com/gakonst/ethers-rs#80e1b4f0)`
    ... which satisfies git dependency `ethers` of package `workstreams-api v0.1.0 (/Users/odys/code/radicle/ws-api)`
versions that meet the requirements `^1.0.36` are: 1.0.36

all possible versions conflict with previously selected packages.

  previously selected package `proc-macro2 v1.0.29`
    ... which satisfies dependency `proc-macro2 = "=1.0.29"` of package `async-trait v0.1.51`
    ... which satisfies dependency `async-trait = "=0.1.51"` of package `ethers-middleware v0.6.0 (https://github.com/gakonst/ethers-rs#80e1b4f0)`
    ... which satisfies git dependency `ethers-middleware` of package `ethers v0.6.0 (https://github.com/gakonst/ethers-rs#80e1b4f0)`
    ... which satisfies git dependency `ethers` of package `workstreams-api v0.1.0 (/Users/odys/code/radicle/ws-api)`

failed to select a version for `proc-macro2` which could resolve this conflict

Error: wasm-pack exited with status exit status: 1
Error: Build failed! Status Code: 1
```