### PR TITLE
fix(solc): flatten replacement target location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 
 ### Unreleased
 
+- Fix flatten replacement target location
+  [#846](https://github.com/gakonst/ethers-rs/pull/846)
 - Fix duplicate files during flattening
   [#813](https://github.com/gakonst/ethers-rs/pull/813)
 - Add ability to flatten file imports

--- a/ethers-solc/src/resolver.rs
+++ b/ethers-solc/src/resolver.rs
@@ -485,7 +485,8 @@ impl<T> SolDataUnit<T> {
     pub fn loc_by_offset(&self, offset: isize) -> (usize, usize) {
         (
             offset.saturating_add(self.loc.start as isize) as usize,
-            offset.saturating_add(self.loc.end as isize) as usize,
+            // make the end location exclusive
+            offset.saturating_add(self.loc.end as isize + 1) as usize,
         )
     }
 }

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -376,4 +376,5 @@ fn can_flatten_file_with_duplicates() {
     assert_eq!(result.matches("contract Foo {").count(), 1);
     assert_eq!(result.matches("contract Bar {").count(), 1);
     assert_eq!(result.matches("contract FooBar {").count(), 1);
+    assert_eq!(result.matches(";").count(), 1);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Addresses [foundry #641](https://github.com/gakonst/foundry/issues/641)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The end location of the target replacement is adjusted to be exclusive. That's how it was primarily used during flattening.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
