### PR TITLE
feat(ethers-core/Chain): implement Default trait

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use thiserror::Error;
 
 use core::convert::TryFrom;
-use std::{fmt, str::FromStr};
+use std::{default, fmt, str::FromStr};
 
 use crate::types::U256;
 
@@ -176,4 +176,15 @@ impl Chain {
                 Chain::Cronos,
         )
     }
+}
+
+impl default::Default for Chain {
+    fn default() -> Self {
+        Chain::Mainnet
+    }
+}
+
+#[test]
+fn test_default_chain() {
+    assert_eq!(Chain::default(), Chain::Mainnet);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Not all that important, just more convenient when you are trying to derive `Default` on structs that may include the `Chain` as one of the fields.

## Solution

Implementing the `std::default::Default` trait

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
