### PR TITLE
[WIP] Forge middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +319,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "borsh"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dda7dc709193c0d86a1a51050a926dc3df1cf262ec46a23a25dba421ea1924"
+dependencies = [
+ "borsh-derive",
+ "hashbrown 0.9.1",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684155372435f578c0fa1acd13ebbb182cc19d6b38b64ae7901da4393217d264"
+dependencies = [
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "borsh-derive-internal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2102f62f8b6d3edeab871830782285b64cc1830168094db05c8e458f209bc5c3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196c978c4c9b0b142d446ef3240690bf5a8a33497074a113ff9a337ccb750483"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,7 +580,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2 0.9.9",
- "sha3",
+ "sha3 0.9.1",
  "thiserror",
 ]
 
@@ -870,6 +921,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1089,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "environmental"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
+
+[[package]]
 name = "eth-keystore"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,7 +1111,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.9.9",
- "sha3",
+ "sha3 0.9.1",
  "thiserror",
  "uuid",
 ]
@@ -1059,7 +1127,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.9.1",
  "thiserror",
  "uint",
 ]
@@ -1072,9 +1140,30 @@ checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
 dependencies = [
  "crunchy",
  "fixed-hash",
+ "impl-codec",
  "impl-rlp",
  "impl-serde",
+ "scale-info",
  "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34c90e0a755da706ce0970ec0fa8cc48aabcc8e8efa1245336acf718dab06ffe"
+dependencies = [
+ "bytes",
+ "ethereum-types",
+ "hash-db",
+ "hash256-std-hasher",
+ "parity-scale-codec",
+ "rlp",
+ "rlp-derive",
+ "scale-info",
+ "serde",
+ "sha3 0.9.1",
+ "triehash",
 ]
 
 [[package]]
@@ -1085,9 +1174,11 @@ checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
 dependencies = [
  "ethbloom",
  "fixed-hash",
+ "impl-codec",
  "impl-rlp",
  "impl-serde",
  "primitive-types",
+ "scale-info",
  "uint",
 ]
 
@@ -1097,19 +1188,34 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "bytes",
- "ethers-addressbook",
- "ethers-contract",
+ "ethers-addressbook 0.1.0",
+ "ethers-contract 0.6.0",
  "ethers-core",
- "ethers-etherscan",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
- "ethers-solc",
+ "ethers-etherscan 0.2.0",
+ "ethers-middleware 0.6.0",
+ "ethers-providers 0.6.0",
+ "ethers-signers 0.6.0",
+ "ethers-solc 0.1.0",
  "hex",
  "rand 0.8.4",
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "ethers"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#78dfd7591d03f1ab031de7c5878e60b7df918c0e"
+dependencies = [
+ "ethers-addressbook 0.1.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core",
+ "ethers-etherscan 0.2.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-middleware 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-signers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-solc 0.1.0 (git+https://github.com/gakonst/ethers-rs)",
 ]
 
 [[package]]
@@ -1123,17 +1229,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-addressbook"
+version = "0.1.0"
+source = "git+https://github.com/gakonst/ethers-rs#78dfd7591d03f1ab031de7c5878e60b7df918c0e"
+dependencies = [
+ "ethers-core",
+ "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ethers-contract"
 version = "0.6.0"
 dependencies = [
- "ethers-contract-abigen",
- "ethers-contract-derive",
+ "ethers-contract-abigen 0.6.0",
+ "ethers-contract-derive 0.6.0",
  "ethers-core",
  "ethers-derive-eip712",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
- "ethers-solc",
+ "ethers-middleware 0.6.0",
+ "ethers-providers 0.6.0",
+ "ethers-signers 0.6.0",
+ "ethers-solc 0.1.0",
  "futures-util",
  "hex",
  "once_cell",
@@ -1142,6 +1259,24 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "ethers-contract"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#80e1b4f0790e01e2685e0cedf3ef21d38a336be0"
+dependencies = [
+ "ethers-contract-abigen 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-derive 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core",
+ "ethers-providers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "futures-util",
+ "hex",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1168,10 +1303,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-contract-abigen"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#80e1b4f0790e01e2685e0cedf3ef21d38a336be0"
+dependencies = [
+ "Inflector",
+ "anyhow",
+ "cfg-if 1.0.0",
+ "dunce",
+ "ethers-core",
+ "getrandom 0.2.4",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "syn",
+ "url",
+ "walkdir",
+]
+
+[[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
 dependencies = [
- "ethers-contract-abigen",
+ "ethers-contract-abigen 0.6.0",
+ "ethers-core",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "ethers-contract-derive"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#80e1b4f0790e01e2685e0cedf3ef21d38a336be0"
+dependencies = [
+ "ethers-contract-abigen 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
  "ethers-core",
  "hex",
  "proc-macro2",
@@ -1215,10 +1387,10 @@ dependencies = [
 name = "ethers-derive-eip712"
 version = "0.2.0"
 dependencies = [
- "ethers-contract",
- "ethers-contract-derive",
+ "ethers-contract 0.6.0",
+ "ethers-contract-derive 0.6.0",
  "ethers-core",
- "ethers-signers",
+ "ethers-signers 0.6.0",
  "hex",
  "proc-macro2",
  "quote",
@@ -1242,16 +1414,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-etherscan"
+version = "0.2.0"
+source = "git+https://github.com/gakonst/ethers-rs#78dfd7591d03f1ab031de7c5878e60b7df918c0e"
+dependencies = [
+ "ethers-core",
+ "reqwest",
+ "serde",
+ "serde-aux",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "ethers-middleware"
 version = "0.6.0"
 dependencies = [
  "async-trait",
- "ethers-contract",
+ "ethers-contract 0.6.0",
  "ethers-core",
- "ethers-etherscan",
- "ethers-providers",
- "ethers-signers",
- "ethers-solc",
+ "ethers-etherscan 0.2.0",
+ "ethers-providers 0.6.0",
+ "ethers-signers 0.6.0",
+ "ethers-solc 0.1.0",
+ "evm",
+ "evm-adapters",
  "futures-util",
  "hex",
  "instant",
@@ -1261,6 +1448,29 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "ethers-middleware"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#78dfd7591d03f1ab031de7c5878e60b7df918c0e"
+dependencies = [
+ "async-trait",
+ "ethers-contract 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core",
+ "ethers-etherscan 0.2.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-providers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-signers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "futures-util",
+ "instant",
+ "reqwest",
+ "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",
@@ -1302,6 +1512,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-providers"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#80e1b4f0790e01e2685e0cedf3ef21d38a336be0"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "ethers-core",
+ "futures-channel",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "hex",
+ "parking_lot",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-timer",
+ "web-sys",
+ "ws_stream_wasm",
+]
+
+[[package]]
 name = "ethers-signers"
 version = "0.6.0"
 dependencies = [
@@ -1311,7 +1550,7 @@ dependencies = [
  "coins-ledger",
  "elliptic-curve",
  "eth-keystore",
- "ethers-contract",
+ "ethers-contract 0.6.0",
  "ethers-core",
  "ethers-derive-eip712",
  "futures-executor",
@@ -1333,6 +1572,27 @@ dependencies = [
  "tracing-subscriber",
  "trezor-client",
  "yubihsm",
+]
+
+[[package]]
+name = "ethers-signers"
+version = "0.6.0"
+source = "git+https://github.com/gakonst/ethers-rs#78dfd7591d03f1ab031de7c5878e60b7df918c0e"
+dependencies = [
+ "async-trait",
+ "coins-bip32",
+ "coins-bip39",
+ "elliptic-curve",
+ "eth-keystore",
+ "ethers-core",
+ "futures-executor",
+ "futures-util",
+ "hex",
+ "home",
+ "rand 0.8.4",
+ "semver",
+ "sha2 0.9.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -1370,11 +1630,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-solc"
+version = "0.1.0"
+source = "git+https://github.com/gakonst/ethers-rs#78dfd7591d03f1ab031de7c5878e60b7df918c0e"
+dependencies = [
+ "colored",
+ "dunce",
+ "ethers-core",
+ "futures-util",
+ "getrandom 0.2.4",
+ "glob",
+ "hex",
+ "home",
+ "md-5 0.10.0",
+ "num_cpus",
+ "once_cell",
+ "rayon",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2 0.9.9",
+ "solang-parser",
+ "svm-rs",
+ "thiserror",
+ "tiny-keccak",
+ "tokio",
+ "tracing",
+ "walkdir",
+]
+
+[[package]]
 name = "ethers-wasm"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
- "ethers",
+ "ethers 0.6.0",
  "hex",
  "serde",
  "serde_derive",
@@ -1384,6 +1675,97 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
  "wee_alloc",
+]
+
+[[package]]
+name = "evm"
+version = "0.33.1"
+source = "git+https://github.com/rust-blockchain/evm#78c49debfc65ddf3c0635edd02045a937dcc15d5"
+dependencies = [
+ "auto_impl",
+ "environmental",
+ "ethereum",
+ "evm-core",
+ "evm-gasometer",
+ "evm-runtime",
+ "log",
+ "parity-scale-codec",
+ "primitive-types",
+ "rlp",
+ "scale-info",
+ "serde",
+ "sha3 0.8.2",
+]
+
+[[package]]
+name = "evm-adapters"
+version = "0.1.0"
+dependencies = [
+ "ansi_term",
+ "bytes",
+ "ethers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core",
+ "ethers-providers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "evm",
+ "eyre",
+ "foundry-utils",
+ "futures",
+ "hex",
+ "once_cell",
+ "parking_lot",
+ "proptest",
+ "revm_precompiles",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "evm-core"
+version = "0.33.0"
+source = "git+https://github.com/rust-blockchain/evm#78c49debfc65ddf3c0635edd02045a937dcc15d5"
+dependencies = [
+ "funty",
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-info",
+ "serde",
+]
+
+[[package]]
+name = "evm-gasometer"
+version = "0.33.0"
+source = "git+https://github.com/rust-blockchain/evm#78c49debfc65ddf3c0635edd02045a937dcc15d5"
+dependencies = [
+ "environmental",
+ "evm-core",
+ "evm-runtime",
+ "primitive-types",
+]
+
+[[package]]
+name = "evm-runtime"
+version = "0.33.0"
+source = "git+https://github.com/rust-blockchain/evm#78c49debfc65ddf3c0635edd02045a937dcc15d5"
+dependencies = [
+ "auto_impl",
+ "environmental",
+ "evm-core",
+ "primitive-types",
+ "sha3 0.8.2",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc225d8f637923fe585089fcf03e705c222131232d2c1fb622e84ecf725d0eb8"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -1458,6 +1840,22 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "foundry-utils"
+version = "0.1.0"
+dependencies = [
+ "ethers-addressbook 0.1.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core",
+ "ethers-etherscan 0.2.0 (git+https://github.com/gakonst/ethers-rs)",
+ "eyre",
+ "hex",
+ "reqwest",
+ "rustc-hex",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -1651,6 +2049,30 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hash-db"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
+
+[[package]]
+name = "hash256-std-hasher"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c171d55b98633f4ed3860808f004099b36c1cc29c42cfc53aa8591b21efcf2"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1853,13 +2275,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1933,7 +2361,7 @@ dependencies = [
  "elliptic-curve",
  "sec1",
  "sha2 0.9.9",
- "sha3",
+ "sha3 0.9.1",
 ]
 
 [[package]]
@@ -1979,6 +2407,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -2138,6 +2569,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,12 +2594,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2304,7 +2769,7 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2564,7 +3029,17 @@ dependencies = [
  "impl-codec",
  "impl-rlp",
  "impl-serde",
+ "scale-info",
  "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
 ]
 
 [[package]]
@@ -2617,10 +3092,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.4",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47c327e191621a2158159df97cdbc2e7074bb4e940275e35abf38eb3d2595754"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -2720,6 +3227,15 @@ name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.3",
 ]
@@ -2842,6 +3358,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm_precompiles"
+version = "0.4.0"
+source = "git+https://github.com/bluealloy/revm#1a5b05d033bddb0e540d505846fe0df61f8484bb"
+dependencies = [
+ "borsh",
+ "bytes",
+ "k256",
+ "num",
+ "primitive-types",
+ "ripemd",
+ "sha2 0.10.1",
+ "sha3 0.10.0",
+ "substrate-bn",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2865,6 +3397,15 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea54b64a1a8410c48395c154adadbad7e1bcd02debca79fc3694386cf73e5799"
+dependencies = [
+ "digest 0.10.1",
 ]
 
 [[package]]
@@ -3035,6 +3576,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,6 +3609,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scale-info"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55b744399c25532d63a0d2789b109df8d46fc93752d46b0782991a931a782f"
+dependencies = [
+ "bitvec 0.20.4",
+ "cfg-if 1.0.0",
+ "derive_more",
+ "parity-scale-codec",
+ "scale-info-derive",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
+dependencies = [
+ "proc-macro-crate 1.1.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3280,12 +3858,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.1",
+]
+
+[[package]]
 name = "sha2-asm"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf27176fb5d15398e3a479c652c20459d9dac830dedd1fa55b42a77dbcdbfcea"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "sha3"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
+dependencies = [
+ "block-buffer 0.7.3",
+ "byte-tools",
+ "digest 0.8.1",
+ "keccak",
+ "opaque-debug 0.2.3",
 ]
 
 [[package]]
@@ -3298,6 +3900,16 @@ dependencies = [
  "digest 0.9.0",
  "keccak",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f935e31cf406e8c0e96c2815a5516181b7004ae8c5f296293221e9b1e356bd"
+dependencies = [
+ "digest 0.10.1",
+ "keccak",
 ]
 
 [[package]]
@@ -3446,6 +4058,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.4",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -3808,6 +4433,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "triehash"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1631b201eb031b563d2e85ca18ec8092508e262a3196ce9bd10a67ec87b9f5c"
+dependencies = [
+ "hash-db",
+ "rlp",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3937,6 +4572,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,7 @@ dependencies = [
  "ethers-solc 0.1.0",
  "evm",
  "evm-adapters",
+ "eyre",
  "futures-util",
  "hex",
  "instant",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#78dfd7591d03f1ab031de7c5878e60b7df918c0e"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "ethers-addressbook 0.1.0 (git+https://github.com/gakonst/ethers-rs)",
  "ethers-contract 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
@@ -1261,7 +1261,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#78dfd7591d03f1ab031de7c5878e60b7df918c0e"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1294,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#80e1b4f0790e01e2685e0cedf3ef21d38a336be0"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "ethers-contract-abigen 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
  "ethers-contract-derive 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
@@ -1335,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#80e1b4f0790e01e2685e0cedf3ef21d38a336be0"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1371,7 +1371,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#80e1b4f0790e01e2685e0cedf3ef21d38a336be0"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "ethers-contract-abigen 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
  "ethers-core",
@@ -1446,7 +1446,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#78dfd7591d03f1ab031de7c5878e60b7df918c0e"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1488,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#78dfd7591d03f1ab031de7c5878e60b7df918c0e"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "async-trait",
  "ethers-contract 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
@@ -1546,16 +1546,18 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#80e1b4f0790e01e2685e0cedf3ef21d38a336be0"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "async-trait",
  "auto_impl",
+ "base64 0.13.0",
  "ethers-core",
  "futures-channel",
  "futures-core",
  "futures-timer",
  "futures-util",
  "hex",
+ "http",
  "parking_lot",
  "pin-project",
  "reqwest",
@@ -1609,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#78dfd7591d03f1ab031de7c5878e60b7df918c0e"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1664,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#78dfd7591d03f1ab031de7c5878e60b7df918c0e"
+source = "git+https://github.com/gakonst/ethers-rs#24c39bd32af37f7906bf0d5288a4daa7c83ac095"
 dependencies = [
  "colored",
  "dunce",
@@ -1732,13 +1734,12 @@ dependencies = [
 [[package]]
 name = "evm-adapters"
 version = "0.1.0"
+source = "git+https://github.com/gakonst/foundry#2f6148fc6794ed5b66e02bcee91be3e268c4ff95"
 dependencies = [
  "ansi_term",
  "bytes",
  "ethers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-contract 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
  "ethers-core",
- "ethers-providers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
  "evm",
  "eyre",
  "foundry-utils",
@@ -1877,6 +1878,7 @@ dependencies = [
 [[package]]
 name = "foundry-utils"
 version = "0.1.0"
+source = "git+https://github.com/gakonst/foundry#2f6148fc6794ed5b66e02bcee91be3e268c4ff95"
 dependencies = [
  "ethers-addressbook 0.1.0 (git+https://github.com/gakonst/ethers-rs)",
  "ethers-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,8 @@ solc-async = ["ethers-solc/async"]
 solc-full = ["ethers-solc/full"]
 solc-tests = ["ethers-solc/tests"]
 solc-sha2-asm = ["ethers-solc/asm"]
+## middleware
+forge = ["ethers-middleware/forge"]
 
 [dependencies]
 ethers-addressbook = { version = "^0.1.0", default-features = false, path = "./ethers-addressbook" }
@@ -110,3 +112,7 @@ bytes = "1.1.0"
 [profile.release.package.ethers-wasm]
 # Tell `rustc` to optimize for small code size.
 opt-level = "s"
+
+# Patch required to compile forge feature with evm_adapters
+[patch."https://github.com/gakonst/ethers-rs"]
+ethers-core = { path = "./ethers-core"}

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -34,6 +34,9 @@ url = { version = "2.2.2", default-features = false }
 serde_json = { version = "1.0.64", default-features = false }
 instant = {version = "0.1.12", features = ["now"] }
 
+evm-adapters = { path = "../../foundry/evm-adapters", features = ["sputnik", "sputnik-helpers"], optional = true }
+sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm", optional = true }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.5" }
 
@@ -50,3 +53,4 @@ tokio = { version = "1.5", default-features = false, features = ["rt", "macros",
 
 [features]
 celo = ["ethers-core/celo", "ethers-providers/celo", "ethers-signers/celo", "ethers-contract/celo"]
+forge = ["evm-adapters", "sputnik"]

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -36,6 +36,7 @@ instant = {version = "0.1.12", features = ["now"] }
 
 evm-adapters = { git = "https://github.com/gakonst/foundry", features = ["sputnik", "sputnik-helpers"], optional = true }
 sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm", optional = true }
+eyre = { version = "0.6.5", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.5" }
@@ -53,4 +54,4 @@ tokio = { version = "1.5", default-features = false, features = ["rt", "macros",
 
 [features]
 celo = ["ethers-core/celo", "ethers-providers/celo", "ethers-signers/celo", "ethers-contract/celo"]
-forge = ["evm-adapters", "sputnik"]
+forge = ["evm-adapters", "sputnik", "eyre"]

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -34,7 +34,7 @@ url = { version = "2.2.2", default-features = false }
 serde_json = { version = "1.0.64", default-features = false }
 instant = {version = "0.1.12", features = ["now"] }
 
-evm-adapters = { path = "../../foundry/evm-adapters", features = ["sputnik", "sputnik-helpers"], optional = true }
+evm-adapters = { git = "https://github.com/gakonst/foundry", features = ["sputnik", "sputnik-helpers"], optional = true }
 sputnik = { package = "evm", git = "https://github.com/rust-blockchain/evm", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/ethers-middleware/src/forge.rs
+++ b/ethers-middleware/src/forge.rs
@@ -1,0 +1,166 @@
+use async_trait::async_trait;
+use ethers_core::types::{
+    transaction::eip2718::TypedTransaction, Address, BlockId, Bytes, NameOrAddress,
+    TransactionReceipt,
+};
+use ethers_providers::{
+    JsonRpcClient, Middleware, PendingTransaction, PendingTxState, Provider, ProviderError,
+};
+use evm_adapters::Evm;
+use std::{fmt::Debug, marker::PhantomData, sync::Arc};
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, Copy)]
+pub struct NullProvider;
+impl NullProvider {
+    pub fn new() -> Self {
+        Self
+    }
+}
+#[async_trait]
+impl JsonRpcClient for NullProvider {
+    type Error = ProviderError;
+
+    async fn request<T, R>(&self, _method: &str, _params: T) -> Result<R, Self::Error>
+    where
+        T: std::fmt::Debug + serde::Serialize + Send + Sync,
+        R: serde::de::DeserializeOwned,
+    {
+        unreachable!("Cannot send requests")
+    }
+}
+
+#[derive(Clone)]
+pub struct Forge<V, S> {
+    pub vm: Arc<Mutex<V>>,
+    provider: Provider<NullProvider>,
+    _state: PhantomData<S>,
+}
+impl<V, S> Forge<V, S> {
+    pub fn new(vm: Arc<Mutex<V>>) -> Self {
+        Self { vm, provider: Provider::new(NullProvider), _state: PhantomData }
+    }
+}
+// Stand-in impl because some sputnik component is not Debug
+impl<V, S> Debug for Forge<V, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Forge").finish()
+    }
+}
+
+#[async_trait]
+impl<E, S> Middleware for Forge<E, S>
+where
+    E: Evm<S> + Send + Sync,
+    S: Send + Sync + Debug,
+{
+    type Error = ProviderError;
+    type Provider = NullProvider;
+    type Inner = Self;
+
+    fn inner(&self) -> &Self::Inner {
+        unreachable!("There is no inner provider here")
+    }
+
+    fn provider(&self) -> &Provider<Self::Provider> {
+        &self.provider
+    }
+
+    async fn send_transaction<T: Into<TypedTransaction> + Send + Sync>(
+        &self,
+        tx: T,
+        block: Option<BlockId>,
+    ) -> Result<PendingTransaction<'_, Self::Provider>, Self::Error> {
+        let mut tx = tx.into();
+        // Will panic if gas or gas price aren't set, because we don't really have a provider
+        self.provider().fill_transaction(&mut tx, block).await?;
+
+        // Pull fields from tx to pass to evm
+        let from = tx.from().unwrap();
+        let to = match tx.to().unwrap() {
+            NameOrAddress::Name(ens) => self.resolve_name(ens).await?,
+            NameOrAddress::Address(addr) => *addr,
+        };
+        let data = match tx.data() {
+            Some(data) => data.clone(),
+            _ => Default::default(),
+        };
+        let val = tx.value().unwrap();
+
+        // receipt to populate with the result of running the partial tx
+        let mut receipt = TransactionReceipt::default();
+
+        let mut lock = self.vm.lock().await;
+
+        if *from == Address::zero() {
+            // contract deployment
+            let (addr, exit, gas, _) = lock.deploy(*from, data.clone(), *val).unwrap();
+            receipt.gas_used = Some(gas.into());
+            receipt.status = Some((if E::is_success(&exit) { 1usize } else { 0 }).into());
+            receipt.contract_address = Some(addr);
+        } else {
+            // (contract) call
+            let (_bytes, exit, gas, _) = lock.call_raw(*from, to, data, *val, false).unwrap();
+            receipt.gas_used = Some(gas.into());
+            receipt.status = Some((if E::is_success(&exit) { 1usize } else { 0 }).into());
+        }
+
+        // Fake the tx hash for the receipt. Should be able to get a "real"
+        // hash modulo signature, which we may not have
+        let hash = tx.sighash(1usize);
+        receipt.transaction_hash = hash;
+        // receipt.transaction_index = 0usize.into();
+        // receipt.cumulative_gas_used = 0usize.into();
+
+        let mut pending = PendingTransaction::new(hash, self.provider());
+        // Set the future to resolve immediately to the populated receipt when polled.
+        // TODO: handle confirmations > 1
+        pending.set_state(PendingTxState::CheckingReceipt(Some(receipt)));
+        Ok(pending)
+    }
+
+    async fn call(
+        &self,
+        tx: &TypedTransaction,
+        _block: Option<BlockId>,
+    ) -> Result<Bytes, Self::Error> {
+        let from = tx.from().unwrap();
+        let to = match tx.to().unwrap() {
+            NameOrAddress::Name(ens) => self.resolve_name(ens).await?,
+            NameOrAddress::Address(addr) => *addr,
+        };
+        let data = match tx.data() {
+            Some(data) => data.clone(),
+            _ => Default::default(),
+        };
+        let val = tx.value().unwrap();
+        let mut lock = self.vm.lock().await;
+        let res = lock.call_raw(*from, to, data, *val, false).unwrap();
+        Ok(res.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ethers_core::types::TransactionRequest;
+    use evm_adapters::sputnik::{
+        helpers::{new_backend, CFG, GAS_LIMIT, VICINITY},
+        Executor, PRECOMPILES_MAP,
+    };
+
+    #[tokio::test]
+    async fn test_forge() {
+        let from: Address = "0xEA674fdDe714fd979de3EdF0F56AA9716B898ec8".parse().unwrap();
+        let to: Address = "0xD3D13a578a53685B4ac36A1Bab31912D2B2A2F36".parse().unwrap();
+
+        let backend = new_backend(&*VICINITY, Default::default());
+        let vm = Executor::new(GAS_LIMIT, &*CFG, &backend, &*PRECOMPILES_MAP);
+        let forge = Forge::new(Arc::new(Mutex::new(vm)));
+
+        let tx = TransactionRequest::new().to(to).from(from).value(1).gas(2300).gas_price(1);
+        let receipt = forge.send_transaction(tx, None).await.unwrap().await.unwrap();
+        dbg!(receipt);
+    }
+}

--- a/ethers-middleware/src/forge.rs
+++ b/ethers-middleware/src/forge.rs
@@ -1,14 +1,50 @@
 use async_trait::async_trait;
 use ethers_core::types::{
     transaction::eip2718::TypedTransaction, Address, BlockId, Bytes, NameOrAddress,
-    TransactionReceipt,
+    TransactionReceipt, U256, U64,
 };
 use ethers_providers::{
-    JsonRpcClient, Middleware, PendingTransaction, PendingTxState, Provider, ProviderError,
+    maybe, JsonRpcClient, Middleware, PendingTransaction, PendingTxState, Provider, ProviderError,
 };
-use evm_adapters::Evm;
-use std::{fmt::Debug, marker::PhantomData, sync::Arc};
-use tokio::sync::Mutex;
+use evm_adapters::{
+    sputnik::{Executor, SputnikExecutor},
+    Evm,
+};
+use sputnik::backend::Backend;
+use std::{
+    fmt::Debug,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+use tokio::sync::RwLock;
+
+pub trait VmShow {
+    fn gas_price(&self) -> U256;
+    fn block_number(&self) -> U256;
+    fn chain_id(&self) -> U256;
+    fn balance(&self, from: Address, block: Option<BlockId>) -> U256;
+}
+
+impl<'a, S, E> VmShow for Executor<S, E>
+where
+    E: SputnikExecutor<S>,
+    S: Backend,
+{
+    fn gas_price(&self) -> U256 {
+        self.executor.state().gas_price()
+    }
+    fn block_number(&self) -> U256 {
+        self.executor.state().block_number()
+    }
+    fn chain_id(&self) -> U256 {
+        self.executor.state().block_number()
+    }
+    // TODO: incorporate block parameter
+    fn balance(&self, addr: Address, block: Option<BlockId>) -> U256 {
+        self.executor.state().basic(addr).balance
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct NullProvider;
@@ -32,13 +68,20 @@ impl JsonRpcClient for NullProvider {
 
 #[derive(Clone)]
 pub struct Forge<V, S> {
-    pub vm: Arc<Mutex<V>>,
+    pub vm: Arc<RwLock<V>>,
     provider: Provider<NullProvider>,
     _state: PhantomData<S>,
 }
 impl<V, S> Forge<V, S> {
-    pub fn new(vm: Arc<Mutex<V>>) -> Self {
+    pub fn new(vm: Arc<RwLock<V>>) -> Self {
         Self { vm, provider: Provider::new(NullProvider), _state: PhantomData }
+    }
+    // async fn vm(&self) -> tokio::sync::RwLockReadGuard<'_, V> {
+    async fn vm(&self) -> impl Deref<Target = V> + '_ {
+        self.vm.read().await
+    }
+    async fn vm_mut(&self) -> impl DerefMut<Target = V> + '_ {
+        self.vm.write().await
     }
 }
 // Stand-in impl because some sputnik component is not Debug
@@ -51,19 +94,110 @@ impl<V, S> Debug for Forge<V, S> {
 #[async_trait]
 impl<E, S> Middleware for Forge<E, S>
 where
-    E: Evm<S> + Send + Sync,
+    E: Evm<S> + VmShow + Send + Sync,
     S: Send + Sync + Debug,
 {
     type Error = ProviderError;
     type Provider = NullProvider;
-    type Inner = Self;
+    type Inner = Provider<NullProvider>;
 
     fn inner(&self) -> &Self::Inner {
-        unreachable!("There is no inner provider here")
+        self.provider()
     }
 
     fn provider(&self) -> &Provider<Self::Provider> {
         &self.provider
+    }
+
+    async fn estimate_gas(&self, _tx: &TypedTransaction) -> Result<U256, Self::Error> {
+        Ok(0usize.into())
+    }
+
+    async fn get_gas_price(&self) -> Result<U256, Self::Error> {
+        Ok(self.vm().await.gas_price())
+    }
+
+    async fn get_block_number(&self) -> Result<U64, Self::Error> {
+        Ok(self.vm().await.block_number().as_u64().into())
+    }
+
+    async fn get_chainid(&self) -> Result<U256, Self::Error> {
+        Ok(self.vm().await.chain_id())
+    }
+
+    async fn get_balance<T: Into<NameOrAddress> + Send + Sync>(
+        &self,
+        from: T,
+        block: Option<BlockId>,
+    ) -> Result<U256, Self::Error> {
+        let addr = match from.into() {
+            NameOrAddress::Name(ref ens) => self.resolve_name(ens).await?,
+            NameOrAddress::Address(a) => a,
+        };
+        Ok(self.vm().await.balance(addr, block))
+    }
+
+    // Copied from Provider::fill_transaction because we need other middleware
+    // method calls to be captured by Forge
+    async fn fill_transaction(
+        &self,
+        tx: &mut TypedTransaction,
+        block: Option<BlockId>,
+    ) -> Result<(), Self::Error> {
+        if let Some(default_sender) = self.default_sender() {
+            if tx.from().is_none() {
+                tx.set_from(default_sender);
+            }
+        }
+
+        // TODO: Can we poll the futures below at the same time?
+        // Access List + Name resolution and then Gas price + Gas
+
+        // set the ENS name
+        if let Some(NameOrAddress::Name(ref ens_name)) = tx.to() {
+            let addr = self.resolve_name(ens_name).await?;
+            tx.set_to(addr);
+        }
+
+        // estimate the gas without the access list
+        let gas = maybe(tx.gas().cloned(), self.estimate_gas(tx)).await?;
+        let mut al_used = false;
+
+        // set the access lists
+        if let Some(access_list) = tx.access_list() {
+            if access_list.0.is_empty() {
+                if let Ok(al_with_gas) = self.create_access_list(tx, block).await {
+                    // only set the access list if the used gas is less than the
+                    // normally estimated gas
+                    if al_with_gas.gas_used < gas {
+                        tx.set_access_list(al_with_gas.access_list);
+                        tx.set_gas(al_with_gas.gas_used);
+                        al_used = true;
+                    }
+                }
+            }
+        }
+
+        if !al_used {
+            tx.set_gas(gas);
+        }
+
+        match tx {
+            TypedTransaction::Eip2930(_) | TypedTransaction::Legacy(_) => {
+                let gas_price = maybe(tx.gas_price(), self.get_gas_price()).await?;
+                tx.set_gas_price(gas_price);
+            }
+            TypedTransaction::Eip1559(ref mut inner) => {
+                if inner.max_fee_per_gas.is_none() || inner.max_priority_fee_per_gas.is_none() {
+                    let (max_fee_per_gas, max_priority_fee_per_gas) =
+                        self.estimate_eip1559_fees(None).await?;
+                    inner.max_fee_per_gas = Some(max_fee_per_gas);
+                    inner.max_priority_fee_per_gas = Some(max_priority_fee_per_gas);
+                };
+            }
+        }
+
+        Ok(())
     }
 
     async fn send_transaction<T: Into<TypedTransaction> + Send + Sync>(
@@ -73,7 +207,7 @@ where
     ) -> Result<PendingTransaction<'_, Self::Provider>, Self::Error> {
         let mut tx = tx.into();
         // Will panic if gas or gas price aren't set, because we don't really have a provider
-        self.provider().fill_transaction(&mut tx, block).await?;
+        self.fill_transaction(&mut tx, block).await?;
 
         // Pull fields from tx to pass to evm
         let from = tx.from().unwrap();
@@ -83,26 +217,25 @@ where
                 NameOrAddress::Address(addr) => *addr,
             }
         });
-        let data = match tx.data() {
-            Some(data) => data.clone(),
-            _ => Default::default(),
-        };
+        let data = tx.data().map_or(Default::default(), |d| d.clone());
         let val = tx.value().unwrap();
 
         // receipt to populate with the result of running the partial tx
         let mut receipt = TransactionReceipt::default();
 
-        let mut lock = self.vm.lock().await;
+        // let mut lock = self.vm.write().await;
 
         if let Some(fut) = maybe_to {
             let to = fut.await;
             // (contract) call
-            let (_bytes, exit, gas, _) = lock.call_raw(*from, to, data, *val, false).unwrap();
+            let (_bytes, exit, gas, _) =
+                self.vm_mut().await.call_raw(*from, to, data, *val, false).unwrap();
             receipt.gas_used = Some(gas.into());
             receipt.status = Some((if E::is_success(&exit) { 1usize } else { 0 }).into());
         } else {
             // contract deployment
-            let (addr, exit, gas, _) = lock.deploy(*from, data.clone(), *val).unwrap();
+            let (addr, exit, gas, _) =
+                self.vm_mut().await.deploy(*from, data.clone(), *val).unwrap();
             receipt.gas_used = Some(gas.into());
             receipt.status = Some((if E::is_success(&exit) { 1usize } else { 0 }).into());
             receipt.contract_address = Some(addr);
@@ -112,8 +245,6 @@ where
         // hash modulo signature, which we may not have
         let hash = tx.sighash(1usize);
         receipt.transaction_hash = hash;
-        // receipt.transaction_index = 0usize.into();
-        // receipt.cumulative_gas_used = 0usize.into();
 
         let mut pending = PendingTransaction::new(hash, self.provider());
         // Set the future to resolve immediately to the populated receipt when polled.
@@ -137,7 +268,7 @@ where
             _ => Default::default(),
         };
         let val = tx.value().unwrap();
-        let mut lock = self.vm.lock().await;
+        let mut lock = self.vm.write().await;
         let res = lock.call_raw(*from, to, data, *val, false).unwrap();
         Ok(res.0)
     }
@@ -147,7 +278,7 @@ where
 mod tests {
     use super::*;
 
-    use ethers_core::types::TransactionRequest;
+    use ethers_core::types::{Address, TransactionRequest};
     use evm_adapters::sputnik::{
         helpers::{new_backend, CFG, GAS_LIMIT, VICINITY},
         Executor, PRECOMPILES_MAP,
@@ -160,7 +291,7 @@ mod tests {
 
         let backend = new_backend(&*VICINITY, Default::default());
         let vm = Executor::new(GAS_LIMIT, &*CFG, &backend, &*PRECOMPILES_MAP);
-        let forge = Forge::new(Arc::new(Mutex::new(vm)));
+        let forge = Forge::new(Arc::new(RwLock::new(vm)));
 
         let tx = TransactionRequest::new().to(to).from(from).value(1).gas(2300).gas_price(1);
         let receipt = forge.send_transaction(tx, None).await.unwrap().await.unwrap();

--- a/ethers-middleware/src/lib.rs
+++ b/ethers-middleware/src/lib.rs
@@ -33,3 +33,8 @@ pub use policy::PolicyMiddleware;
 /// before the chain tip
 pub mod timelag;
 pub use timelag::TimeLag;
+
+#[cfg(feature = "forge")]
+pub mod forge;
+#[cfg(feature = "forge")]
+pub use forge::Forge;

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ens;
 
 mod pending_transaction;
 pub use pending_transaction::PendingTransaction;
+pub use pending_transaction::PendingTxState;
 
 mod pending_escalator;
 pub use pending_escalator::EscalatingPending;

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -12,8 +12,7 @@ mod provider;
 pub mod ens;
 
 mod pending_transaction;
-pub use pending_transaction::PendingTransaction;
-pub use pending_transaction::PendingTxState;
+pub use pending_transaction::{PendingTransaction, PendingTxState};
 
 mod pending_escalator;
 pub use pending_escalator::EscalatingPending;

--- a/ethers-providers/src/pending_transaction.rs
+++ b/ethers-providers/src/pending_transaction.rs
@@ -47,6 +47,10 @@ impl<'a, P: JsonRpcClient> PendingTransaction<'a, P> {
         }
     }
 
+    pub fn set_state(&mut self, state: PendingTxState<'a>) {
+        self.state = state
+    }
+
     /// Returns the Provider associated with the pending transaction
     pub fn provider(&self) -> Provider<P>
     where
@@ -266,7 +270,7 @@ impl<'a, P> Deref for PendingTransaction<'a, P> {
 }
 
 // We box the TransactionReceipts to keep the enum small.
-enum PendingTxState<'a> {
+pub enum PendingTxState<'a> {
     /// Initial delay to ensure the GettingTx loop doesn't immediately fail
     InitialDelay(Pin<Box<Delay>>),
 


### PR DESCRIPTION
## Motivation

**Goal:** Write rust tests for smart contracts that leverage Foundry's performance, debugging, and usability. Ideally, minimal effort is required to switch your rust tests between using an rpc endpoint and using a Foundry `evm_adapter`.

See https://github.com/gakonst/foundry/issues/22.

## Solution

An ethers middleware that is instantiated with an implementer of Foundry's [`evm_adapters::Evm`](https://github.com/gakonst/foundry/blob/0773fb41582d7ad02269902b0097e5db58198831/evm-adapters/src/lib.rs#L57) trait. Instead of sending transactions over rpc, this middleware interfaces directly with the evm instance via `Evm::call_raw()`.

## Challenges

It's not clear that this is really the best way to do things. Currently, this middleware needs to make every effort to avoid delegating anything to an inner middleware, because there is a good chance that inner middleware simply does not exist. It also will need to re-implement many of the methods that the `Provider` struct currently implements, because every sub-call needs to go through this middleware, and `Provider` is currently enshrined as the innermost middleware. 

The sputnik [`Backend`](https://github.com/rust-blockchain/evm/blob/78c49debfc65ddf3c0635edd02045a937dcc15d5/src/backend/mod.rs#L52-L86) trait gives a good idea of what kind of data we have available from an `evm_adapter` instance. In short, it doesn't look like we can get anything block or node related, including most historical data.

There are situations where a meaningful implementation of an inner middleware might exist, though. For instance, if you instantiate this middleware with an `evm_adapter` using forked state from mainnet, you could also provide an inner rpc client that can query historical data from a mainnet rpc endpoint. Or, there may ultimately be an rpc endpoint talking to the same `evm_adapter` instance: https://github.com/gakonst/foundry/pull/174.

## Alternative Solutions

1. Have the middleware live at the level of a `JsonRpcClient` instead, intercepting requests to rpc methods and dispatching to either the evm instance or to another optional inner provider. This seems like a more natural place for this to live, and it would avoid needing to reimplement many of the methods already defined on `Provider`. But, it would require deserializing requests that were just serialized in the provider, then doing the same round trip with the response from the evm instance. This poses both performance and correctness challenges.

2. Split the work between a `Middleware` and a `JsonRpcClient` impl, allowing the `JsonRpcClient` impl to catch requests from the `Provider` middleware impl and pass them back up to the Forge middleware. The same concerns above apply for this approach in addition to the potential to end up stuck in a  `middleware -> provider -> client -> middleware -> ...` loop. But, this avoids needing to redefine all of the Provider methods on our middleware, and it would allow us to use the inner provider more effectively.

3. Put the middleware right where `Provider` lives now. Currently, the `Provider<P: JsonRpcClient>` struct is enshrined as the "base" of the middleware. If you were able to replace the Provider with any "innerware", that would be a logical place for the Forge middleware to live.

## TLDR
The interesting pieces here are probably the implementation of the `Middleware` trait's `call()` and `send_transaction()` methods, and the associated `apply_tx()` method.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
