### PR TITLE
feat(etherscan): source tree support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,6 +1274,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "serial_test",
+ "tempfile",
  "thiserror",
  "tokio",
 ]

--- a/ethers-etherscan/Cargo.toml
+++ b/ethers-etherscan/Cargo.toml
@@ -23,6 +23,7 @@ serde-aux = { version = "3.0.1", default-features = false }
 thiserror = "1.0.29"
 
 [dev-dependencies]
+tempfile = "3.3.0"
 tokio = { version = "1.5", features = ["macros", "rt-multi-thread", "time"] }
 serial_test = "0.6.0"
 

--- a/ethers-etherscan/src/errors.rs
+++ b/ethers-etherscan/src/errors.rs
@@ -23,4 +23,6 @@ pub enum EtherscanError {
     Serde(#[from] serde_json::Error),
     #[error("Contract source code not verified: {0}")]
     ContractCodeNotVerified(Address),
+    #[error(transparent)]
+    IO(#[from] std::io::Error),
 }

--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -12,6 +12,7 @@ pub mod account;
 pub mod contract;
 pub mod errors;
 pub mod gas;
+pub mod source_tree;
 pub mod transaction;
 
 pub(crate) type Result<T> = std::result::Result<T, EtherscanError>;

--- a/ethers-etherscan/src/source_tree.rs
+++ b/ethers-etherscan/src/source_tree.rs
@@ -1,0 +1,94 @@
+use crate::Result;
+use std::{
+    fs::create_dir_all,
+    path::{Component, Path, PathBuf},
+};
+
+#[derive(Debug)]
+pub struct SourceTreeEntry {
+    pub path: PathBuf,
+    pub contents: String,
+}
+
+#[derive(Debug)]
+pub struct SourceTree {
+    pub entries: Vec<SourceTreeEntry>,
+}
+
+impl SourceTree {
+    /// Expand the source tree into the provided directory.  This method sanitizes paths to ensure
+    /// that no directory traversal happens.
+    pub fn write_to(&self, dir: &Path) -> Result<()> {
+        create_dir_all(&dir)?;
+        for entry in &self.entries {
+            let sanitized_path = sanitize_path(&entry.path);
+            let joined = dir.join(sanitized_path);
+            if let Some(parent) = joined.parent() {
+                create_dir_all(parent)?;
+                std::fs::write(joined, &entry.contents)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Remove any components in a smart contract source path that could cause a directory traversal.
+fn sanitize_path(path: &Path) -> PathBuf {
+    Path::new(path)
+        .components()
+        .filter(|x| x.as_os_str() != Component::ParentDir.as_os_str())
+        .collect::<PathBuf>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::read_dir;
+
+    #[test]
+    fn test_source_tree_write() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let st = SourceTree {
+            entries: vec![
+                SourceTreeEntry { path: PathBuf::from("a/a.sol"), contents: String::from("Test") },
+                SourceTreeEntry {
+                    path: PathBuf::from("b/b.sol"),
+                    contents: String::from("Test 2"),
+                },
+            ],
+        };
+        st.write_to(&tempdir.path()).unwrap();
+        let written_paths = read_dir(tempdir.path()).unwrap();
+        let paths: Vec<PathBuf> =
+            written_paths.into_iter().filter_map(|x| x.ok()).map(|x| x.path()).collect();
+        assert_eq!(paths.len(), 2);
+        assert!(paths.contains(&tempdir.path().join("a")));
+        assert!(paths.contains(&tempdir.path().join("b")));
+    }
+
+    /// Ensure that the .. are ignored when writing the source tree to disk because of
+    /// sanitization.
+    #[test]
+    fn test_malformed_source_tree_write() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let st = SourceTree {
+            entries: vec![
+                SourceTreeEntry {
+                    path: PathBuf::from("../a/a.sol"),
+                    contents: String::from("Test"),
+                },
+                SourceTreeEntry {
+                    path: PathBuf::from("../b/../b.sol"),
+                    contents: String::from("Test 2"),
+                },
+            ],
+        };
+        st.write_to(&tempdir.path()).unwrap();
+        let written_paths = read_dir(tempdir.path()).unwrap();
+        let paths: Vec<PathBuf> =
+            written_paths.into_iter().filter_map(|x| x.ok()).map(|x| x.path()).collect();
+        assert_eq!(paths.len(), 2);
+        assert!(paths.contains(&tempdir.path().join("a")));
+        assert!(paths.contains(&tempdir.path().join("b")));
+    }
+}


### PR DESCRIPTION
* Create a source tree of paths and their respective contents from the
ContractMetadata.

This is useful for file level analysis or writing the resulting files to disk.

* Test writing to disk via cargo test
* Test etherscan by uncommenting the ignore on
can_fetch_contract_source_tree_for_multi_entry_contract
and can_fetch_contract_source_tree_for_singleton_contract
