### PR TITLE
feat(ethers-contract): add `send_with_receipt` to `Deployer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
   [#854](https://github.com/gakonst/ethers-rs/pull/852)
 - Refactor `ethers-contract-abigen` to use `eyre` instead of `anyhow` via
   [#858](https://github.com/gakonst/ethers-rs/pull/858)
+- Add `Deployer.send_with_receipt -> Result<(Contract, Receipt), Error>`
+  so that the receipt can be returned to the called when deploying
+  a contract [#865](https://github.com/gakonst/ethers-rs/pull/865)
 
 ## ethers-contract-abigen
 

--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -42,7 +42,8 @@ mod eth_tests {
         // dry runs the deployment of the contract. takes the deployer by reference, no need to
         // clone.
         assert!(deployer.call().await.is_ok());
-        let contract = deployer.clone().send().await.unwrap();
+        let (contract, receipt) = deployer.clone().send_with_receipt().await.unwrap();
+        assert_eq!(receipt.contract_address.unwrap(), contract.address());
 
         let get_value = contract.method::<_, String>("getValue", ()).unwrap();
         let last_sender = contract.method::<_, Address>("lastSender", ()).unwrap();


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

I'd like to print the transaction hash when using `forge create` and its just generally
useful to have a reference to the receipt when deploying a contract. Currently
this is not possible due to the interface on the `Deployer`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

The `Deployer` is used to deploy contracts and its `send`
function returns an attached instance of a `Contract`.
There is no way to know the transaction hash of the
deployment transaction, so this commit adds another
method `send_with_receipt` that returns an attached
`Contract` as well as a `TransactionReceipt`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
