### PR TITLE
feat(ethers-compile): ethers-compile crate to refactor compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,7 @@ version = "0.6.0"
 dependencies = [
  "bytes",
  "ethers-addressbook",
+ "ethers-compile",
  "ethers-contract",
  "ethers-core",
  "ethers-etherscan",
@@ -1157,6 +1158,10 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "ethers-compile"
+version = "0.1.0"
 
 [[package]]
 name = "ethers-contract"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "ethers-middleware",
     "ethers-etherscan",
     "ethers-solc",
+    "ethers-compile",
     "examples/ethers-wasm",
 ]
 
@@ -34,6 +35,7 @@ default-members = [
     "ethers-middleware",
     "ethers-etherscan",
     "ethers-solc",
+    "ethers-compile",
 ]
 
 [package.metadata.docs.rs]
@@ -80,6 +82,8 @@ solc-async = ["ethers-solc/async"]
 solc-full = ["ethers-solc/full"]
 solc-tests = ["ethers-solc/tests"]
 solc-sha2-asm = ["ethers-solc/asm"]
+## compiler
+# TODO: ...
 
 [dependencies]
 ethers-addressbook = { version = "^0.1.0", default-features = false, path = "./ethers-addressbook" }
@@ -90,6 +94,7 @@ ethers-signers = { version = "^0.6.0", default-features = false, path = "./ether
 ethers-middleware = { version = "^0.6.0", default-features = false, path = "./ethers-middleware" }
 ethers-solc = { version = "^0.3.0", default-features = false, path = "./ethers-solc" }
 ethers-etherscan = { version = "^0.2.0", default-features = false, path = "./ethers-etherscan" }
+ethers-compile = { version = "^0.1.0", default-features = false, path = "./ethers-compile" }
 
 [dev-dependencies]
 ethers-contract = { version = "^0.6.0", default-features = false, path = "./ethers-contract", features = ["abigen", "eip712"] }

--- a/assets/COMPILE_README.md
+++ b/assets/COMPILE_README.md
@@ -1,0 +1,27 @@
+# ethers-compile
+
+A refactored compiling framework.
+
+First add `ethers-compile` to your cargo build-dependencies.
+
+[Explain how to implement/use]
+
+```toml
+[build-dependencies]
+ethers-compile = { git = "https://github.com/gakonst/ethers-rs" }
+```
+
+```rust
+use ethers_compile::{Project, ProjectPathsConfig};
+fn main() {
+    // configure the project with all its paths, solc, cache etc.
+    let project = Project::builder()
+        .paths(ProjectPathsConfig::hardhat(env!("CARGO_MANIFEST_DIR")).unwrap())
+        .build()
+        .unwrap();
+    let output = project.compile().unwrap();
+    
+    // Tell Cargo that if a source file changes, to rerun this build script.
+    project.rerun_if_sources_changed();
+}
+```

--- a/ethers-compile/Cargo.toml
+++ b/ethers-compile/Cargo.toml
@@ -14,7 +14,7 @@ Compiler Abstraction
 keywords = ["ethereum", "web3", "solc", "solidity", "ethers", "vyper"]
 
 [dependencies]
-
+rayon = "1.5.1"
 
 [features]
 # default = ["rustls"]

--- a/ethers-compile/Cargo.toml
+++ b/ethers-compile/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ethers-compile"
+version = "0.1.0"
+authors = ["Andreas Bigger <andreas@nascent.xyz>"]
+license = "MIT OR Apache-2.0"
+edition = "2018"
+readme = "../README.md"
+documentation = "https://docs.rs/ethers"
+repository = "https://github.com/gakonst/ethers-rs"
+homepage = "https://docs.rs/ethers"
+description = """
+Compiler Abstraction
+"""
+keywords = ["ethereum", "web3", "solc", "solidity", "ethers", "vyper"]
+
+[dependencies]
+
+
+[features]
+# default = ["rustls"]
+# async = ["tokio", "futures-util"]
+# full = ["async", "svm", "svm/blocking"]
+# # Utilities for creating and testing project workspaces
+# project-util = ["tempfile", "fs_extra"]
+# tests = []
+# openssl = ["svm/openssl"]
+# rustls = ["svm/rustls"]
+# asm = ["sha2/asm", "svm/sha2-asm"]

--- a/ethers-compile/README.md
+++ b/ethers-compile/README.md
@@ -1,0 +1,27 @@
+# ethers-compile
+
+A refactored compiling framework.
+
+First add `ethers-compile` to your cargo build-dependencies.
+
+[Explain how to implement/use]
+
+```toml
+[build-dependencies]
+ethers-compile = { git = "https://github.com/gakonst/ethers-rs" }
+```
+
+```rust
+use ethers_compile::{Project, ProjectPathsConfig};
+fn main() {
+    // configure the project with all its paths, solc, cache etc.
+    let project = Project::builder()
+        .paths(ProjectPathsConfig::hardhat(env!("CARGO_MANIFEST_DIR")).unwrap())
+        .build()
+        .unwrap();
+    let output = project.compile().unwrap();
+    
+    // Tell Cargo that if a source file changes, to rerun this build script.
+    project.rerun_if_sources_changed();
+}
+```

--- a/ethers-compile/compiler/mod.rs
+++ b/ethers-compile/compiler/mod.rs
@@ -1,0 +1,2 @@
+pub mod traits;
+pub mod pipeline;

--- a/ethers-compile/compiler/pipeline.rs
+++ b/ethers-compile/compiler/pipeline.rs
@@ -1,0 +1,25 @@
+//! Manages compiling a solidity `Project`
+//!
+//! 
+
+use traits::{Compiler, Result};
+use rayon::prelude::*;
+use std::collections::btree_map::BTreeMap;
+
+#[derive(Debug)]
+pub struct Pipeline {}
+
+impl Pipeline {
+    /// Does basic preprocessing
+    ///   - sets proper source unit names
+    ///   - check cache
+    fn preprocess(self, T: Compiler) -> Result<PreprocessedState<'a, T>> {
+        let Self { edges, project, mut sources } = self;
+
+        let mut cache = ArtifactsCache::new(project, edges)?;
+        // retain and compile only dirty sources and all their imports
+        sources = sources.filtered(&mut cache);
+
+        Ok(PreprocessedState { sources, cache })
+    }
+}

