### PR TITLE
fix(abigen/solc): make abigen work with ethers-solc and abiencoderv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@
 
 ### Unreleased
 
+- Wrap `ethabi::Contract` into new type `LosslessAbi` and `abi: Option<Abi>` with `abi: Option<LosslessAbi>` in `ConfigurableContractArtifact`
+  [#952](https://github.com/gakonst/ethers-rs/pull/952)
 - Let `Project` take ownership of `ArtifactOutput` and change trait interface
   [#907](https://github.com/gakonst/ethers-rs/pull/907)
 - Total revamp of the `Project::compile` pipeline

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,6 +1187,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "dunce",
  "ethers-core",
+ "ethers-solc",
  "eyre",
  "getrandom 0.2.4",
  "hex",

--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -42,3 +42,4 @@ rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 tempfile = "3.2.0"
+ethers-solc = { path = "../../ethers-solc", default-features = false, features = ["project-util"] }

--- a/ethers-contract/ethers-contract-abigen/src/lib.rs
+++ b/ethers-contract/ethers-contract-abigen/src/lib.rs
@@ -235,6 +235,7 @@ impl ContractBindings {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ethers_solc::project_util::TempProject;
 
     #[test]
     fn can_generate_structs() {
@@ -243,5 +244,43 @@ mod tests {
         let gen = abigen.generate().unwrap();
         let out = gen.tokens.to_string();
         assert!(out.contains("pub struct Stuff"));
+    }
+
+    #[test]
+    fn can_compile_and_generate() {
+        let tmp = TempProject::dapptools().unwrap();
+
+        tmp.add_source(
+            "Greeter",
+            r#"
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+contract Greeter {
+
+    struct Inner {
+        bool a;
+    }
+
+    struct Stuff {
+        Inner inner;
+    }
+
+    function greet(Stuff calldata stuff) public view returns (Stuff memory) {
+        return stuff;
+    }
+}
+"#,
+        )
+        .unwrap();
+
+        let _ = tmp.compile().unwrap();
+
+        let abigen =
+            Abigen::from_file(tmp.artifacts_path().join("Greeter.sol/Greeter.json")).unwrap();
+        let gen = abigen.generate().unwrap();
+        let out = gen.tokens.to_string();
+        assert!(out.contains("pub struct Stuff"));
+        assert!(out.contains("pub struct Inner"));
     }
 }

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -718,7 +718,7 @@ mod tests {
     }
 
     #[test]
-    fn can_detect_incosistent_single_file_crate() {
+    fn can_detect_inconsistent_single_file_crate() {
         run_test(|context| {
             let Context { multi_gen, mod_root } = context;
 

--- a/ethers-contract/ethers-contract-abigen/src/rawabi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/rawabi.rs
@@ -8,7 +8,8 @@ use serde::{
 };
 
 /// Contract ABI as a list of items where each item can be a function, constructor or event
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(transparent)]
 pub struct RawAbi(Vec<Item>);
 
 impl IntoIterator for RawAbi {

--- a/ethers-solc/src/artifact_output/configurable.rs
+++ b/ethers-solc/src/artifact_output/configurable.rs
@@ -4,12 +4,11 @@ use crate::{
     artifacts::{
         output_selection::{ContractOutputSelection, EvmOutputSelection, EwasmOutputSelection},
         CompactBytecode, CompactContract, CompactContractBytecode, CompactDeployedBytecode,
-        CompactEvm, DevDoc, Ewasm, GasEstimates, Metadata, Offsets, Settings, StorageLayout,
-        UserDoc,
+        CompactEvm, DevDoc, Ewasm, GasEstimates, LosslessAbi, Metadata, Offsets, Settings,
+        StorageLayout, UserDoc,
     },
     ArtifactOutput, Contract, SolcConfig, SolcError,
 };
-use ethers_core::abi::Abi;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fs, path::Path};
 
@@ -21,7 +20,7 @@ use std::{collections::BTreeMap, fs, path::Path};
 pub struct ConfigurableContractArtifact {
     /// The Ethereum Contract ABI. If empty, it is represented as an empty
     /// array. See https://docs.soliditylang.org/en/develop/abi-spec.html
-    pub abi: Option<Abi>,
+    pub abi: Option<LosslessAbi>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bytecode: Option<CompactBytecode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -74,7 +73,7 @@ impl ConfigurableContractArtifact {
 impl From<ConfigurableContractArtifact> for CompactContractBytecode {
     fn from(artifact: ConfigurableContractArtifact) -> Self {
         CompactContractBytecode {
-            abi: artifact.abi,
+            abi: artifact.abi.map(Into::into),
             bytecode: artifact.bytecode,
             deployed_bytecode: artifact.deployed_bytecode,
         }

--- a/ethers-solc/src/hh.rs
+++ b/ethers-solc/src/hh.rs
@@ -3,11 +3,10 @@
 use crate::{
     artifacts::{
         Bytecode, BytecodeObject, CompactContract, CompactContractBytecode, Contract,
-        ContractBytecode, DeployedBytecode, Offsets,
+        ContractBytecode, DeployedBytecode, LosslessAbi, Offsets,
     },
     ArtifactOutput,
 };
-use ethers_core::abi::Abi;
 use serde::{Deserialize, Serialize};
 use std::collections::btree_map::BTreeMap;
 
@@ -24,7 +23,7 @@ pub struct HardhatArtifact {
     /// The source name of this contract in the workspace like `contracts/Greeter.sol`
     pub source_name: String,
     /// The contract's ABI
-    pub abi: Abi,
+    pub abi: LosslessAbi,
     /// A "0x"-prefixed hex string of the unlinked deployment bytecode. If the contract is not
     /// deployable, this has the string "0x"
     pub bytecode: Option<BytecodeObject>,
@@ -44,7 +43,7 @@ pub struct HardhatArtifact {
 impl From<HardhatArtifact> for CompactContract {
     fn from(artifact: HardhatArtifact) -> Self {
         CompactContract {
-            abi: Some(artifact.abi),
+            abi: Some(artifact.abi.abi),
             bin: artifact.bytecode,
             bin_runtime: artifact.deployed_bytecode,
         }
@@ -65,7 +64,7 @@ impl From<HardhatArtifact> for ContractBytecode {
             bcode.into()
         });
 
-        ContractBytecode { abi: Some(artifact.abi), bytecode, deployed_bytecode }
+        ContractBytecode { abi: Some(artifact.abi.abi), bytecode, deployed_bytecode }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Close #947 
Close #951
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add `LosslessAbi` type in ethers-solc to mitigate the fact that `ethabi::Abi` is not lossless
support `ethers-solc` -> abigen! with solidity structs
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
