### PR TITLE
chore: add rate limit message

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/source.rs
+++ b/ethers-contract/ethers-contract-abigen/src/source.rs
@@ -279,6 +279,12 @@ fn get_etherscan_contract(address: Address, domain: &str) -> Result<String> {
     if abi.starts_with("Contract source code not verified") {
         eyre::bail!("Contract source code not verified: {:?}", address);
     }
+    if abi.starts_with('{') && abi.contains("Max rate limit reached") {
+        eyre::bail!(
+            "Max rate limit reached, please use etherscan API Key for higher rate limit: {:?}",
+            address
+        );
+    }
 
     Ok(abi)
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
If no etherscan API key is set, Multiabigen (1+ etherscan sources) fails with "missing field abi" however the etherscan response is "{"status":"0","message":"NOTOK","result":"Max rate limit reached, please use API Key for higher rate limit"}"

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add max rate limit check for better error message
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
