### PR TITLE
refactor(solc): bump svm-rs and use returned install path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3576,7 +3576,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "svm-rs"
 version = "0.2.9"
-source = "git+https://github.com/roynalnaruto/svm-rs#ae79a29f5bde08f1991f981456253fa5b6859047"
+source = "git+https://github.com/roynalnaruto/svm-rs#37d0095eeac73546c507b706c51e8f901541a7c1"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",

--- a/ethers-solc/src/resolver/mod.rs
+++ b/ethers-solc/src/resolver/mod.rs
@@ -627,23 +627,22 @@ impl VersionedSources {
 
         let mut sources_by_version = std::collections::BTreeMap::new();
         for (version, sources) in self.inner {
-            let mut solc = None;
-            if !version.is_installed() {
+            let solc = if !version.is_installed() {
                 if self.offline {
                     return Err(SolcError::msg(format!(
                         "missing solc \"{}\" installation in offline mode",
                         version
                     )))
                 } else {
-                    solc = Some(Solc::blocking_install(version.as_ref())?);
+                    // install missing solc
+                    Solc::blocking_install(version.as_ref())?
                 }
-            }
-
-            let solc = solc.map(Ok).unwrap_or_else(|| {
+            } else {
+                // find installed svm
                 Solc::find_svm_installed_version(version.to_string())?.ok_or_else(|| {
                     SolcError::msg(format!("solc \"{}\" should have been installed", version))
-                })
-            })?;
+                })?
+            };
 
             if self.offline {
                 tracing::trace!(

--- a/ethers-solc/src/resolver/mod.rs
+++ b/ethers-solc/src/resolver/mod.rs
@@ -627,6 +627,7 @@ impl VersionedSources {
 
         let mut sources_by_version = std::collections::BTreeMap::new();
         for (version, sources) in self.inner {
+            let mut solc = None;
             if !version.is_installed() {
                 if self.offline {
                     return Err(SolcError::msg(format!(
@@ -634,11 +635,14 @@ impl VersionedSources {
                         version
                     )))
                 } else {
-                    Solc::blocking_install(version.as_ref())?;
+                    solc = Some(Solc::blocking_install(version.as_ref())?);
                 }
             }
-            let solc = Solc::find_svm_installed_version(version.to_string())?.ok_or_else(|| {
-                SolcError::msg(format!("solc \"{}\" should have been installed", version))
+
+            let solc = solc.map(Ok).unwrap_or_else(|| {
+                Solc::find_svm_installed_version(version.to_string())?.ok_or_else(|| {
+                    SolcError::msg(format!("solc \"{}\" should have been installed", version))
+                })
             })?;
 
             if self.offline {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
smv-rs now returns the path where a solc was installed.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Use the path instead of the additional `find_installed_version` 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