--- a/ethers-compile/compiler/traits.rs
+++ b/ethers-compile/compiler/traits.rs
@@ -13,13 +13,13 @@ pub type Result<T, E> = std::result::Result<T, E>;
 ///
 /// pub struct Sanskrit {};
 ///
-/// pub enum SEroor {
+/// pub enum SError {
 ///   IO,
 ///   Compile,
 ///   Unknown
 /// };
 ///
-/// impl Compiler<u64, u64, SEroor> for Sanskrit {
+/// impl Compiler<u64, u64, SError> for Sanskrit {
 ///   fn compile(&self, input: &Self::Input) -> Result<Self::Output, Self::Error> {
 ///     return Ok(1);
 ///   }

--- a/ethers-compile/compiler/traits.rs
+++ b/ethers-compile/compiler/traits.rs
@@ -33,5 +33,8 @@ pub trait Compiler {
   type Output;
   type Error;
 
-  fn compile(&self, input: &Self::Input) -> Result<Self::Output, Self::Error>;
+  pub fn compile(&self, input: &Self::Input) -> Result<Self::Output, Self::Error>;
+
+  /// Exposes an api to set the underlying compiler version
+  pub fn configure_version(&self) -> Result<bool, Self::Error>;
 }

--- a/ethers-compile/project/builder.rs
+++ b/ethers-compile/project/builder.rs
@@ -1,0 +1,363 @@
+
+
+
+pub struct ProjectBuilder<T: ArtifactOutput = ConfigurableArtifacts> {
+    /// The layout of the
+    paths: Option<ProjectPathsConfig>,
+    /// Whether caching is enabled, default is true.
+    cached: bool,
+    /// Whether writing artifacts to disk is enabled, default is true.
+    no_artifacts: bool,
+    /// Whether automatic solc version detection is enabled
+    auto_detect: bool,
+    /// Use offline mode
+    offline: bool,
+    /// handles all artifacts related tasks
+    artifacts: T,
+    /// Which error codes to ignore
+    pub ignored_error_codes: Vec<u64>,
+    /// All allowed paths
+    pub allowed_paths: Vec<PathBuf>,
+    /// Maximum number of compiling processes to run simultaneously.
+    pub processes: usize,
+}
+
+impl<T: ArtifactOutput> ProjectBuilder<T> {
+    /// Create a new builder with the given artifacts handler
+    pub fn new(artifacts: T) -> Self {
+        Self {
+            paths: None,
+            cached: true,
+            no_artifacts: false,
+            auto_detect: true,
+            offline: false,
+            artifacts,
+            ignored_error_codes: Vec::new(),
+            allowed_paths: vec![],
+            processes: None,
+        }
+    }
+
+    #[must_use]
+    pub fn paths(mut self, paths: ProjectPathsConfig) -> Self {
+        self.paths = Some(paths);
+        self
+    }
+
+    #[must_use]
+    pub fn ignore_error_code(mut self, code: u64) -> Self {
+        self.ignored_error_codes.push(code);
+        self
+    }
+
+    #[must_use]
+    pub fn ignore_error_codes(mut self, codes: impl IntoIterator<Item = u64>) -> Self {
+        for code in codes {
+            self = self.ignore_error_code(code);
+        }
+        self
+    }
+
+    /// Disables cached builds
+    #[must_use]
+    pub fn ephemeral(self) -> Self {
+        self.set_cached(false)
+    }
+
+    /// Sets the cache status
+    #[must_use]
+    pub fn set_cached(mut self, cached: bool) -> Self {
+        self.cached = cached;
+        self
+    }
+
+    /// Activates offline mode
+    ///
+    /// Prevents network possible access to download/check solc installs
+    #[must_use]
+    pub fn offline(self) -> Self {
+        self.set_offline(true)
+    }
+
+    /// Sets the offline status
+    #[must_use]
+    pub fn set_offline(mut self, offline: bool) -> Self {
+        self.offline = offline;
+        self
+    }
+
+    /// Disables writing artifacts to disk
+    #[must_use]
+    pub fn no_artifacts(self) -> Self {
+        self.set_no_artifacts(true)
+    }
+
+    /// Sets the no artifacts status
+    #[must_use]
+    pub fn set_no_artifacts(mut self, artifacts: bool) -> Self {
+        self.no_artifacts = artifacts;
+        self
+    }
+
+    /// Sets automatic solc version detection
+    #[must_use]
+    pub fn set_auto_detect(mut self, auto_detect: bool) -> Self {
+        self.auto_detect = auto_detect;
+        self
+    }
+
+    /// Disables automatic solc version detection
+    #[must_use]
+    pub fn no_auto_detect(self) -> Self {
+        self.set_auto_detect(false)
+    }
+
+    /// Sets the maximum number of parallel compiling processes to run simultaneously.
+    ///
+    /// **Panics if `count == 0`**
+    pub fn set_processes(mut self, count: usize) {
+        assert!(count > 0);
+        self.processes = Some(count);
+        self
+    }
+
+    /// Sets the number of parallel processes to `1`, no parallelization
+    #[must_use]
+    pub fn single_processes(self) -> Self {
+        self.set_processes(1)
+    }
+
+    /// Set arbitrary `ArtifactOutputHandler`
+    pub fn artifacts<A: ArtifactOutput>(self, artifacts: A) -> ProjectBuilder<A> {
+        let ProjectBuilder {
+            paths,
+            cached,
+            no_artifacts,
+            auto_detect,
+            ignored_error_codes,
+            allowed_paths,
+            processes,
+            offline,
+            ..
+        } = self;
+        ProjectBuilder {
+            paths,
+            cached,
+            no_artifacts,
+            auto_detect,
+            offline,
+            artifacts,
+            ignored_error_codes,
+            allowed_paths,
+            processes,
+        }
+    }
+
+    /// Adds an allowed-path to the solc executable
+    #[must_use]
+    pub fn allowed_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
+        self.allowed_paths.push(path.into());
+        self
+    }
+
+    /// Adds multiple allowed-path to the solc executable
+    #[must_use]
+    pub fn allowed_paths<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<PathBuf>,
+    {
+        for arg in args {
+            self = self.allowed_path(arg);
+        }
+        self
+    }
+
+    pub fn build(self) -> Result<Project<T>> {
+        let Self {
+            paths,
+            cached,
+            no_artifacts,
+            auto_detect,
+            artifacts,
+            ignored_error_codes,
+            mut allowed_paths,
+            processes,
+            offline,
+        } = self;
+
+        let paths = paths.map(Ok).unwrap_or_else(ProjectPathsConfig::current_hardhat)?;
+
+        if allowed_paths.is_empty() {
+            // allow every contract under root by default
+            allowed_paths.push(paths.root.clone())
+        }
+
+        Ok(Project {
+            paths,
+            cached,
+            no_artifacts,
+            auto_detect,
+            artifacts,
+            ignored_error_codes,
+            allowed_lib_paths: allowed_paths.into(),
+            processes: processes.unwrap_or_else(::num_cpus::get),
+            offline,
+        })
+    }
+}
+
+impl<T: ArtifactOutput + Default> Default for ProjectBuilder<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T: ArtifactOutput> ArtifactOutput for Project<T> {
+    type Artifact = T::Artifact;
+
+    fn on_output(
+        &self,
+        contracts: &VersionedContracts,
+        layout: &ProjectPathsConfig,
+    ) -> Result<Artifacts<Self::Artifact>> {
+        self.artifacts_handler().on_output(contracts, layout)
+    }
+
+    fn write_contract_extras(&self, contract: &Contract, file: &Path) -> Result<()> {
+        self.artifacts_handler().write_contract_extras(contract, file)
+    }
+
+    fn write_extras(
+        &self,
+        contracts: &VersionedContracts,
+        layout: &ProjectPathsConfig,
+    ) -> Result<()> {
+        self.artifacts_handler().write_extras(contracts, layout)
+    }
+
+    fn output_file_name(name: impl AsRef<str>) -> PathBuf {
+        T::output_file_name(name)
+    }
+
+    fn output_file_name_versioned(name: impl AsRef<str>, version: &Version) -> PathBuf {
+        T::output_file_name_versioned(name, version)
+    }
+
+    fn output_file(contract_file: impl AsRef<Path>, name: impl AsRef<str>) -> PathBuf {
+        T::output_file(contract_file, name)
+    }
+
+    fn output_file_versioned(
+        contract_file: impl AsRef<Path>,
+        name: impl AsRef<str>,
+        version: &Version,
+    ) -> PathBuf {
+        T::output_file_versioned(contract_file, name, version)
+    }
+
+    fn contract_name(file: impl AsRef<Path>) -> Option<String> {
+        T::contract_name(file)
+    }
+
+    fn output_exists(
+        contract_file: impl AsRef<Path>,
+        name: impl AsRef<str>,
+        root: impl AsRef<Path>,
+    ) -> bool {
+        T::output_exists(contract_file, name, root)
+    }
+
+    fn read_cached_artifact(path: impl AsRef<Path>) -> Result<Self::Artifact> {
+        T::read_cached_artifact(path)
+    }
+
+    fn read_cached_artifacts<P, I>(files: I) -> Result<BTreeMap<PathBuf, Self::Artifact>>
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        T::read_cached_artifacts(files)
+    }
+
+    fn contract_to_artifact(&self, file: &str, name: &str, contract: Contract) -> Self::Artifact {
+        self.artifacts_handler().contract_to_artifact(file, name, contract)
+    }
+
+    fn output_to_artifacts(&self, contracts: &VersionedContracts) -> Artifacts<Self::Artifact> {
+        self.artifacts_handler().output_to_artifacts(contracts)
+    }
+}
+
+#[cfg(test)]
+#[cfg(all(feature = "svm", feature = "async"))]
+mod tests {
+    use crate::remappings::Remapping;
+
+    #[test]
+    fn test_build_all_versions() {
+        use super::*;
+
+        let paths = ProjectPathsConfig::builder()
+            .root("./test-data/test-contract-versions")
+            .sources("./test-data/test-contract-versions")
+            .build()
+            .unwrap();
+        let project = Project::builder().paths(paths).no_artifacts().ephemeral().build().unwrap();
+        let compiled = project.compile().unwrap();
+        assert!(!compiled.has_compiler_errors());
+        let contracts = compiled.output().contracts;
+        // Contracts A to F
+        assert_eq!(contracts.contracts().count(), 5);
+    }
+
+    #[test]
+    fn test_build_many_libs() {
+        use super::*;
+
+        let root = utils::canonicalize("./test-data/test-contract-libs").unwrap();
+
+        let paths = ProjectPathsConfig::builder()
+            .root(&root)
+            .sources(root.join("src"))
+            .lib(root.join("lib1"))
+            .lib(root.join("lib2"))
+            .remappings(
+                Remapping::find_many(&root.join("lib1"))
+                    .into_iter()
+                    .chain(Remapping::find_many(&root.join("lib2"))),
+            )
+            .build()
+            .unwrap();
+        let project = Project::builder()
+            .paths(paths)
+            .no_artifacts()
+            .ephemeral()
+            .no_artifacts()
+            .build()
+            .unwrap();
+        let compiled = project.compile().unwrap();
+        assert!(!compiled.has_compiler_errors());
+        let contracts = compiled.output().contracts;
+        assert_eq!(contracts.contracts().count(), 3);
+    }
+
+    #[test]
+    fn test_build_remappings() {
+        use super::*;
+
+        let root = utils::canonicalize("./test-data/test-contract-remappings").unwrap();
+        let paths = ProjectPathsConfig::builder()
+            .root(&root)
+            .sources(root.join("src"))
+            .lib(root.join("lib"))
+            .remappings(Remapping::find_many(&root.join("lib")))
+            .build()
+            .unwrap();
+        let project = Project::builder().no_artifacts().paths(paths).ephemeral().build().unwrap();
+        let compiled = project.compile().unwrap();
+        assert!(!compiled.has_compiler_errors());
+        let contracts = compiled.output().contracts;
+        assert_eq!(contracts.contracts().count(), 2);
+    }
+}

