### PR TITLE
core: fix overflow and panic in priority fee estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Fix overflow and possible divide-by-zero in `estimate_priority_fee`
 - Add BSC mainnet and testnet to the list of known chains
   [831](https://github.com/gakonst/ethers-rs/pull/831)
 - Returns error on invalid type conversion instead of panicking


### PR DESCRIPTION
The U256 priority fees were being coerced into u32, which was not big
enough for actual values. The overflow was happening but not checked.
This led to a possible divide-by-zero panic in this code as well.

This change does the math as I256 -- overkill, but it works.

## Motivation

This is a simple bug fix for the issue described above, which could lead in some 
cases to somewhat incorrect gas estimation and the occasional panic.

## Solution

The fix just uses I256 math instead.

## PR Checklist

- [ x] Added Tests
- [ x] Added Documentation
- [ x] Updated the changelog
