### PR TITLE
fix: don't evict cache entries with no artifacts

### DIFF
--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -294,6 +294,12 @@ impl SolFilesCache {
         let mut files: HashMap<_, _> = files.into_iter().map(|(p, v)| (p, v)).collect();
 
         self.files.retain(|file, entry| {
+            if entry.artifacts.is_empty() {
+                // keep entries that didn't emit any artifacts in the first place, such as a
+                // solidity file that only includes error definitions
+                return true
+            }
+
             if let Some(versions) = files.remove(file.as_path()) {
                 entry.retain_versions(versions);
             } else {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes https://github.com/gakonst/foundry/issues/941
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
The way the `Cache::retain` function was implemented didn't account for entries without any artifacts such as a errors.sol file, which lead to them being evicted from the cache entry set.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