--- a/ethers-compile/project/mod.rs
+++ b/ethers-compile/project/mod.rs
@@ -1,0 +1,7 @@
+/// Reexport the Project Module
+mod project;
+pub use project::*;
+
+/// Reexport the Builder Module
+mod builder;
+pub use builder::*;

--- a/ethers-compile/project/project.rs
+++ b/ethers-compile/project/project.rs
@@ -1,0 +1,363 @@
+// pub mod artifacts;
+// pub mod sourcemap;
+
+// pub use artifacts::{CompilerInput, CompilerOutput, EvmVersion};
+// use std::collections::BTreeMap;
+
+// mod artifact_output;
+// pub mod cache;
+// pub mod hh;
+// pub use artifact_output::*;
+
+pub mod resolver;
+pub use hh::{HardhatArtifact, HardhatArtifacts};
+
+// TODO: Refactor Graphing
+// pub use resolver::Graph;
+
+mod compile;
+pub use compile::{
+    output::{AggregatedCompilerOutput, ProjectCompileOutput},
+    *,
+};
+
+mod config;
+pub use config::{AllowedLibPaths, PathStyle, ProjectPathsConfig, SolcConfig};
+
+pub mod remappings;
+use crate::artifacts::Source;
+
+pub mod error;
+pub mod report;
+pub mod utils;
+
+use crate::{
+    artifacts::{Contract, Sources},
+    contracts::VersionedContracts,
+    error::{SolcError, SolcIoError},
+};
+use error::Result;
+use semver::Version;
+use std::path::{Path, PathBuf};
+
+/// Utilities for creating, mocking and testing of (temporary) projects
+#[cfg(feature = "project-util")]
+pub mod project_util;
+
+/// Represents a project workspace
+#[derive(Debug)]
+pub struct Project<T: ArtifactOutput = ConfigurableArtifacts> {
+    /// The layout of the
+    pub paths: ProjectPathsConfig,
+    /// Whether caching is enabled
+    pub cached: bool,
+    /// Whether writing artifacts to disk is enabled
+    pub no_artifacts: bool,
+    /// Whether writing artifacts to disk is enabled
+    pub auto_detect: bool,
+    /// Handles all artifacts related tasks, reading and writing from the artifact dir.
+    pub artifacts: T,
+    /// Errors/Warnings which match these error codes are not going to be logged
+    pub ignored_error_codes: Vec<u64>,
+    /// The paths which will be allowed for library inclusion
+    pub allowed_lib_paths: AllowedLibPaths,
+    /// Maximum number of compiling processes to run simultaneously.
+    pub processes: usize,
+    /// Offline mode, if set, network access (downloading lang compilers) is disallowed
+    pub offline: bool,
+}
+
+impl Project {
+    /// Convenience function to call `ProjectBuilder::default()`
+    ///
+    /// # Example
+    ///
+    /// Configure with `ConfigurableArtifacts` artifacts output
+    ///
+    /// ```rust
+    /// use ethers_compile::Project;
+    /// let config = Project::builder().build().unwrap();
+    /// ```
+    ///
+    /// To configure any a project with any `ArtifactOutput` use either
+    ///
+    /// ```rust
+    /// use ethers_compile::Project;
+    /// let config = Project::builder().build().unwrap();
+    /// ```
+    ///
+    /// or use the builder directly
+    ///
+    /// ```rust
+    /// use ethers_compile::{ConfigurableArtifacts, ProjectBuilder};
+    /// let config = ProjectBuilder::<ConfigurableArtifacts>::default().build().unwrap();
+    /// ```
+    pub fn builder() -> ProjectBuilder {
+        ProjectBuilder::default()
+    }
+}
+
+// TODO: Refactor ArtifactOutput
+impl<T: ArtifactOutput> Project<T> {
+    /// Returns the path to the artifacts directory
+    pub fn artifacts_path(&self) -> &PathBuf {
+        &self.paths.artifacts
+    }
+
+    /// Returns the path to the sources directory
+    pub fn sources_path(&self) -> &PathBuf {
+        &self.paths.sources
+    }
+
+    /// Returns the path to the cache file
+    pub fn cache_path(&self) -> &PathBuf {
+        &self.paths.cache
+    }
+
+    /// Returns the root directory of the project
+    pub fn root(&self) -> &PathBuf {
+        &self.paths.root
+    }
+
+    /// Returns the handler that takes care of processing all artifacts
+    pub fn artifacts_handler(&self) -> &T {
+        &self.artifacts
+    }
+
+    /// Sets the maximum number of parallel compiling processes to run simultaneously.
+    ///
+    /// **Panics if `count == 0`**
+    pub fn set_processes(&mut self, count: usize) {
+        assert!(count > 0);
+        self.processes = Some(count);
+    }
+
+    /// Returns all sources found under the project's configured sources path
+    #[tracing::instrument(skip_all, fields(name = "sources"))]
+    pub fn sources(&self) -> Result<Sources> {
+        self.paths.read_sources()
+    }
+
+    /// This emits the cargo [`rerun-if-changed`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-changedpath) instruction.
+    /// Which tells Cargo to re-run the build script if a file inside the project's sources
+    /// directory has changed.
+    ///
+    /// Use this if you compile a project in a `build.rs` file.
+    ///
+    /// # Example `build.rs` file
+    ///
+    ///
+    /// ```no_run
+    /// use ethers_solc::{Project, ProjectPathsConfig};
+    /// // configure the project with all its paths, solc, cache etc. where the root dir is the current rust project.
+    /// let project = Project::builder()
+    ///     .paths(ProjectPathsConfig::hardhat(env!("CARGO_MANIFEST_DIR")).unwrap())
+    ///     .build()
+    ///     .unwrap();
+    /// let output = project.compile().unwrap();
+    /// // Tell Cargo that if a source file changes, to rerun this build script.
+    /// project.rerun_if_sources_changed();
+    /// ```
+    pub fn rerun_if_sources_changed(&self) {
+        println!("cargo:rerun-if-changed={}", self.paths.sources.display())
+    }
+
+    /// Attempts to compile the contracts found at the configured source location, see
+    /// `ProjectPathsConfig::sources`.
+    ///
+    /// NOTE: this does not check if the contracts were successfully compiled, see
+    /// `CompilerOutput::has_error` instead.
+    ///
+    /// NB: If the `svm` feature is enabled, this function will automatically detect
+    /// solc versions across files, see [`Self::svm_compile()`]
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ethers_solc::Project;
+    /// # fn demo(project: Project) {
+    /// let project = Project::builder().build().unwrap();
+    /// let output = project.compile().unwrap();
+    /// # }
+    /// ```
+    #[tracing::instrument(skip_all, name = "compile")]
+    pub fn compile(&self) -> Result<ProjectCompileOutput<T>> {
+        let sources = self.paths.read_input_files()?;
+        tracing::trace!("found {} sources to compile: {:?}", sources.len(), sources.keys());
+
+        #[cfg(all(feature = "svm", feature = "async"))]
+        if self.auto_detect {
+            tracing::trace!("using solc auto detection to compile sources");
+            return self.svm_compile(sources)
+        }
+
+        let solc = self.configure_solc(self.solc.clone());
+
+        self.compile_with_version(&solc, sources)
+    }
+
+    /// Compiles a set of contracts using `svm` managed solc installs
+    ///
+    /// This will autodetect the appropriate `Solc` version(s) to use when compiling the provided
+    /// `Sources`. Solc auto-detection follows semver rules, see also
+    /// [`crate::resolver::Graph::get_input_node_versions()`]
+    ///
+    /// # Errors
+    ///
+    /// This returns an error if contracts in the `Sources` set are incompatible (violate semver
+    /// rules) with their imports, for example source contract `A(=0.8.11)` imports dependency
+    /// `C(<0.8.0)`, which are incompatible.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ethers_solc::{artifacts::Source, Project, utils};
+    /// # fn demo(project: Project) {
+    /// let project = Project::builder().build().unwrap();
+    /// let files = utils::source_files("./src");
+    /// let sources = Source::read_all(files).unwrap();
+    /// let output = project.svm_compile(sources).unwrap();
+    /// # }
+    /// ```
+    #[cfg(all(feature = "svm", feature = "async"))]
+    pub fn svm_compile(&self, sources: Sources) -> Result<ProjectCompileOutput<T>> {
+        project::ProjectCompiler::with_sources(self, sources)?.compile()
+    }
+
+    /// Convenience function to compile a single solidity file with the project's settings.
+    /// Same as [`Self::svm_compile()`] but with the given `file` as input.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ethers_solc::Project;
+    /// # fn demo(project: Project) {
+    /// let project = Project::builder().build().unwrap();
+    /// let output = project.compile_file("example/Greeter.sol").unwrap();
+    /// # }
+    /// ```
+    #[cfg(all(feature = "svm", feature = "async"))]
+    pub fn compile_file(&self, file: impl Into<PathBuf>) -> Result<ProjectCompileOutput<T>> {
+        let file = file.into();
+        let source = Source::read(&file)?;
+        project::ProjectCompiler::with_sources(self, Sources::from([(file, source)]))?.compile()
+    }
+
+    /// Convenience function to compile a series of solidity files with the project's settings.
+    /// Same as [`Self::svm_compile()`] but with the given `files` as input.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ethers_solc::Project;
+    /// # fn demo(project: Project) {
+    /// let project = Project::builder().build().unwrap();
+    /// let output = project
+    ///     .compile_files(
+    ///         vec!["examples/Foo.sol", "examples/Bar.sol"]
+    ///     ).unwrap();
+    /// # }
+    /// ```
+    #[cfg(all(feature = "svm", feature = "async"))]
+    pub fn compile_files<P, I>(&self, files: I) -> Result<ProjectCompileOutput<T>>
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        project::ProjectCompiler::with_sources(self, Source::read_all(files)?)?.compile()
+    }
+
+    /// Compiles the given source files with the exact `Solc` executable
+    ///
+    /// First all libraries for the sources are resolved by scanning all their imports.
+    /// If caching is enabled for the `Project`, then all unchanged files are filtered from the
+    /// sources and their existing artifacts are read instead. This will also update the cache
+    /// file and cleans up entries for files which may have been removed. Unchanged files that
+    /// for which an artifact exist, are not compiled again.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ethers_solc::{Project, Solc};
+    /// # fn demo(project: Project) {
+    /// let project = Project::builder().build().unwrap();
+    /// let sources = project.paths.read_sources().unwrap();
+    /// project
+    ///     .compile_with_version(
+    ///         &Solc::find_svm_installed_version("0.8.11").unwrap().unwrap(),
+    ///         sources,
+    ///     )
+    ///     .unwrap();
+    /// # }
+    /// ```
+    pub fn compile_with_version(
+        &self,
+        solc: &Solc,
+        sources: Sources,
+    ) -> Result<ProjectCompileOutput<T>> {
+        project::ProjectCompiler::with_sources_and_solc(
+            self,
+            sources,
+            self.configure_solc(solc.clone()),
+        )?
+        .compile()
+    }
+
+    /// Removes the project's artifacts and cache file
+    ///
+    /// If the cache file was the only file in the folder, this also removes the empty folder.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ethers_solc::Project;
+    /// # fn demo(project: Project) {
+    /// let project = Project::builder().build().unwrap();
+    /// let _ = project.compile().unwrap();
+    /// assert!(project.artifacts_path().exists());
+    /// assert!(project.cache_path().exists());
+    ///
+    /// project.cleanup();
+    /// assert!(!project.artifacts_path().exists());
+    /// assert!(!project.cache_path().exists());
+    /// # }
+    /// ```
+    pub fn cleanup(&self) -> std::result::Result<(), SolcIoError> {
+        tracing::trace!("clean up project");
+        if self.cache_path().exists() {
+            std::fs::remove_file(self.cache_path())
+                .map_err(|err| SolcIoError::new(err, self.cache_path()))?;
+            if let Some(cache_folder) = self.cache_path().parent() {
+                // remove the cache folder if the cache file was the only file
+                if cache_folder
+                    .read_dir()
+                    .map_err(|err| SolcIoError::new(err, cache_folder))?
+                    .next()
+                    .is_none()
+                {
+                    std::fs::remove_dir(cache_folder)
+                        .map_err(|err| SolcIoError::new(err, cache_folder))?;
+                }
+            }
+            tracing::trace!("removed cache file \"{}\"", self.cache_path().display());
+        }
+        if self.paths.artifacts.exists() {
+            std::fs::remove_dir_all(self.artifacts_path())
+                .map_err(|err| SolcIoError::new(err, self.artifacts_path().clone()))?;
+            tracing::trace!("removed artifacts dir \"{}\"", self.artifacts_path().display());
+        }
+        Ok(())
+    }
+
+    /// Flattens the target solidity file into a single string suitable for verification.
+    ///
+    /// This method uses a dependency graph to resolve imported files and substitute
+    /// import directives with the contents of target files. It will strip the pragma
+    /// version directives and SDPX license identifiers from all imported files.
+    ///
+    /// NB: the SDPX license identifier will be removed from the imported file
+    /// only if it is found at the beginning of the file.
+    pub fn flatten(&self, target: &Path) -> Result<String> {
+        self.paths.flatten(target)
+    }
+}

