### PR TITLE
wip/experimental - add vyper support

### DIFF
--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -1872,7 +1872,11 @@ pub struct StorageType {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct Error {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "serde_helpers::default_on_error"
+    )]
     pub source_location: Option<SourceLocation>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub secondary_source_locations: Vec<SecondarySourceLocation>,

--- a/ethers-solc/src/artifacts/serde_helpers.rs
+++ b/ethers-solc/src/artifacts/serde_helpers.rs
@@ -45,6 +45,14 @@ where
     Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
 }
 
+pub fn default_on_error<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    Ok(Option::<T>::deserialize(deserializer).unwrap_or_default().unwrap_or_default())
+}
+
 pub mod json_string_opt {
     use serde::{
         de::{self, DeserializeOwned},

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -18,6 +18,7 @@ pub mod contracts;
 pub mod many;
 pub mod output;
 pub mod project;
+pub mod vyper;
 
 /// The name of the `solc` binary on the system
 pub const SOLC: &str = "solc";

--- a/ethers-solc/src/compile/vyper.rs
+++ b/ethers-solc/src/compile/vyper.rs
@@ -1,0 +1,178 @@
+use semver::Version;
+use serde::{de::DeserializeOwned, Serialize};
+use std::{
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+
+use crate::{
+    error::{Result, SolcError},
+    CompilerInput, CompilerOutput, Source,
+};
+
+use super::{compile_output, version_from_output};
+
+/// The name of the `solc` binary on the system
+pub const VYPER: &str = "vyper";
+
+pub struct Vyper {
+    /// Path to the `solc` executable
+    pub vyper: PathBuf,
+    /// Additional arguments passed to the `solc` exectuable
+    pub args: Vec<String>,
+}
+
+impl Default for Vyper {
+    fn default() -> Self {
+        if let Ok(vyper) = std::env::var("VYPER_PATH") {
+            return Vyper::new(vyper)
+        }
+
+        Vyper::new(VYPER)
+    }
+}
+
+impl Vyper {
+    /// A new instance which points to `vyper`
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Vyper { vyper: path.into(), args: Vec::new() }
+    }
+
+    pub fn compile_source(&self, path: impl AsRef<Path>) -> Result<CompilerOutput> {
+        let path = path.as_ref();
+        self.compile(&CompilerInput::new(path)?)
+    }
+
+    pub fn compile_exact(&self, input: &CompilerInput) -> Result<CompilerOutput> {
+        let mut out = self.compile(input)?;
+        out.retain_files(input.sources.keys().filter_map(|p| p.to_str()));
+        Ok(out)
+    }
+
+    pub fn compile<T: Serialize>(&self, input: &T) -> Result<CompilerOutput> {
+        self.compile_as(input)
+    }
+
+    pub fn compile_as<T: Serialize, D: DeserializeOwned>(&self, input: &T) -> Result<D> {
+        let output = self.compile_output(input)?;
+        Ok(serde_json::from_slice(&output)?)
+    }
+
+    pub fn compile_output<T: Serialize>(&self, input: &T) -> Result<Vec<u8>> {
+        let mut cmd = Command::new(&self.vyper);
+
+        // Filter out solc arguments
+        let mut args = vec![];
+        let mut skip = false;
+        for arg in &self.args {
+            if skip {
+                continue
+            }
+            if arg == "--allow-paths" {
+                skip = true;
+            } else {
+                skip = false;
+                args.push(arg);
+            }
+        }
+
+        let mut child = cmd
+            .args(&args)
+            .arg("--standard-json")
+            .stdin(Stdio::piped())
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .map_err(|err| SolcError::io(err, &self.vyper))?; // todo error
+        let stdin = child.stdin.take().expect("Stdin exists.");
+        serde_json::to_writer(stdin, input)?;
+        compile_output(child.wait_with_output().map_err(|err| SolcError::Message(err.to_string()))?)
+    }
+
+    pub fn version_short(&self) -> Result<Version> {
+        let version = self.version()?;
+        Ok(Version::new(version.major, version.minor, version.patch))
+    }
+
+    pub fn version(&self) -> Result<Version> {
+        version_from_output(
+            Command::new(&self.vyper)
+                .arg("--version")
+                .stdin(Stdio::piped())
+                .stderr(Stdio::piped())
+                .stdout(Stdio::piped())
+                .output()
+                .map_err(|err| SolcError::io(err, &self.vyper))?,
+        )
+    }
+
+    #[cfg(feature = "async")]
+    /// Convenience function for compiling all sources under the given path
+    pub async fn async_compile_source<T: Serialize>(
+        &self,
+        path: impl AsRef<Path>,
+    ) -> Result<CompilerOutput> {
+        self.async_compile(&CompilerInput::with_sources(Source::async_read_all_from(path).await?))
+            .await
+    }
+
+    #[cfg(feature = "async")]
+    /// Run `solc --stand-json` and return the `solc`'s output as
+    /// `CompilerOutput`
+    pub async fn async_compile<T: Serialize + std::marker::Sync>(
+        &self,
+        input: &T,
+    ) -> Result<CompilerOutput> {
+        self.async_compile_as(input).await
+    }
+
+    #[cfg(feature = "async")]
+    /// Run `solc --stand-json` and return the `solc`'s output as the given json
+    /// output
+    pub async fn async_compile_as<T: Serialize + std::marker::Sync, D: DeserializeOwned>(
+        &self,
+        input: &T,
+    ) -> Result<D> {
+        let output = self.async_compile_output(input).await?;
+        Ok(serde_json::from_slice(&output)?)
+    }
+
+    #[cfg(feature = "async")]
+    pub async fn async_compile_output<T: Serialize + std::marker::Sync>(
+        &self,
+        input: &T,
+    ) -> Result<Vec<u8>> {
+        use tokio::io::AsyncWriteExt;
+        let content = serde_json::to_vec(input)?;
+        let mut child = tokio::process::Command::new(&self.vyper)
+            .args(&self.args)
+            .arg("--standard-json")
+            .stdin(Stdio::piped())
+            .stderr(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .map_err(|err| SolcError::io(err, &self.vyper))?;
+        let stdin = child.stdin.as_mut().unwrap();
+        stdin.write_all(&content).await.map_err(|err| SolcError::io(err, &self.vyper))?;
+        stdin.flush().await.map_err(|err| SolcError::io(err, &self.vyper))?;
+        compile_output(
+            child.wait_with_output().await.map_err(|err| SolcError::io(err, &self.vyper))?,
+        )
+    }
+
+    #[cfg(feature = "async")]
+    pub async fn async_version(&self) -> Result<Version> {
+        version_from_output(
+            tokio::process::Command::new(&self.vyper)
+                .arg("--version")
+                .stdin(Stdio::piped())
+                .stderr(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .map_err(|err| SolcError::io(err, &self.vyper))?
+                .wait_with_output()
+                .await
+                .map_err(|err| SolcError::io(err, &self.vyper))?,
+        )
+    }
+}

--- a/ethers-solc/src/utils.rs
+++ b/ethers-solc/src/utils.rs
@@ -67,7 +67,7 @@ pub fn source_files(root: impl AsRef<Path>) -> Vec<PathBuf> {
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| e.file_type().is_file())
-        .filter(|e| e.path().extension().map(|ext| ext == "sol").unwrap_or_default())
+        .filter(|e| e.path().extension().map(|ext| ext == "sol" || ext == "vy").unwrap_or_default())
         .map(|e| e.path().into())
         .collect()
 }


### PR DESCRIPTION
I initially tried to make something of a compiler trait, but with how much `solc` is spread, I kinda gave up and tried to keep the changes as compartmentalized as possible.

What do you think? Is it something that might be of interest pursuing? What would be the direction that you'd suggest?

Depends on: https://github.com/vyperlang/vyper/issues/2674
``
I tried out building `year/yearn-vaults` with foundry and this branch

`brownie compile  56.32s user 0.77s system 97% cpu 58.326 total`
`target/debug/forge build --evm-version berlin  51.66s user 0.35s system 96% cpu 53.705 total`

`forge run` also works fine with this branch.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
