### PR TITLE
Expose New `call_raw` API that permits MultiCalls without Detokenization

### DIFF
--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -187,14 +187,7 @@ impl<M: Middleware> Multicall<M> {
     }
 
     /// Appends a `call` to the list of calls for the Multicall instance
-    ///
-    /// # Panics
-    ///
-    /// If more than the maximum number of supported calls are added. The maximum
-    /// limits is constrained due to tokenization/detokenization support for tuples
     pub fn add_call<D: Detokenize>(&mut self, call: ContractCall<M, D>) -> &mut Self {
-        assert!(self.calls.len() < 16, "Cannot support more than {} calls", 16);
-
         match (call.tx.to(), call.tx.data()) {
             (Some(NameOrAddress::Address(target)), Some(data)) => {
                 let call = Call { target: *target, data: data.clone(), function: call.function };
@@ -284,23 +277,60 @@ impl<M: Middleware> Multicall<M> {
     /// # }
     /// ```
     ///
+    /// # Panics
+    ///
+    /// If more than the maximum number of supported calls are added. The maximum
+    /// limits is constrained due to tokenization/detokenization support for tuples
+    ///
     /// Note: this method _does not_ send a transaction from your account
     ///
     /// [`ContractError<M>`]: crate::ContractError<M>
     pub async fn call<D: Detokenize>(&self) -> Result<D, ContractError<M>> {
-        let contract_call = self.as_contract_call();
+        assert!(self.calls.len() < 16, "Cannot decode more than {} calls", 16);
+        let tokens = self.call_raw().await?;
+        let tokens = vec![Token::Tuple(tokens)];
+        let data = D::from_tokens(tokens)?;
+        Ok(data)
+    }
 
+    /// Queries the Ethereum blockchain via an `eth_call`, but via the Multicall contract and
+    /// without detokenization.
+    ///
+    /// It returns a [`ContractError<M>`] if there is any error in the RPC call.
+    ///
+    /// ```no_run
+    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use ethers_core::types::{U256, Address};
+    /// # use ethers_providers::{Provider, Http};
+    /// # use ethers_contract::Multicall;
+    /// # use std::convert::TryFrom;
+    /// #
+    /// # let client = Provider::<Http>::try_from("http://localhost:8545")?;
+    /// #
+    /// # let multicall = Multicall::new(client, None).await?;
+    /// // If the Solidity function calls has the following return types:
+    /// // 1. `returns (uint256)`
+    /// // 2. `returns (string, address)`
+    /// // 3. `returns (bool)`
+    /// let tokens = multicall.call_raw().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Note: this method _does not_ send a transaction from your account
+    ///
+    /// [`ContractError<M>`]: crate::ContractError<M>
+
+    pub async fn call_raw(&self) -> Result<Vec<Token>, ContractError<M>> {
+        let contract_call = self.as_contract_call();
         // Fetch response from the Multicall contract
         let (_block_number, return_data) = contract_call.call().await?;
-
-        // Decode return data into ABI tokens
         let tokens = self
             .calls
             .iter()
             .zip(&return_data)
             .map(|(call, bytes)| {
                 let mut tokens: Vec<Token> = call.function.decode_output(bytes.as_ref())?;
-
                 Ok(match tokens.len() {
                     0 => Token::Tuple(vec![]),
                     1 => tokens.remove(0),
@@ -308,14 +338,7 @@ impl<M: Middleware> Multicall<M> {
                 })
             })
             .collect::<Result<Vec<Token>, ContractError<M>>>()?;
-
-        // Form tokens that represent tuples
-        let tokens = vec![Token::Tuple(tokens)];
-
-        // Detokenize from the tokens into the provided tuple D
-        let data = D::from_tokens(tokens)?;
-
-        Ok(data)
+        Ok(tokens)
     }
 
     /// Signs and broadcasts a batch of transactions by using the Multicall contract as proxy.

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -308,10 +308,8 @@ impl<M: Middleware> Multicall<M> {
     /// # let client = Provider::<Http>::try_from("http://localhost:8545")?;
     /// #
     /// # let multicall = Multicall::new(client, None).await?;
-    /// // If the Solidity function calls has the following return types:
-    /// // 1. `returns (uint256)`
-    /// // 2. `returns (string, address)`
-    /// // 3. `returns (bool)`
+    /// // The consumer of the API is responsible for detokenizing the results
+    /// // as the results will be a Vec<Token>
     /// let tokens = multicall.call_raw().await?;
     /// # Ok(())
     /// # }


### PR DESCRIPTION
## Motivation

Multicall's `add_call` method is capped at 16 calls due to detokenization (tuple) contraints. Such a cap may force users to make more calls than necessary. 

References:  #900 

## Solution

Expose a new `call_raw` method on the MultiCall interface that skips detokenization. The `call` method can then wrap `call_raw` to avoid code duplication and add in the detokenization. 

## Additional Notes
- While current tests should ensure no regressions for `call`, only a simple test was added for `call_raw`. This may need to be improved.
- The 16 call limit panic is moved from `add_call` to `call`. As it's a panic, it is not likely to cause issues in current deployments; however, it may be worth pointing out in Changelog in case anyone relied upon it.
- The test cases for `multicall_aggregate` did not appear to be compatible with ganache ^7.0.0 as they assumed default accounts were seeded with 100 ether, not 1000 ether. Changes were made to `spawn` to accommodate this
- Documentation was added / modified for `call_raw` and `call`; however, formatting still needs to be checked

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
