### PR TITLE
fix(core): prevent chain_id from serializing for requests

### DIFF
--- a/ethers-core/src/types/transaction/eip1559.rs
+++ b/ethers-core/src/types/transaction/eip1559.rs
@@ -58,7 +58,8 @@ pub struct Eip1559TransactionRequest {
     /// baseFeePerGas + maxPriorityFeePerGas is “refunded” to the user.
     pub max_fee_per_gas: Option<U256>,
 
-    #[serde(rename = "chainId", default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing)]
+    #[serde(rename = "chainId")]
     /// Chain ID (None for mainnet)
     pub chain_id: Option<U64>,
 }

--- a/ethers-core/src/types/transaction/eip1559.rs
+++ b/ethers-core/src/types/transaction/eip1559.rs
@@ -59,7 +59,7 @@ pub struct Eip1559TransactionRequest {
     pub max_fee_per_gas: Option<U256>,
 
     #[serde(skip_serializing)]
-    #[serde(rename = "chainId")]
+    #[serde(default, rename = "chainId")]
     /// Chain ID (None for mainnet)
     pub chain_id: Option<U64>,
 }

--- a/ethers-core/src/types/transaction/request.rs
+++ b/ethers-core/src/types/transaction/request.rs
@@ -43,7 +43,7 @@ pub struct TransactionRequest {
 
     /// Chain ID (None for mainnet)
     #[serde(skip_serializing)]
-    #[serde(rename = "chainId")]
+    #[serde(default, rename = "chainId")]
     pub chain_id: Option<U64>,
 
     /////////////////  Celo-specific transaction fields /////////////////

--- a/ethers-core/src/types/transaction/request.rs
+++ b/ethers-core/src/types/transaction/request.rs
@@ -42,7 +42,8 @@ pub struct TransactionRequest {
     pub nonce: Option<U256>,
 
     /// Chain ID (None for mainnet)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing)]
+    #[serde(rename = "chainId")]
     pub chain_id: Option<U64>,
 
     /////////////////  Celo-specific transaction fields /////////////////


### PR DESCRIPTION
## Motivation
OpenEthereum seems to not have a `chainId` field in its [`TransactionRequest`](https://github.com/openethereum/openethereum/blob/main/crates/rpc/src/v1/types/transaction_request.rs#L32) type.

## Solution
This PR disables serialization for the `chain_id`, so we don't send it in RPC requests.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

Fixes #877 