--- a/ethers-compile/solc/compiler.rs
+++ b/ethers-compile/solc/compiler.rs
@@ -1,0 +1,42 @@
+//! Manages compiling a solidity `Project`
+//!
+//! 
+
+use crate::{Compiler, Result};
+use rayon::prelude::*;
+use std::collections::btree_map::BTreeMap;
+
+#[derive(Debug)]
+pub struct SolcCompiler<'a, T> {
+    /// Contains the relationship of the source files and their imports
+    edges: GraphEdges,
+    project: &'a Project<T>,
+    /// how to compile all the sources
+    sources: CompilerSources,
+}
+
+#[derive(Debug)]
+pub enum SolcCompilerError {
+    Unknown
+};
+
+impl Compiler<CompilerInput, ProjectCompileOutput, SolcCompilerError> for SolcCompiler {
+    /// Compiles all the sources of the `Project` in the appropriate mode
+    ///
+    /// If caching is enabled, the sources are filtered and only _dirty_ sources are recompiled.
+    ///
+    /// The output of the compile process can be a mix of reused artifacts and freshly compiled
+    /// `Contract`s
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use ethers_solc::Project;
+    ///
+    /// let project = Project::builder().build().unwrap();
+    /// let output = project.compile().unwrap();
+    /// ```
+    fn compile(&self, input: &Self::Input) -> Result<Self::Output, Self::Error> {
+        Pipeline::preprocess(&self)?.compile(&self)?.write_artifacts(&self)?.write_cache(&self)
+    }
+};

