### PR TITLE
chore: trim more deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,19 +219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
 dependencies = [
  "either",
- "radium 0.3.0",
-]
-
-[[package]]
-name = "bitvec"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1489fcb93a5bb47da0462ca93ad252ad6af2145cce58d10d46a83931ba9f016b"
-dependencies = [
- "funty",
- "radium 0.7.0",
- "tap",
- "wyz",
+ "radium",
 ]
 
 [[package]]
@@ -335,12 +323,6 @@ name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
-
-[[package]]
-name = "byte-slice-cast"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c751592b77c499e7bce34d99d67c2c11bdc0574e9a488ddade14150a4698"
 
 [[package]]
 name = "byte-tools"
@@ -531,7 +513,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f473ea37dfc9d2cb94fdde50c3d41f28c3f384b367573d66386fea38d76d466"
 dependencies = [
- "bitvec 0.17.4",
+ "bitvec",
  "coins-bip32",
  "getrandom 0.2.5",
  "hex",
@@ -1086,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "16.0.0"
-source = "git+https://github.com/rust-ethereum/ethabi?branch=master#d64dfbac38d10de01cf1c7b6ab669f07b375ecc6"
+source = "git+https://github.com/gakonst/ethabi?branch=more-trim#279e63e67902a677fb053edabc8bc4c4b3d11e03"
 dependencies = [
  "ethereum-types",
  "hex",
@@ -1102,8 +1084,7 @@ dependencies = [
 [[package]]
 name = "ethbloom"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
+source = "git+https://github.com/gakonst/parity-common?branch=trim#b7b371fdfcdb932881fff7907fc6989d0b6f5334"
 dependencies = [
  "crunchy",
  "fixed-hash",
@@ -1115,8 +1096,7 @@ dependencies = [
 [[package]]
 name = "ethereum-types"
 version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
+source = "git+https://github.com/gakonst/parity-common?branch=trim#b7b371fdfcdb932881fff7907fc6989d0b6f5334"
 dependencies = [
  "ethbloom",
  "fixed-hash",
@@ -1466,8 +1446,7 @@ dependencies = [
 [[package]]
 name = "fixed-hash"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+source = "git+https://github.com/gakonst/parity-common?branch=trim#b7b371fdfcdb932881fff7907fc6989d0b6f5334"
 dependencies = [
  "byteorder",
  "rand 0.8.5",
@@ -1517,12 +1496,6 @@ name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1879,19 +1852,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec",
-]
-
-[[package]]
 name = "impl-rlp"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+source = "git+https://github.com/gakonst/parity-common?branch=trim#b7b371fdfcdb932881fff7907fc6989d0b6f5334"
 dependencies = [
  "rlp",
 ]
@@ -1899,21 +1862,9 @@ dependencies = [
 [[package]]
 name = "impl-serde"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+source = "git+https://github.com/gakonst/parity-common?branch=trim#b7b371fdfcdb932881fff7907fc6989d0b6f5334"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "impl-trait-for-tuples"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2382,32 +2333,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-scale-codec"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7f3fcf5e45fc28b84dcdab6b983e77f197ec01f325a33f404ba6855afd1070"
-dependencies = [
- "arrayvec 0.7.2",
- "bitvec 1.0.0",
- "byte-slice-cast",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6e626dc84025ff56bf1476ed0e30d10c84d7f89a475ef46ebabee1095a8fba"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,24 +2602,12 @@ dependencies = [
 [[package]]
 name = "primitive-types"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
+source = "git+https://github.com/gakonst/parity-common?branch=trim#b7b371fdfcdb932881fff7907fc6989d0b6f5334"
 dependencies = [
  "fixed-hash",
- "impl-codec",
  "impl-rlp",
  "impl-serde",
  "uint",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
-dependencies = [
- "thiserror",
- "toml",
 ]
 
 [[package]]
@@ -2756,12 +2669,6 @@ name = "radium"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2994,8 +2901,7 @@ dependencies = [
 [[package]]
 name = "rlp"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
+source = "git+https://github.com/gakonst/parity-common?branch=trim#b7b371fdfcdb932881fff7907fc6989d0b6f5334"
 dependencies = [
  "bytes",
  "rustc-hex",
@@ -3622,12 +3528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3858,15 +3758,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3947,7 +3838,7 @@ dependencies = [
 [[package]]
 name = "trezor-client"
 version = "0.0.4"
-source = "git+https://github.com/gakonst/rust-trezor-api?branch=chore/bump-eth-types#113dbd29f4ce2c76e997dbd7e273ec456d179d97"
+source = "git+https://github.com/gakonst/rust-trezor-api?branch=trim#ed1beeea21a3e7569e42e4acaf2abed388a256dc"
 dependencies = [
  "byteorder",
  "hex",
@@ -3994,9 +3885,8 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "uint"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
+version = "0.9.3"
+source = "git+https://github.com/gakonst/parity-common?branch=trim#b7b371fdfcdb932881fff7907fc6989d0b6f5334"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -4326,15 +4216,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -10,8 +10,9 @@ repository = "https://github.com/gakonst/ethers-rs"
 keywords = ["ethereum", "web3", "celo", "ethers"]
 
 [dependencies]
-rlp = { version = "0.5.0", default-features = false }
-ethabi = { git = "https://github.com/rust-ethereum/ethabi", branch = "master", default-features = false, features = ["full-serde", "rlp"] }
+# rlp = { version = "0.5.0", default-features = false }
+rlp = { git = "https://github.com/gakonst/parity-common", branch = "trim", default-features = false }
+ethabi = { git = "https://github.com/gakonst/ethabi", branch = "more-trim", default-features = false, features = ["full-serde", "rlp"] }
 arrayvec = { version = "0.7.2", default-features = false }
 rlp-derive = { version = "0.1.0", default-features = false }
 

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = "^0.3"
 futures-executor = "^0.3"
 semver = "1.0.6"
 # trezor-client = { version = "0.0.4", optional = true, default-features = false, features = ["f_ethereum"] }
-trezor-client = { git = "https://github.com/gakonst/rust-trezor-api", branch = "chore/bump-eth-types", optional = true, default-features = false, features = ["f_ethereum"] }
+trezor-client = { git = "https://github.com/gakonst/rust-trezor-api", branch = "trim", optional = true, default-features = false, features = ["f_ethereum"] }
 
 # aws
 rusoto_core = { version = "0.47.0", optional = true }


### PR DESCRIPTION
Uses [this](https://github.com/gakonst/parity-common/tree/trim) branch from Parity-common which incorporates these PRs: https://github.com/paritytech/parity-common/pull/625, https://github.com/paritytech/parity-common/pull/630.

Then proceeds to use the new ethereum-types in:
1. ethabi: https://github.com/gakonst/ethabi/commit/279e63e67902a677fb053edabc8bc4c4b3d11e03
2. trezor client https://github.com/gakonst/rust-trezor-api/tree/trim


We cannot merge this PR, while it trims a lot of deps in ethers, the dependency is low enough that the rest of the ecosystem also needs to upgrade to it. At least shows that we can get rid of the parity deps once the relevant PRs are merged.