### PR TITLE
fix(providers): doc test for dev_rpc

### DIFF
--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1133,7 +1133,7 @@ impl TryFrom<String> for Provider<HttpProvider> {
 /// use ethers_core::utils::Ganache;
 /// use std::convert::TryFrom;
 ///
-/// # #[tokio::main]
+/// # #[tokio::main(flavor = "current_thread")]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let ganache = Ganache::new().spawn();
 /// let provider = Provider::<Http>::try_from(ganache.endpoint()).unwrap();


### PR DESCRIPTION
## Motivation

The doc test for the `dev_rpc` mod was failing when run directly from `ethers_providers`, because tokio's `rt-multi-thread` feature is not enabled.

## Solution

Specify the `current_thread` runtime flavor instead.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
