### PR TITLE
feat: cached provider PoC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0834a35a3fce649144119e18da2a4d8ed12ef3862f47183fd46f625d072d96c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num_cpus",
+ "parking_lot 0.12.0",
+ "rayon",
+ "serde",
+]
+
+[[package]]
 name = "dbl"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1326,7 @@ dependencies = [
  "auto_impl",
  "base64 0.13.0",
  "bytes",
+ "dashmap",
  "ethers-core",
  "futures-channel",
  "futures-core",
@@ -1320,7 +1334,7 @@ dependencies = [
  "futures-util",
  "hex",
  "http",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-project",
  "reqwest",
  "serde",
@@ -2070,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -2415,7 +2429,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -2430,6 +2454,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3337,7 +3374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
 dependencies = [
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.11.2",
  "serial_test_derive",
 ]
 
@@ -3555,7 +3592,7 @@ checksum = "923f0f39b6267d37d23ce71ae7235602134b250ace715dd2c90421998ddac0c6"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.11.2",
  "phf_shared 0.8.0",
  "precomputed-hash",
 ]
@@ -3774,7 +3811,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
@@ -4225,7 +4262,7 @@ checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4303,6 +4340,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "winreg"

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -39,6 +39,7 @@ tracing = { version = "0.1.31", default-features = false }
 tracing-futures = { version = "0.2.5", default-features = false, features = ["std-future"] }
 
 bytes = { version  = "1.1.0", default-features = false, optional = true }
+dashmap = { version = "5.1.0", features = ["serde", "rayon"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # tokio

--- a/ethers-providers/src/cache.rs
+++ b/ethers-providers/src/cache.rs
@@ -1,0 +1,98 @@
+use crate::ProviderError;
+use dashmap::DashMap;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{
+    fs::File,
+    io::{BufReader, BufWriter},
+    path::PathBuf,
+};
+
+#[derive(Clone, Debug, Default)]
+/// Simple in-memory K-V cache using concurrent dashmap which flushes
+/// its state to disk on `Drop`.
+pub struct Cache {
+    path: PathBuf,
+    // serialized request / response pair
+    requests: DashMap<String, String>,
+}
+
+// Helper type for (de)serialization
+#[derive(Serialize, Deserialize)]
+struct CachedRequest<'a, T> {
+    method: &'a str,
+    params: T,
+}
+
+impl Cache {
+    /// Instantiates a new cache at a file path.
+    pub fn new(path: PathBuf) -> Result<Self, ProviderError> {
+        // try to read the already existing requests
+        let reader =
+            BufReader::new(File::options().write(true).read(true).create(true).open(&path)?);
+        let requests = serde_json::from_reader(reader).unwrap_or_default();
+        Ok(Self { path, requests })
+    }
+
+    pub fn get<T: Serialize, R: DeserializeOwned>(
+        &self,
+        method: &str,
+        params: &T,
+    ) -> Result<Option<R>, ProviderError> {
+        let key = serde_json::to_string(&CachedRequest { method, params })?;
+        let value = self.requests.get(&key);
+        value.map(|x| serde_json::from_str(&x).map_err(ProviderError::SerdeJson)).transpose()
+    }
+
+    pub fn set<T: Serialize, R: Serialize>(
+        &self,
+        method: &str,
+        params: T,
+        response: R,
+    ) -> Result<(), ProviderError> {
+        let key = serde_json::to_string(&CachedRequest { method, params })?;
+        let value = serde_json::to_string(&response)?;
+        self.requests.insert(key, value);
+        Ok(())
+    }
+}
+
+impl Drop for Cache {
+    fn drop(&mut self) {
+        let file = match File::options().write(true).read(true).create(true).open(&self.path) {
+            Ok(inner) => BufWriter::new(inner),
+            Err(err) => {
+                tracing::error!("could not open cache file {}", err);
+                return
+            }
+        };
+
+        // overwrite the cache
+        if let Err(err) = serde_json::to_writer(file, &self.requests) {
+            tracing::error!("could not write to cache file {}", err);
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Middleware, Provider};
+    use ethers_core::types::{Address, U256};
+
+    #[tokio::test]
+    async fn test_cache() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let (provider, mock) = Provider::mocked();
+        let provider = provider.with_cache(cache.clone());
+        let addr = Address::random();
+
+        assert!(provider.cache().unwrap().requests.is_empty());
+
+        mock.push(U256::from(100u64)).unwrap();
+        let res = provider.get_balance(addr, None).await.unwrap();
+        assert_eq!(res, 100.into());
+
+        assert!(!provider.cache().unwrap().requests.is_empty());
+        dbg!(&provider.cache());
+    }
+}

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![allow(clippy::type_complexity)]
 #![doc = include_str!("../README.md")]
 mod transports;

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -8,6 +8,8 @@ pub use transports::*;
 
 mod provider;
 
+mod cache;
+
 // ENS support
 pub mod ens;
 


### PR DESCRIPTION
# Problem

We want to avoid repeating requests which we expect to have the same response. This is useful when used together with Forge's mainnet forking tests.

# Solution

Add a `Cache` which stores all request/responses pairs in-memory, which then proceeds to store them in disk when it gets Dropped
