### PR TITLE
Add pub fn initialize_nonce in NonceMiddleManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@
   [#568](https://github.com/gakonst/ethers-rs/pull/568)
 - Removes GasNow as a gas price oracle
   [#508](https://github.com/gakonst/ethers-rs/pull/508)
+- add initialize_nonce public function to initialize NonceMiddleManager
 
 ### 0.5.3
 


### PR DESCRIPTION
Initialize the nonce manager with the current nonce


## Motivation

The nonce middleManager initializes with nonce 0.
Restarting the built application with ethers-rs, will set it back to 0, the next time the application sends a transaction, it will first pull the nonce, which results in an unnecessary call.

## Solution

Added a public function to initialize the nonce, so it can be loaded before a transaction is submitted.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
