### PR TITLE
Remove `limit` on `Filter`

### DIFF
--- a/ethers-core/src/types/log.rs
+++ b/ethers-core/src/types/log.rs
@@ -160,9 +160,6 @@ pub struct Filter {
     // TODO: We could improve the low level API here by using ethabi's RawTopicFilter
     // and/or TopicFilter
     pub topics: [Option<ValueOrArray<H256>>; 4],
-
-    /// Limit
-    limit: Option<usize>,
 }
 
 impl Serialize for Filter {
@@ -201,10 +198,6 @@ impl Serialize for Filter {
             }
         }
         s.serialize_field("topics", &filtered_topics)?;
-
-        if let Some(ref limit) = self.limit {
-            s.serialize_field("limit", limit)?;
-        }
 
         s.end()
     }
@@ -341,12 +334,6 @@ impl Filter {
     #[must_use]
     pub fn topic3<T: Into<ValueOrArray<H256>>>(mut self, topic: T) -> Self {
         self.topics[3] = Some(topic.into());
-        self
-    }
-
-    #[must_use]
-    pub fn limit(mut self, limit: usize) -> Self {
-        self.limit = Some(limit);
         self
     }
 }


### PR DESCRIPTION
## Motivation

While building a CLI to decode logs I reached for the `limit` method on `Filter` in order to implement some sort of pagination. To my surprise, it does not seem to have any effect. Combing through the documentation for Alchemy and Infura, the entries for `eth_getLogs` do not appear to include any `limit` option.

After pinging @gakonst in telegram, he suggested I make a PR to remove this as it doesn't appear to be part of the JSON-RPC specification.

## Solution

Removed the `limit` option from `Filter`.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog