### PR TITLE
feat(ethers-core/Chain): make to_string and from_str inverse functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- `Chain::to_string` will return the same chain name as `Chain::from_str`
 - Add `eth_syncing` [848](https://github.com/gakonst/ethers-rs/pull/848)
 - Fix overflow and possible divide-by-zero in `estimate_priority_fee`
 - Add BSC mainnet and testnet to the list of known chains

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -40,7 +40,32 @@ pub enum Chain {
 
 impl fmt::Display for Chain {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "{:?}", self)
+        let chain = match self {
+            Chain::Mainnet => "mainnet",
+            Chain::Ropsten => "ropsten",
+            Chain::Rinkeby => "rinkeby",
+            Chain::Goerli => "goerli",
+            Chain::Kovan => "kovan",
+            Chain::XDai => "xdai",
+            Chain::Polygon => "polygon",
+            Chain::PolygonMumbai => "polygon-mumbai",
+            Chain::Avalanche => "avalanche",
+            Chain::AvalancheFuji => "avalanche-fuji",
+            Chain::Sepolia => "sepolia",
+            Chain::Moonbeam => "moonbeam",
+            Chain::MoonbeamDev => "moonbeam-dev",
+            Chain::Moonriver => "moonriver",
+            Chain::Optimism => "optimism",
+            Chain::OptimismKovan => "optimism-kovan",
+            Chain::Fantom => "fantom",
+            Chain::FantomTestnet => "fantom-testnet",
+            Chain::BinanceSmartChain => "bsc",
+            Chain::BinanceSmartChainTestnet => "bsc-testnet",
+            Chain::Arbitrum => "arbitrum",
+            Chain::ArbitrumTestnet => "arbitrum-testnet",
+        };
+
+        write!(formatter, "{}", chain)
     }
 }
 

--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -232,7 +232,7 @@ mod tests {
         let err = Client::new_from_env(Chain::XDai).unwrap_err();
 
         assert!(matches!(err, EtherscanError::ChainNotSupported(_)));
-        assert_eq!(err.to_string(), "chain XDai not supported");
+        assert_eq!(err.to_string(), "chain xdai not supported");
     }
 
     pub async fn run_at_least_duration(duration: Duration, block: impl Future) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->
Closes #897 

## Motivation
Currently, to_string and from_str are not mirroring each other, maybe they should.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Overriding the default `Debug`'s impl.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
