### PR TITLE
fix: Export `ethers_providers::IpcError` and `ethers_providers::QuorumError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,13 @@
 
 ## ethers-providers
 
+### Unreleased
+
+- Add support for basic and bearer authentication in http and non-wasm websockets.
+  [829](https://github.com/gakonst/ethers-rs/pull/829)
+- Export `ethers_providers::IpcError` and `ethers_providers::QuorumError`
+  [1012](https://github.com/gakonst/ethers-rs/pull/1012)
+
 ### 0.6.0
 
 - re-export error types for `Http` and `Ws` providers in
@@ -143,11 +150,6 @@
   [595](https://github.com/gakonst/ethers-rs/pull/595)
 - Add support for `evm_snapshot` and `evm_revert` dev RPC methods.
   [640](https://github.com/gakonst/ethers-rs/pull/640)
-
-### Unreleased
-
-- Add support for basic and bearer authentication in http and non-wasm websockets.
-  [829](https://github.com/gakonst/ethers-rs/pull/829)
 
 ### 0.5.3
 

--- a/ethers-providers/src/transports/mod.rs
+++ b/ethers-providers/src/transports/mod.rs
@@ -22,7 +22,7 @@ macro_rules! if_not_wasm {
 #[cfg(all(target_family = "unix", feature = "ipc"))]
 mod ipc;
 #[cfg(all(target_family = "unix", feature = "ipc"))]
-pub use ipc::Ipc;
+pub use ipc::{Ipc, IpcError};
 
 mod http;
 pub use self::http::{ClientError as HttpClientError, Provider as Http};
@@ -34,7 +34,7 @@ pub use ws::{ClientError as WsClientError, Ws};
 
 mod quorum;
 pub(crate) use quorum::JsonRpcClientWrapper;
-pub use quorum::{Quorum, QuorumProvider, WeightedProvider};
+pub use quorum::{Quorum, QuorumError, QuorumProvider, WeightedProvider};
 
 mod mock;
 pub use mock::{MockError, MockProvider};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I was writing some wrappers and I noticed that `ethers_providers::IpcError` and `ethers_providers::QuorumError` were not exported.

## Solution

Export them in `pub use`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
