### PR TITLE
add eth_syncing RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Add `eth_syncing` [848](https://github.com/gakonst/ethers-rs/pull/848)
 - Fix overflow and possible divide-by-zero in `estimate_priority_fee`
 - Add BSC mainnet and testnet to the list of known chains
   [831](https://github.com/gakonst/ethers-rs/pull/831)

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -83,7 +83,9 @@ where
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum SyncingStatus {
-    IsFalse(bool),
+    /// When client is synced to highest block, eth_syncing with return string "false"
+    IsFalse,
+    /// When client is still syncing past blocks we get IsSyncing mode.
     IsSyncing { starting_block: U256, current_block: U256, highest_block: U256 },
 }
 

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -27,7 +27,7 @@ pub use pubsub::{PubsubClient, SubscriptionStream};
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use ethers_core::types::transaction::{eip2718::TypedTransaction, eip2930::AccessListWithGasUsed};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 use std::{error::Error, fmt::Debug, future::Future, pin::Pin};
 
 pub use provider::{FilterKind, Provider, ProviderError};
@@ -80,12 +80,11 @@ where
 }
 
 /// Structure used in eth_syncing RPC
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
+#[derive(Clone, Debug)]
 pub enum SyncingStatus {
     /// When client is synced to highest block, eth_syncing with return string "false"
     IsFalse,
-    /// When client is still syncing past blocks we get IsSyncing mode.
+    /// When client is still syncing past blocks we get IsSyncing information.
     IsSyncing { starting_block: U256, current_block: U256, highest_block: U256 },
 }
 

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -3,7 +3,7 @@ use crate::{
     pubsub::{PubsubClient, SubscriptionStream},
     stream::{FilterWatcher, DEFAULT_POLL_INTERVAL},
     FromErr, Http as HttpProvider, JsonRpcClient, JsonRpcClientWrapper, MockProvider,
-    PendingTransaction, QuorumProvider,
+    PendingTransaction, QuorumProvider, SyncingStatus,
 };
 
 #[cfg(feature = "celo")]
@@ -495,6 +495,11 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
     /// transaction signing as introduced by EIP-155.
     async fn get_chainid(&self) -> Result<U256, ProviderError> {
         self.request("eth_chainId", ()).await
+    }
+
+    /// Return current client syncing status. If IsFalse sync is over.
+    async fn syncing(&self) -> Result<SyncingStatus, Self::Error> {
+        self.request("eth_syncing", ()).await
     }
 
     /// Returns the network version.


### PR DESCRIPTION
Add `eth_syncing` endpoint: https://eth.wiki/json-rpc/API#eth_syncing

Tested it with infure and return `false` successfully, don't have any syncing node to check return when it is syncing.
