### PR TITLE
feat: Make `Event` an owned struct by storing `Arc<M>` instead of `&M`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,8 @@
 
 ### Unreleased
 
+- Make `Event` an owned struct by storing `Arc<M>` instead of `&M`
+  [#1015](https://github.com/gakonst/ethers-rs/pull/1015)
 - Add `EventStream::select` to combine streams with different event types
   [#725](https://github.com/gakonst/ethers-rs/pull/725)
 - Substitute output tuples with rust struct types for function calls

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -171,7 +171,7 @@ impl<M: Middleware> Contract<M> {
     /// Returns an [`Event`](crate::builders::Event) builder with the provided filter.
     pub fn event_with_filter<D: EthLogDecode>(&self, filter: Filter) -> Event<M, D> {
         Event {
-            provider: &self.client,
+            provider: self.client.clone(),
             filter: filter.address(ValueOrArray::Value(self.address)),
             datatype: PhantomData,
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Motivation was described in #1014.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

`Event` now stores `Arc<M>` instead of `&M`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
