### PR TITLE
fix(solc): use lowercase when comparing paths

### DIFF
--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -14,7 +14,6 @@ use std::{
         btree_map::{BTreeMap, Entry},
         hash_map, BTreeSet, HashMap, HashSet,
     },
-    fmt,
     fs::{self},
     path::{Path, PathBuf},
     time::{Duration, UNIX_EPOCH},
@@ -758,7 +757,7 @@ impl FilteredSources {
     }
 
     /// Returns all dirty files
-    pub fn dirty_files(&self) -> impl Iterator<Item = &PathBuf> + fmt::Debug + '_ {
+    pub fn dirty_files(&self) -> impl Iterator<Item = &PathBuf> + '_ {
         self.0.iter().filter_map(|(k, s)| s.is_dirty().then(|| k))
     }
 

--- a/ethers-solc/src/compile/project.rs
+++ b/ethers-solc/src/compile/project.rs
@@ -438,7 +438,7 @@ fn compile_sequential(
             let output = solc.compile_exact(&input)?;
             report::solc_success(&solc, &version, &output);
             tracing::trace!("compiled input, output has error: {}", output.has_error());
-            tracing::trace!("received compiler output: {:?}", output.contracts.values());
+            tracing::trace!("received compiler output: {:?}", output.contracts.keys());
             aggregated.extend(version.clone(), output);
         }
     }

--- a/ethers-solc/src/compile/project.rs
+++ b/ethers-solc/src/compile/project.rs
@@ -317,7 +317,7 @@ impl CompilerSources {
                     tracing::trace!(
                         "Detected {} dirty sources {:?}",
                         sources.dirty().count(),
-                        sources.dirty_files()
+                        sources.dirty_files().collect::<Vec<_>>()
                     );
                     (solc, (version, sources))
                 })
@@ -438,6 +438,7 @@ fn compile_sequential(
             let output = solc.compile_exact(&input)?;
             report::solc_success(&solc, &version, &output);
             tracing::trace!("compiled input, output has error: {}", output.has_error());
+            tracing::trace!("received compiler output: {:?}", output.contracts.values());
             aggregated.extend(version.clone(), output);
         }
     }

--- a/ethers-solc/src/project_util/mod.rs
+++ b/ethers-solc/src/project_util/mod.rs
@@ -342,7 +342,7 @@ pub(crate) fn create_contract_file(path: PathBuf, content: impl AsRef<str>) -> R
 }
 
 fn contract_file_name(name: impl AsRef<str>) -> String {
-    let name = name.as_ref();
+    let name = name.as_ref().trim();
     if name.ends_with(".sol") {
         name.to_string()
     } else {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
https://github.com/odyslam/foundry-upgrades/tree/feat/core highlighted an issue in which errors went undetected, turns out solc not necessarily emits the exact file name, e.g. `src/utils/upgradeProxy.sol` is emitted as `src/utils/UpgradeProxy.sol` so we ended up swallowing some errors.

needs a followup with some tests.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use lowercase
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
