### PR TITLE
dep: replace anyhow with eyre in examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,7 +1125,6 @@ dependencies = [
 name = "ethers"
 version = "0.6.0"
 dependencies = [
- "anyhow",
  "bytes",
  "ethers-addressbook",
  "ethers-contract",
@@ -1135,6 +1134,7 @@ dependencies = [
  "ethers-providers",
  "ethers-signers",
  "ethers-solc",
+ "eyre",
  "hex",
  "rand 0.8.4",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ ethers-providers = { version = "^0.6.0", default-features = false, path = "./eth
 
 [target.'cfg(target_family = "unix")'.dev-dependencies]
 ethers-providers = { version = "^0.6.0", default-features = false, path = "./ethers-providers", features = ["ws", "ipc"] }
-anyhow = "1.0.39"
+eyre = "0.6.6"
 rand = "0.8.4"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"

--- a/examples/abigen.rs
+++ b/examples/abigen.rs
@@ -1,6 +1,6 @@
 use ethers::{contract::Abigen, solc::Solc};
 
-fn main() -> anyhow::Result<()> {
+fn main() -> eyre::Result<()> {
     let mut args = std::env::args();
     args.next().unwrap(); // skip program name
 

--- a/examples/contract_human_readable.rs
+++ b/examples/contract_human_readable.rs
@@ -1,9 +1,9 @@
-use anyhow::Result;
 use ethers::{
     prelude::*,
     solc::{Project, ProjectPathsConfig},
     utils::Ganache,
 };
+use eyre::Result;
 use std::{convert::TryFrom, path::PathBuf, sync::Arc, time::Duration};
 
 // Generate the type-safe contract bindings by providing the ABI

--- a/examples/contract_with_abi.rs
+++ b/examples/contract_with_abi.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use ethers::{prelude::*, utils::Ganache};
+use eyre::Result;
 use std::{convert::TryFrom, path::Path, sync::Arc, time::Duration};
 
 // Generate the type-safe contract bindings by providing the ABI

--- a/examples/ens.rs
+++ b/examples/ens.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use ethers::{prelude::*, utils::Ganache};
+use eyre::Result;
 use std::convert::TryFrom;
 
 #[tokio::main]
@@ -20,7 +20,7 @@ async fn main() -> Result<()> {
         .send_transaction(tx, None)
         .await?
         .await?
-        .ok_or_else(|| anyhow::format_err!("tx dropped from mempool"))?;
+        .ok_or_else(|| eyre::format_err!("tx dropped from mempool"))?;
     let tx = provider.get_transaction(receipt.transaction_hash).await?;
 
     println!("{}", serde_json::to_string(&tx)?);

--- a/examples/ipc.rs
+++ b/examples/ipc.rs
@@ -1,6 +1,6 @@
 #[tokio::main]
 #[cfg(feature = "ipc")]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> eyre::Result<()> {
     use ethers::prelude::*;
 
     let provider = Provider::connect_ipc("~/.ethereum/geth.ipc")

--- a/examples/local_signer.rs
+++ b/examples/local_signer.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use ethers::{prelude::*, utils::Ganache};
+use eyre::Result;
 use std::convert::TryFrom;
 
 #[tokio::main]
@@ -22,8 +22,7 @@ async fn main() -> Result<()> {
     let pending_tx = client.send_transaction(tx, None).await?;
 
     // get the mined tx
-    let receipt =
-        pending_tx.await?.ok_or_else(|| anyhow::format_err!("tx dropped from mempool"))?;
+    let receipt = pending_tx.await?.ok_or_else(|| eyre::format_err!("tx dropped from mempool"))?;
     let tx = client.get_transaction(receipt.transaction_hash).await?;
 
     println!("Sent tx: {}\n", serde_json::to_string(&tx)?);

--- a/examples/mnemonic.rs
+++ b/examples/mnemonic.rs
@@ -1,6 +1,6 @@
 use ethers::signers::{coins_bip39::English, MnemonicBuilder};
 
-fn main() -> anyhow::Result<()> {
+fn main() -> eyre::Result<()> {
     let phrase = "work man father plunge mystery proud hollow address reunion sauce theory bonus";
     let index = 0u32;
     let password = "TREZOR123";

--- a/examples/moonbeam_with_abi.rs
+++ b/examples/moonbeam_with_abi.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use ethers::prelude::*;
+use eyre::Result;
 use std::{convert::TryFrom, path::Path, sync::Arc, time::Duration};
 
 abigen!(

--- a/examples/quorum.rs
+++ b/examples/quorum.rs
@@ -5,7 +5,7 @@ use ethers::{prelude::*, utils::Ganache};
 use std::{str::FromStr, time::Duration};
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> eyre::Result<()> {
     let ganache = Ganache::new().spawn();
 
     // create a quorum provider with some providers

--- a/examples/sign.rs
+++ b/examples/sign.rs
@@ -1,5 +1,5 @@
-// use the anyhow crate for easy idiomatic error handling
-use anyhow::Result;
+// use the eyre crate for easy idiomatic error handling
+use eyre::Result;
 // use the ethers_core rand for rng
 use ethers_core::rand::thread_rng;
 // use the ethers_signers crate to manage LocalWallet and Signer

--- a/examples/transfer_eth.rs
+++ b/examples/transfer_eth.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use ethers::{prelude::*, utils::Ganache};
+use eyre::Result;
 use std::convert::TryFrom;
 
 #[tokio::main]

--- a/examples/uniswapv2.rs
+++ b/examples/uniswapv2.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
 use ethers::prelude::*;
+use eyre::Result;
 use std::sync::Arc;
 
 // Generate the type-safe contract bindings by providing the ABI

--- a/examples/watch_blocks.rs
+++ b/examples/watch_blocks.rs
@@ -2,7 +2,7 @@ use ethers::{prelude::*, utils::Ganache};
 use std::time::Duration;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> eyre::Result<()> {
     let ganache = Ganache::new().block_time(1u64).spawn();
     let ws = Ws::connect(ganache.ws_endpoint()).await?;
     let provider = Provider::new(ws).interval(Duration::from_millis(2000));


### PR DESCRIPTION
## Motivation

Slow move from anyhow to eyre throughout the crate

## Solution

Make examples use eyre.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
