### PR TITLE
Add missing chains into parse method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Add FTM Mainet and testnet to parse method "try_from" from Chain.rs and add cronos mainet and testnet to "from_str"
 - Add FTM mainnet and testnet Multicall addresses [927](https://github.com/gakonst/ethers-rs/pull/927)
 - Add Cronos mainnet beta and testnet to the list of known chains
   [926](https://github.com/gakonst/ethers-rs/pull/926)

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -103,6 +103,8 @@ impl TryFrom<u64> for Chain {
             42 => Chain::Kovan,
             100 => Chain::XDai,
             137 => Chain::Polygon,
+            250 => Chain::Fantom,
+            4002 => Chain::FantomTestnet,
             80001 => Chain::PolygonMumbai,
             43114 => Chain::Avalanche,
             43113 => Chain::AvalancheFuji,
@@ -116,6 +118,8 @@ impl TryFrom<u64> for Chain {
             97 => Chain::BinanceSmartChainTestnet,
             42161 => Chain::Arbitrum,
             421611 => Chain::ArbitrumTestnet,
+            25 => Chain::Cronos,
+            338 => Chain::CronosTestnet,
             _ => return Err(ParseChainError(chain.to_string())),
         })
     }
@@ -147,6 +151,8 @@ impl FromStr for Chain {
             "bsc-testnet" => Chain::BinanceSmartChainTestnet,
             "arbitrum" => Chain::Arbitrum,
             "arbitrum-testnet" => Chain::ArbitrumTestnet,
+            "cronos" => Chain::Cronos,
+            "cronos-testnet" => Chain::CronosTestnet,
             _ => return Err(ParseChainError(chain.to_owned())),
         })
     }


### PR DESCRIPTION

## Motivation
Adding missing chain into parse method, should fix this [issue](https://github.com/gakonst/foundry/issues/777)


## Solution

Just adding chain-id => Chain into "try_from" for Cronosand FTM, and string => Chain into from_str for Cronos

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [X] Updated the changelog
