### PR TITLE
fix(core/TypedTransaction): eip1559 gas price should be max_fee_per_gas

### DIFF
--- a/ethers-core/src/types/transaction/eip2718.rs
+++ b/ethers-core/src/types/transaction/eip2718.rs
@@ -141,10 +141,10 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.gas_price,
             Eip1559(inner) => {
                 match (inner.max_fee_per_gas, inner.max_priority_fee_per_gas) {
-                    (Some(basefee), Some(prio_fee)) => Some(basefee + prio_fee),
+                    (Some(max_fee), Some(_)) => Some(max_fee),
                     // this also covers the None, None case
                     (None, prio_fee) => prio_fee,
-                    (basefee, None) => basefee,
+                    (max_fee, None) => max_fee,
                 }
             }
         }

--- a/ethers-middleware/tests/nonce_manager.rs
+++ b/ethers-middleware/tests/nonce_manager.rs
@@ -30,7 +30,7 @@ async fn nonce_manager() {
         .unwrap()
         .as_u64();
 
-    let num_tx = 5;
+    let num_tx = 3;
     let mut tx_hashes = Vec::with_capacity(num_tx);
     for _ in 0..num_tx {
         let tx = provider
@@ -44,7 +44,7 @@ async fn nonce_manager() {
     }
 
     // sleep a bit to ensure there's no flakiness in the test
-    std::thread::sleep(std::time::Duration::new(3, 0));
+    std::thread::sleep(std::time::Duration::new(5, 0));
 
     let mut nonces = Vec::with_capacity(num_tx);
     for tx_hash in tx_hashes {

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1718,7 +1718,7 @@ mod tests {
         provider.from = Some("0x6fC21092DA55B392b045eD78F4732bff3C580e2c".parse().unwrap());
 
         let gas = U256::from(21000_usize);
-        let basefee = U256::from(25_usize);
+        let max_fee = U256::from(25_usize);
         let prio_fee = U256::from(25_usize);
         let access_list: AccessList = vec![Default::default()].into();
 
@@ -1729,7 +1729,7 @@ mod tests {
             .from(from)
             .to(to)
             .gas(gas)
-            .max_fee_per_gas(basefee)
+            .max_fee_per_gas(max_fee)
             .max_priority_fee_per_gas(prio_fee)
             .access_list(access_list.clone())
             .into();
@@ -1738,7 +1738,7 @@ mod tests {
         assert_eq!(tx.from(), Some(&from));
         assert_eq!(tx.to(), Some(&to.into()));
         assert_eq!(tx.gas(), Some(&gas));
-        assert_eq!(tx.gas_price(), Some(basefee + prio_fee));
+        assert_eq!(tx.gas_price(), Some(max_fee));
         assert_eq!(tx.access_list(), Some(&access_list));
 
         // --- fills a 1559 transaction, leaving the existing gas limit unchanged, but including
@@ -1746,7 +1746,7 @@ mod tests {
         let gas_with_al = gas - 1;
         let mut tx = Eip1559TransactionRequest::new()
             .gas(gas)
-            .max_fee_per_gas(basefee)
+            .max_fee_per_gas(max_fee)
             .max_priority_fee_per_gas(prio_fee)
             .into();
 
@@ -1766,7 +1766,7 @@ mod tests {
         // --- fills a 1559 transaction, ignoring access list if more expensive
         let gas_with_al = gas + 1;
         let mut tx = Eip1559TransactionRequest::new()
-            .max_fee_per_gas(basefee)
+            .max_fee_per_gas(max_fee)
             .max_priority_fee_per_gas(prio_fee)
             .into();
 
@@ -1786,7 +1786,7 @@ mod tests {
 
         // --- fills a 1559 transaction, using estimated gas if create_access_list() errors
         let mut tx = Eip1559TransactionRequest::new()
-            .max_fee_per_gas(basefee)
+            .max_fee_per_gas(max_fee)
             .max_priority_fee_per_gas(prio_fee)
             .into();
 
@@ -1803,7 +1803,7 @@ mod tests {
 
         // --- propogates estimate_gas() error
         let mut tx = Eip1559TransactionRequest::new()
-            .max_fee_per_gas(basefee)
+            .max_fee_per_gas(max_fee)
             .max_priority_fee_per_gas(prio_fee)
             .into();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

Gas price is `max_fee_per_gas`, not `max_fee_per_gas + max_priority_fee_per_gas`. 

