### PR TITLE
chore(abigen): improve error message when bindings out of sync

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -709,8 +709,9 @@ fn check_file_in_dir(dir: &Path, file_name: &str, expected_contents: &[u8]) -> R
     let file_path = dir.join(file_name);
     eyre::ensure!(file_path.is_file(), "Not a file: {}", file_path.display());
 
-    let contents = fs::read(file_path).expect("Unable to read file");
-    eyre::ensure!(contents == expected_contents, "file contents do not match");
+    let contents = fs::read(&file_path).expect("Unable to read file");
+    eyre::ensure!(contents == expected_contents, format!("The contents of `{}` do not match the expected output of the newest `ethers::Abigen` version.\
+This indicates that the existing bindings are outdated and need to be generated again.", file_path.display()));
     Ok(())
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Ref https://github.com/gakonst/foundry/issues/934
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Better error message if bindings outdated
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
