### PR TITLE
fix(abigen): do not panic when run on non-cargo projects

### DIFF
--- a/ethers-core/src/macros/ethers_crate.rs
+++ b/ethers-core/src/macros/ethers_crate.rs
@@ -43,7 +43,14 @@ pub fn ethers_providers_crate() -> Path {
 /// `cargo metadata` if a `Cargo.lock` file exists and delete it afterwards if
 /// it was created by `cargo metadata`.
 pub fn determine_ethers_crates() -> (&'static str, &'static str, &'static str) {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("No Manifest found");
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR");
+
+    // if there is no cargo manifest, default to `ethers::`-style imports.
+    let manifest_dir = if let Ok(manifest_dir) = manifest_dir {
+        manifest_dir
+    } else {
+        return ("ethers::core", "ethers::contract", "ethers::providers")
+    };
 
     // check if the lock file exists, if it's missing we need to clean up afterward
     let lock_file = format!("{}/Cargo.lock", manifest_dir);

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -728,7 +728,7 @@ mod tests {
             // update this test whenever there's a new sol
             // version. that's ok! good reminder to check the
             // patch notes.
-            (">=0.5.0", "0.8.11"),
+            (">=0.5.0", "0.8.12"),
             // range
             (">=0.4.0 <0.5.0", "0.4.26"),
         ]


### PR DESCRIPTION
This allows us to generate bindings in projects that do not have a `Cargo.toml`, e.g. in Solidity repositories when using `forge bind` https://github.com/gakonst/foundry/pull/620. Previously, we had to not support it: https://github.com/gakonst/foundry/pull/663