### PR TITLE
change visibility of request in Provider<JsonRpcClient>

### DIFF
--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -184,7 +184,7 @@ impl<P: JsonRpcClient> Provider<P> {
         self
     }
 
-    async fn request<T, R>(&self, method: &str, params: T) -> Result<R, ProviderError>
+    pub async fn request<T, R>(&self, method: &str, params: T) -> Result<R, ProviderError>
     where
         T: Debug + Serialize + Send + Sync,
         R: Serialize + DeserializeOwned + Debug,


### PR DESCRIPTION
## Motivation

I want to implement a custom MIddleware to call otterscan RPC calls on the node and self implemented ones, currently the `request` function on `Provider<JsonRpcClient>` is private, changing the function to public will allow me to create implementations like this one.

```rs
#[async_trait]
pub trait OtterScanMiddleware: Middleware {
    async fn get_api_level(&self) -> Result<U64, ProviderError> {
        self.provider().get_api_level().await.map_err(FromErr::from)
    }
}

#[async_trait]
impl<P: JsonRpcClient> OtterScanMiddleware for Provider<P> {
    async fn get_api_level(&self) -> Result<U64, ProviderError> {
        self.request("ots_getApiLevel", []).await
    }
}

```



## Solution

change `request` function to `pub`