--- a/ethers-compile/solc/mod.rs
+++ b/ethers-compile/solc/mod.rs
@@ -1,0 +1,2 @@
+/// The Solc Compiler
+pub mod compiler;

--- a/ethers-compile/src/ctrait.rs
+++ b/ethers-compile/src/ctrait.rs
@@ -1,0 +1,37 @@
+/// A Compiler-specific Result Type
+pub type Result<T, E> = std::result::Result<T, E>;
+
+/// # Compiler
+///
+/// A Generalized Compiler Trait
+/// Must be implemented to support specific compilation.
+///
+/// ### Example Implementation
+///
+/// ```no_run
+/// use ethers_compile::{Compiler};
+///
+/// pub struct Sanskrit {};
+///
+/// pub enum SEroor {
+///   IO,
+///   Compile,
+///   Unknown
+/// };
+///
+/// impl Compiler<u64, u64, SEroor> for Sanskrit {
+///   fn compile(&self, input: &Self::Input) -> Result<Self::Output, Self::Error> {
+///     return Ok(1);
+///   }
+/// };
+///
+/// let scompiler = Sanskrit {};
+/// let result = scompiler.compile(&input).unwrap();
+/// ```
+pub trait Compiler {
+  type Input;
+  type Output;
+  type Error;
+
+  fn compile(&self, input: &Self::Input) -> Result<Self::Output, Self::Error>;
+}

