### PR TITLE
feat: add getter to `ProjectCompileOutput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
   so that the receipt can be returned to the called when deploying
   a contract [#865](https://github.com/gakonst/ethers-rs/pull/865)
 - Add Arbitrum mainnet and testnet to the list of known chains
+- Add a getter to `ProjectCompileOutput` that returns a mapping of compiler
+  versions to a vector of name + contract struct tuples
+  [#908](https://github.com/gakonst/ethers-rs/pull/908)
 
 ## ethers-contract-abigen
 

--- a/ethers-solc/src/compile/output.rs
+++ b/ethers-solc/src/compile/output.rs
@@ -145,7 +145,7 @@ impl<T: ArtifactOutput> ProjectCompileOutput<T> {
     /// Returns a `BTreeMap` that maps the compiler version used during [`Project::compile()`]
     /// to a Vector of tuples containing the contract name and the `Contract`
     pub fn compiled_contracts_by_compiler_version(
-        &mut self,
+        &self,
     ) -> BTreeMap<Version, Vec<(String, Contract)>> {
         let mut contracts = BTreeMap::new();
         let versioned_contracts = &self.compiler_output.contracts;

--- a/ethers-solc/src/compile/output.rs
+++ b/ethers-solc/src/compile/output.rs
@@ -141,6 +141,22 @@ impl<T: ArtifactOutput> ProjectCompileOutput<T> {
     pub fn compiled_artifacts(&self) -> &Artifacts<T::Artifact> {
         &self.compiled_artifacts
     }
+
+    /// Returns a `BTreeMap` that maps the compiler version used during [`Project::compile()`]
+    /// to a Vector of tuples containing the contract name and the `Contract`
+    pub fn compiled_contracts_by_compiler_version(
+        &mut self,
+    ) -> BTreeMap<Version, Vec<(String, Contract)>> {
+        let mut contracts = BTreeMap::new();
+        let versioned_contracts = &self.compiler_output.contracts;
+        for (_, name, contract, version) in versioned_contracts.contracts_with_files_and_version() {
+            contracts
+                .entry(version.to_owned())
+                .or_insert(Vec::<(String, Contract)>::new())
+                .push((name.to_string(), contract.clone()));
+        }
+        contracts
+    }
 }
 
 impl<T: ArtifactOutput> ProjectCompileOutput<T>


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

I'd like to be able to print off the compiled contract names when running `forge build`.
Addresses https://github.com/gakonst/foundry/pull/682#discussion_r804496272

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Add a function `compiled_contracts_by_compiler_version`
to the `ProjectCompileOutput` that returns a `BTreeMap`
that maps the compiler version to a vector of the contract
names and contract structs.


## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
