### PR TITLE
fix(solc/etherscan): trim constructor args

### DIFF
--- a/ethers-etherscan/src/contract.rs
+++ b/ethers-etherscan/src/contract.rs
@@ -105,6 +105,7 @@ impl VerifyContract {
     ) -> Self {
         self.constructor_arguments = constructor_arguments.map(|s| {
             s.into()
+                .trim()
                 // TODO is this correct?
                 .trim_start_matches("0x")
                 .to_string()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Ref https://github.com/gakonst/foundry/issues/931
When the constructor args argument comes from an inline `cast abi-encode` output, there's a newline that can break verification.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
trim before stripping 0x
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
