### PR TITLE
feat(chain): add Cronos and Cronos testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Unreleased
 
+- Add Cronos mainnet beta and testnet to the list of known chains
+  [926](https://github.com/gakonst/ethers-rs/pull/926)
 - `Chain::to_string` will return the same chain name as `Chain::from_str`
 - Add `eth_syncing` [848](https://github.com/gakonst/ethers-rs/pull/848)
 - Fix overflow and possible divide-by-zero in `estimate_priority_fee`

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -36,6 +36,8 @@ pub enum Chain {
     BinanceSmartChainTestnet = 97,
     Arbitrum = 42161,
     ArbitrumTestnet = 421611,
+    Cronos = 25,
+    CronosTestnet = 338,
 }
 
 impl fmt::Display for Chain {
@@ -63,6 +65,8 @@ impl fmt::Display for Chain {
             Chain::BinanceSmartChainTestnet => "bsc-testnet",
             Chain::Arbitrum => "arbitrum",
             Chain::ArbitrumTestnet => "arbitrum-testnet",
+            Chain::Cronos => "cronos",
+            Chain::CronosTestnet => "cronos-testnet",
         };
 
         write!(formatter, "{}", chain)
@@ -162,7 +166,8 @@ impl Chain {
                 Chain::BinanceSmartChain |
                 Chain::BinanceSmartChainTestnet |
                 Chain::Arbitrum |
-                Chain::ArbitrumTestnet,
+                Chain::ArbitrumTestnet |
+                Chain::Cronos,
         )
     }
 }

--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -87,6 +87,9 @@ impl Client {
                 Url::parse("https://api-testnet.arbiscan.io/api"),
                 Url::parse("https://testnet.arbiscan.io"),
             ),
+            Chain::Cronos => {
+                (Url::parse("https://api.cronoscan.com/api"), Url::parse("https://cronoscan.com"))
+            }
             chain => return Err(EtherscanError::ChainNotSupported(chain)),
         };
 
@@ -116,9 +119,10 @@ impl Client {
             Chain::BinanceSmartChain |
             Chain::BinanceSmartChainTestnet |
             Chain::Arbitrum |
-            Chain::ArbitrumTestnet => std::env::var("ETHERSCAN_API_KEY")?,
+            Chain::ArbitrumTestnet |
+            Chain::Cronos => std::env::var("ETHERSCAN_API_KEY")?,
 
-            Chain::XDai | Chain::Sepolia => String::default(),
+            Chain::XDai | Chain::Sepolia | Chain::CronosTestnet => String::default(),
             Chain::Moonbeam | Chain::MoonbeamDev | Chain::Moonriver => {
                 std::env::var("MOONSCAN_API_KEY")?
             }


### PR DESCRIPTION
## Motivation

Missing support of Cronos in Foundry, as the mainnet beta does not support EIP-1559 yet (the latest testnet does). 

## Solution

Added Cronos and CronosTestnet to the Chain enum in ethers-core types, and marked Cronos in the is_legacy function.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
