### PR TITLE
fix(solc): remove unnecessary indent

### DIFF
--- a/ethers-solc/src/resolver/tree.rs
+++ b/ethers-solc/src/resolver/tree.rs
@@ -160,7 +160,6 @@ fn print_imports(
     let mut iter = imports.iter().peekable();
 
     while let Some(import) = iter.next() {
-        // levels_continue.push(false);
         levels_continue.push(iter.peek().is_some());
         print_node(
             graph,

--- a/ethers-solc/src/resolver/tree.rs
+++ b/ethers-solc/src/resolver/tree.rs
@@ -157,14 +157,10 @@ fn print_imports(
         return Ok(())
     }
 
-    for continues in &**levels_continue {
-        let c = if *continues { symbols.down } else { " " };
-        write!(out, "{}   ", c)?;
-    }
-
     let mut iter = imports.iter().peekable();
 
     while let Some(import) = iter.next() {
+        // levels_continue.push(false);
         levels_continue.push(iter.peek().is_some());
         print_node(
             graph,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
remove wrong indent
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
on https://github.com/gakonst/dapptools-template :

```console
forge tree --no-dedupe                                                                                  
src/Greeter.sol ^0.8.0
└── lib/openzeppelin-contracts/contracts/access/Ownable.sol ^0.8.0
    └── lib/openzeppelin-contracts/contracts/utils/Context.sol ^0.8.0
src/test/Greeter.t.sol ^0.8.0
├── src/test/utils/GreeterTest.sol ^0.8.0
│   ├── lib/ds-test/src/test.sol >=0.4.23
│   ├── src/Greeter.sol ^0.8.0
│   │   └── lib/openzeppelin-contracts/contracts/access/Ownable.sol ^0.8.0
│   │       └── lib/openzeppelin-contracts/contracts/utils/Context.sol ^0.8.0
│   └── src/test/utils/Hevm.sol ^0.8.0
└── src/Greeter.sol ^0.8.0
    └── lib/openzeppelin-contracts/contracts/access/Ownable.sol ^0.8.0
        └── lib/openzeppelin-contracts/contracts/utils/Context.sol ^0.8.0
src/test/utils/GreeterTest.sol ^0.8.0
├── lib/ds-test/src/test.sol >=0.4.23
├── src/Greeter.sol ^0.8.0
│   └── lib/openzeppelin-contracts/contracts/access/Ownable.sol ^0.8.0
│       └── lib/openzeppelin-contracts/contracts/utils/Context.sol ^0.8.0
└── src/test/utils/Hevm.sol ^0.8.0
src/test/utils/Hevm.sol ^0.8.0
```
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
