### PR TITLE
feat(solc): use svm-builds instead of fetching http releases list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
+
+[[package]]
 name = "bumpalo"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,6 +1411,7 @@ dependencies = [
  "sha2 0.9.9",
  "solang-parser",
  "svm-rs",
+ "svm-rs-builds",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -3312,9 +3319,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -3576,7 +3583,7 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 [[package]]
 name = "svm-rs"
 version = "0.2.9"
-source = "git+https://github.com/roynalnaruto/svm-rs#37d0095eeac73546c507b706c51e8f901541a7c1"
+source = "git+https://github.com/roynalnaruto/svm-rs#496888fdcd9d2316a52020a09e281414755de3f8"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3599,6 +3606,18 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "svm-rs-builds"
+version = "0.1.0"
+source = "git+https://github.com/roynalnaruto/svm-rs#496888fdcd9d2316a52020a09e281414755de3f8"
+dependencies = [
+ "build_const",
+ "hex",
+ "semver",
+ "serde_json",
+ "svm-rs",
 ]
 
 [[package]]

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -44,6 +44,7 @@ home = "0.5.3"
 # SVM is not WASM compatible yet.
 # svm = { package = "svm-rs", default-features = false, version = "0.2.7", optional = true }
 svm = { package = "svm-rs", default-features = false, git = "https://github.com/roynalnaruto/svm-rs", optional = true, features = ["blocking"] }
+svm-builds = { package = "svm-rs-builds", git = "https://github.com/roynalnaruto/svm-rs", optional = true}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # NOTE: this enables wasm compatibility for getrandom indirectly
@@ -69,17 +70,17 @@ harness = false
 [[test]]
 name = "project"
 path = "tests/project.rs"
-required-features = ["async", "svm", "project-util"]
+required-features = ["async", "svm", "svm-builds", "project-util"]
 
 [[test]]
 name = "mocked"
 path = "tests/mocked.rs"
-required-features = ["async", "svm", "project-util"]
+required-features = ["async", "svm", "svm-builds", "project-util"]
 
 [features]
 default = ["rustls"]
 async = ["tokio", "futures-util"]
-full = ["async", "svm", "svm/blocking"]
+full = ["async", "svm", "svm/blocking", "svm-builds"]
 # Utilities for creating and testing project workspaces
 project-util = ["tempfile", "fs_extra", "rand"]
 tests = []

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -64,7 +64,7 @@ pub(crate) fn take_solc_installer_lock() -> std::sync::MutexGuard<'static, ()> {
 /// A list of upstream Solc releases, used to check which version
 /// we should download.
 /// The boolean value marks whether there was an error accessing the release list
-#[cfg(all(feature = "svm"))]
+#[cfg(all(feature = "svm", feature = "svm-builds"))]
 pub static RELEASES: once_cell::sync::Lazy<(svm::Releases, Vec<Version>, bool)> =
     once_cell::sync::Lazy::new(|| {
         match serde_json::from_str::<svm::Releases>(svm_builds::RELEASE_LIST_JSON) {

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -63,17 +63,19 @@ pub(crate) fn take_solc_installer_lock() -> std::sync::MutexGuard<'static, ()> {
 
 /// A list of upstream Solc releases, used to check which version
 /// we should download.
-/// The boolean value marks whether there was an error.
+/// The boolean value marks whether there was an error accessing the release list
 #[cfg(all(feature = "svm"))]
 pub static RELEASES: once_cell::sync::Lazy<(svm::Releases, Vec<Version>, bool)> =
-    once_cell::sync::Lazy::new(|| match svm::blocking_all_releases(svm::platform()) {
-        Ok(releases) => {
-            let sorted_versions = releases.clone().into_versions();
-            (releases, sorted_versions, true)
-        }
-        Err(err) => {
-            tracing::error!("{:?}", err);
-            (svm::Releases::default(), Vec::new(), false)
+    once_cell::sync::Lazy::new(|| {
+        match serde_json::from_str::<svm::Releases>(svm_builds::RELEASE_LIST_JSON) {
+            Ok(releases) => {
+                let sorted_versions = releases.clone().into_versions();
+                (releases, sorted_versions, true)
+            }
+            Err(err) => {
+                tracing::error!("{:?}", err);
+                (svm::Releases::default(), Vec::new(), false)
+            }
         }
     });
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
replace the HTTP request to retrieve the version list with the new svm-builds version list.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
