### PR TITLE
feat(providers): Log methods for PendingTransaction

### DIFF
--- a/ethers-providers/src/pending_transaction.rs
+++ b/ethers-providers/src/pending_transaction.rs
@@ -105,6 +105,9 @@ impl<'a, P: JsonRpcClient> PendingTransaction<'a, P> {
 }
 
 impl<'a, P> PendingTransaction<'a, P> {
+    /// Allows inspecting the content of a pending transaction in a builder-like way to avoid
+    /// more verbose calls, e.g.: 
+    /// `let mined = token.transfer(recipient, amt).send().await?.inspect(|tx| println!(".{}", *tx)).await?;`
     pub fn inspect<F>(self, mut f: F) -> Self
     where
         F: FnMut(&Self),
@@ -112,9 +115,13 @@ impl<'a, P> PendingTransaction<'a, P> {
         f(&self);
         self
     }
+    
+    /// Logs the pending transaction hash along with a custom message before it.
     pub fn log_msg<S: std::fmt::Display>(self, msg: S) -> Self {
         self.inspect(|s| println!("{}: {:?}", msg, *s))
     }
+    
+    /// Logs the pending transaction's hash
     pub fn log(self) -> Self {
         self.inspect(|s| println!("Pending hash: {:?}", *s))
     }

--- a/ethers-providers/src/pending_transaction.rs
+++ b/ethers-providers/src/pending_transaction.rs
@@ -50,7 +50,7 @@ use wasm_timer::Delay;
 /// # assert_eq!(balance_after, balance_before + 1000);
 /// # Ok(())
 /// # }
-///```
+/// ```
 #[pin_project]
 pub struct PendingTransaction<'a, P> {
     tx_hash: TxHash,
@@ -105,16 +105,20 @@ impl<'a, P: JsonRpcClient> PendingTransaction<'a, P> {
 }
 
 impl<'a, P> PendingTransaction<'a, P> {
-    pub fn log_msg<S: std::fmt::Display>(self, msg: S) -> Self {
-        println!("{}: {:?}", msg, *self);
+    pub fn inspect<F>(self, mut f: F) -> Self
+    where
+        F: FnMut(&Self),
+    {
+        f(&self);
         self
+    }
+    pub fn log_msg<S: std::fmt::Display>(self, msg: S) -> Self {
+        self.inspect(|s| println!("{}: {:?}", msg, *s))
     }
     pub fn log(self) -> Self {
-        println!("Pending hash: {:?}", *self);
-        self
+        self.inspect(|s| println!("Pending hash: {:?}", *s))
     }
 }
-
 
 macro_rules! rewake_with_new_state {
     ($ctx:ident, $this:ident, $new_state:expr) => {


### PR DESCRIPTION
## Motivation

I frequently want to print the transaction hash of a pending transaction before it is mined. Currently, this is pretty verbose, because you need a let binding for the transaction:
```rust
let tx = token.transfer(recipient, amt);
let pending = tx.send().await?;
println!("Tx hash: {:?}", *pending);
let mined = pending.await?;
```

## Solution

Add two convenience methods on the `PendingTransaction<_>` type, `log()` and `log_msg()`.
```rust
let mined = token.transfer(recipient, amt).send().await?.log_msg("Tx hash").await?;
```

Another approach that isn't just for printing might be to add a method to `PendingTransaction<_>` that returns `(TxHash, Self)`, which would turn the above into:
```rust
let (hash, fut) = token.transfer(recipient, amt).send().await?.hash();
println!("Tx hash: {:?}", hash);
let mined = fut.await?;
```

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
- [ ] Updated the changelog
