### PR TITLE
fix(core): check against ethers internal crate names

### DIFF
--- a/ethers-contract/tests/abigen.rs
+++ b/ethers-contract/tests/abigen.rs
@@ -382,7 +382,7 @@ fn can_handle_underscore_numeric() {
             _100pct(string)
         ]"#
     );
-    let call = _100PctCall("message".to_string());
+    let _call = _100PctCall("message".to_string());
 
     let provider = Arc::new(Provider::new(MockProvider::new()));
     let contract = Test::new(Address::default(), Arc::clone(&provider));

--- a/ethers-core/src/macros/ethers_crate.rs
+++ b/ethers-core/src/macros/ethers_crate.rs
@@ -69,9 +69,18 @@ pub fn determine_ethers_crates() -> (&'static str, &'static str, &'static str) {
         .and_then(|metadata| {
             metadata.root_package().and_then(|pkg| {
                 let sub_crates = Some(("ethers_core", "ethers_contract", "ethers_providers"));
-                if pkg.name == "ethers-contract" {
-                    // Note(mattsse): this is super hacky but required in order to compile the tests
-                    // in the `ethers-contract` crate
+
+                // Note(mattsse): this is super hacky but required in order to compile and test
+                // ethers' internal crates
+                if [
+                    "ethers-contract",
+                    "ethers-derive-eip712",
+                    "ethers-signers",
+                    "ethers-middleware",
+                    "ethers-solc",
+                ]
+                .contains(&pkg.name.as_str())
+                {
                     return sub_crates
                 }
 

--- a/ethers-etherscan/src/account.rs
+++ b/ethers-etherscan/src/account.rs
@@ -601,7 +601,7 @@ mod tests {
 
             let balances = client
                 .get_ether_balance_multi(
-                    &vec![&"0x58eB28A67731c570Ef827C365c89B5751F9E6b0a".parse().unwrap()],
+                    &[&"0x58eB28A67731c570Ef827C365c89B5751F9E6b0a".parse().unwrap()],
                     None,
                 )
                 .await;

--- a/ethers-etherscan/src/source_tree.rs
+++ b/ethers-etherscan/src/source_tree.rs
@@ -57,7 +57,7 @@ mod tests {
                 },
             ],
         };
-        st.write_to(&tempdir.path()).unwrap();
+        st.write_to(tempdir.path()).unwrap();
         let written_paths = read_dir(tempdir.path()).unwrap();
         let paths: Vec<PathBuf> =
             written_paths.into_iter().filter_map(|x| x.ok()).map(|x| x.path()).collect();
@@ -83,7 +83,7 @@ mod tests {
                 },
             ],
         };
-        st.write_to(&tempdir.path()).unwrap();
+        st.write_to(tempdir.path()).unwrap();
         let written_paths = read_dir(tempdir.path()).unwrap();
         let paths: Vec<PathBuf> =
             written_paths.into_iter().filter_map(|x| x.ok()).map(|x| x.path()).collect();

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_arch = "wasm32"))]
-use ethers_providers::{Http, Middleware, Provider, RINKEBY};
+use ethers_providers::{Http, Middleware, Provider};
 use std::{convert::TryFrom, time::Duration};
 
 #[cfg(not(feature = "celo"))]

--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -9,6 +9,7 @@ mod eth_tests {
         types::{Address, BlockId, TransactionRequest, H256},
         utils::Ganache,
     };
+    use ethers_providers::RINKEBY;
 
     #[tokio::test]
     async fn non_existing_data_works() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Make derives work in all crates again
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* check against internal crate names when determining ethers' crate idents
* clippy fix
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
