### PR TITLE
feat(chain): add BSC networks to the is_legacy helper

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -124,7 +124,12 @@ impl Chain {
         // TODO: Add other chains which do not support EIP1559.
         matches!(
             self,
-            Chain::Optimism | Chain::OptimismKovan | Chain::Fantom | Chain::FantomTestnet
+            Chain::Optimism |
+                Chain::OptimismKovan |
+                Chain::Fantom |
+                Chain::FantomTestnet |
+                Chain::BinanceSmartChain |
+                Chain::BinanceSmartChainTestnet
         )
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
BSC networks are a part of the Chain, but were still not used on the `is_legacy`
method.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add the BSC networks to the `is_legacy` Chain method.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