--- a/ethers-compile/src/lib.rs
+++ b/ethers-compile/src/lib.rs
@@ -3,3 +3,7 @@ pub mod compiler;
 
 /// Implements Compiler for Solc
 pub mod solc;
+
+// Reexport everything from the project module
+mod project;
+pub use project::*;

--- a/ethers-compile/src/lib.rs
+++ b/ethers-compile/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod ctrait;

--- a/ethers-compile/src/lib.rs
+++ b/ethers-compile/src/lib.rs
@@ -1,1 +1,5 @@
-pub mod ctrait;
+/// Defines the Compiler Interface
+pub mod compiler;
+
+/// Implements Compiler for Solc
+pub mod solc;

--- a/ethers-solc/src/compile/project.rs
+++ b/ethers-solc/src/compile/project.rs
@@ -9,7 +9,7 @@
 //! [`crate::Solc`] versions.
 //!
 //! At this point we check if we need to compile a source file or whether we can reuse an _existing_
-//! `Artifact`. We don't to compile if:
+//! `Artifact`. We don't want to compile if:
 //!     - caching is enabled
 //!     - the file is **not** dirty [`Cache::is_dirty()`]
 //!     - the artifact for that file exists

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,11 @@ pub mod solc {
     pub use ethers_solc::*;
 }
 
+#[doc = include_str!("../assets/COMPILE_README.md")]
+pub mod compile {
+    pub use ethers_compile::*;
+}
+
 /// Etherscan bindings
 pub mod etherscan {
     pub use ethers_etherscan::*;


### PR DESCRIPTION
## Overview

This PR picks up on #936 .

## Motivation

Currently, compiler support is unstructured.

## Solution

Introduces a `Compiler` trait among other abstractions to create a canonical interface for implementing compiler support.

## PR Checklist

- [x] :gear: `Compiler` Trait
- [ ] :ship: Implement the `Compiler` trait for `ethers-solc`
- [ ] :test_tube: Testing
