### PR TITLE
feat(ethers-providers): expose pending tx_hash with a getter

### DIFF
--- a/ethers-providers/src/pending_transaction.rs
+++ b/ethers-providers/src/pending_transaction.rs
@@ -85,6 +85,11 @@ impl<'a, P: JsonRpcClient> PendingTransaction<'a, P> {
         self.provider.clone()
     }
 
+    /// Returns the transaction hash of the pending transaction
+    pub fn tx_hash(&self) -> TxHash {
+        self.tx_hash
+    }
+
     /// Sets the number of confirmations for the pending transaction to resolve
     /// to a receipt
     #[must_use]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

`ContractCall::send` returns `PendingTransaction`s, there is no way to access the tx hash since its a private field.

## Solution

Adding a getter so the user can get a contract call's tx hash.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
