### PR TITLE
feat(types/chain): is_legacy helper

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -110,3 +110,15 @@ impl FromStr for Chain {
         })
     }
 }
+
+impl Chain {
+    /// Helper function for checking if a chainid corresponds to a legacy chainid
+    /// without eip1559
+    pub fn is_legacy(&self) -> bool {
+        // TODO: Add other chains which do not support EIP1559.
+        matches!(
+            self,
+            Chain::Optimism | Chain::OptimismKovan | Chain::Fantom | Chain::FantomTestnet
+        )
+    }
+}


### PR DESCRIPTION
moving this into ethers-rs from foundry so it can be more easily use elsewhere
