### PR TITLE
fix(abigen): safe ident field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@
 
 ## ethers-contract-abigen
 
+### Unreleased
+
+- Generate correct bindings of struct's field names that are reserved words
+  [#989](https://github.com/gakonst/ethers-rs/pull/989).
+
+### 0.6.0
+
 - Add `MultiAbigen` to generate a series of contract bindings that can be kept in the repo
   [#724](https://github.com/gakonst/ethers-rs/pull/724).
 - Add provided `event_derives` to call and event enums as well

--- a/ethers-contract/ethers-contract-abigen/src/contract/structs.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/structs.rs
@@ -107,7 +107,7 @@ impl Context {
             if is_tuple {
                 fields.push(ty);
             } else {
-                let field_name = util::ident(&field.name().to_snake_case());
+                let field_name = util::safe_ident(&field.name().to_snake_case());
                 fields.push(quote! { pub #field_name: #ty });
             }
         }
@@ -155,7 +155,7 @@ impl Context {
         let mut fields = Vec::with_capacity(sol_struct.fields().len());
         let mut param_types = Vec::with_capacity(sol_struct.fields().len());
         for field in sol_struct.fields() {
-            let field_name = util::ident(&field.name().to_snake_case());
+            let field_name = util::safe_ident(&field.name().to_snake_case());
             match field.r#type() {
                 FieldType::Elementary(ty) => {
                     param_types.push(ty.clone());

--- a/ethers-contract/tests/abigen.rs
+++ b/ethers-contract/tests/abigen.rs
@@ -518,3 +518,15 @@ fn can_gen_multi_etherscan() {
     let _contract = MyContract::new(Address::default(), Arc::clone(&provider));
     let _contract = MyContract2::new(Address::default(), provider);
 }
+
+#[test]
+fn can_gen_reserved_word_field_names() {
+    abigen!(
+        Test,
+        r#"[
+        struct Foo { uint256 ref; }
+    ]"#,
+    );
+
+    let _foo = Foo { ref_: U256::default() };
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

I was generating bindings for a contract that imports [dYdX's I_Solo.sol](https://github.com/dydxprotocol/perpetual/blob/master/contracts/external/dydx/I_Solo.sol) and got an error because `AssetAmount` has a field that is called `ref`.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

`ref` is a reserved word, so I use `util::safe_ident` instead of `util::ident` for field names.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
