### PR TITLE
Tx optional from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Unreleased
 
+- `Transaction::from` will default to `Address::zero()`. Add `recover_from` and
+  `recover_from_mut` methods for recovering the sender from signature, and also
+  setting the same on tx [1075](https://github.com/gakonst/ethers-rs/pull/1075).
 - Add Etherscan account API endpoints [939](https://github.com/gakonst/ethers-rs/pull/939)
 - Add FTM Mainet and testnet to parse method "try_from" from Chain.rs and add cronos mainet and testnet to "from_str"
 - Add FTM mainnet and testnet Multicall addresses [927](https://github.com/gakonst/ethers-rs/pull/927)

--- a/ethers-core/src/types/signature.rs
+++ b/ethers-core/src/types/signature.rs
@@ -60,7 +60,7 @@ pub struct Signature {
     pub r: U256,
     /// S Value
     pub s: U256,
-    /// V value in 'Electrum' notation.
+    /// V value
     pub v: u64,
 }
 

--- a/ethers-core/src/types/transaction/eip1559.rs
+++ b/ethers-core/src/types/transaction/eip1559.rs
@@ -1,6 +1,6 @@
 use super::{eip2930::AccessList, normalize_v, rlp_opt};
 use crate::{
-    types::{Address, Bytes, NameOrAddress, Signature, H256, U256, U64},
+    types::{Address, Bytes, NameOrAddress, Signature, Transaction, H256, U256, U64},
     utils::keccak256,
 };
 use rlp::{Decodable, DecoderError, RlpStream};
@@ -241,6 +241,23 @@ impl From<Eip1559TransactionRequest> for super::request::TransactionRequest {
             #[cfg(feature = "celo")]
             gateway_fee: None,
             chain_id: tx.chain_id,
+        }
+    }
+}
+
+impl From<&Transaction> for Eip1559TransactionRequest {
+    fn from(tx: &Transaction) -> Eip1559TransactionRequest {
+        Eip1559TransactionRequest {
+            from: Some(tx.from),
+            to: tx.to.map(NameOrAddress::Address),
+            gas: Some(tx.gas),
+            value: Some(tx.value),
+            data: Some(Bytes(tx.input.0.clone())),
+            nonce: Some(tx.nonce),
+            access_list: tx.access_list.clone().unwrap_or_default(),
+            max_priority_fee_per_gas: tx.max_priority_fee_per_gas,
+            max_fee_per_gas: tx.max_fee_per_gas,
+            chain_id: tx.chain_id.map(|x| U64::from(x.as_u64())),
         }
     }
 }

--- a/ethers-core/src/types/transaction/eip2930.rs
+++ b/ethers-core/src/types/transaction/eip2930.rs
@@ -1,5 +1,5 @@
 use super::{normalize_v, request::TransactionRequest};
-use crate::types::{Address, Bytes, Signature, H256, U256, U64};
+use crate::types::{Address, Bytes, Signature, Transaction, H256, U256, U64};
 
 use rlp::{Decodable, DecoderError, RlpStream};
 use rlp_derive::{RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper};
@@ -141,6 +141,15 @@ impl Decodable for Eip2930TransactionRequest {
         let mut offset = 0;
         new_tx.decode_base_rlp(rlp, &mut offset)?;
         Ok(new_tx)
+    }
+}
+
+impl From<&Transaction> for Eip2930TransactionRequest {
+    fn from(tx: &Transaction) -> Eip2930TransactionRequest {
+        Eip2930TransactionRequest {
+            tx: tx.into(),
+            access_list: tx.access_list.clone().unwrap_or_default(),
+        }
     }
 }
 

--- a/ethers-core/src/types/transaction/request.rs
+++ b/ethers-core/src/types/transaction/request.rs
@@ -1,7 +1,7 @@
 //! Transaction types
 use super::{extract_chain_id, rlp_opt, NUM_TX_FIELDS};
 use crate::{
-    types::{Address, Bytes, NameOrAddress, Signature, H256, U256, U64},
+    types::{Address, Bytes, NameOrAddress, Signature, Transaction, H256, U256, U64},
     utils::keccak256,
 };
 
@@ -271,6 +271,30 @@ impl Decodable for TransactionRequest {
     /// Decodes the given RLP into a transaction request, ignoring the signature if populated
     fn decode(rlp: &rlp::Rlp) -> Result<Self, rlp::DecoderError> {
         TransactionRequest::decode_unsigned_rlp(rlp)
+    }
+}
+
+impl From<&Transaction> for TransactionRequest {
+    fn from(tx: &Transaction) -> TransactionRequest {
+        TransactionRequest {
+            from: Some(tx.from),
+            to: tx.to.map(NameOrAddress::Address),
+            gas: Some(tx.gas),
+            gas_price: tx.gas_price,
+            value: Some(tx.value),
+            data: Some(Bytes(tx.input.0.clone())),
+            nonce: Some(tx.nonce),
+            chain_id: tx.chain_id.map(|x| U64::from(x.as_u64())),
+
+            #[cfg(feature = "celo")]
+            fee_currency: tx.fee_currency,
+
+            #[cfg(feature = "celo")]
+            gateway_fee_recipient: tx.gateway_fee_recipient,
+
+            #[cfg(feature = "celo")]
+            gateway_fee: tx.gateway_fee,
+        }
     }
 }
 

--- a/ethers-core/src/types/transaction/response.rs
+++ b/ethers-core/src/types/transaction/response.rs
@@ -1,5 +1,7 @@
 //! Transaction types
-use super::{decode_signature, eip2930::AccessList, normalize_v, rlp_opt};
+use super::{
+    decode_signature, eip2718::TypedTransaction, eip2930::AccessList, normalize_v, rlp_opt,
+};
 use crate::{
     types::{Address, Bloom, Bytes, Log, Signature, SignatureError, H256, U256, U64},
     utils::keccak256,
@@ -315,7 +317,8 @@ impl Transaction {
 
     pub fn recover_from(&self) -> Result<Address, SignatureError> {
         let signature = Signature { r: self.r, s: self.s, v: self.v.as_u64() };
-        signature.recover(self.hash)
+        let typed_tx: TypedTransaction = self.into();
+        signature.recover(typed_tx.sighash())
     }
 }
 

--- a/ethers-core/src/types/transaction/response.rs
+++ b/ethers-core/src/types/transaction/response.rs
@@ -315,10 +315,18 @@ impl Transaction {
         Ok(())
     }
 
+    /// Recover the sender of the tx from signature
     pub fn recover_from(&self) -> Result<Address, SignatureError> {
         let signature = Signature { r: self.r, s: self.s, v: self.v.as_u64() };
         let typed_tx: TypedTransaction = self.into();
         signature.recover(typed_tx.sighash())
+    }
+
+    /// Recover the sender of the tx from signature and set the from field
+    pub fn recover_from_mut(&mut self) -> Result<Address, SignatureError> {
+        let from = self.recover_from()?;
+        self.from = from;
+        Ok(from)
     }
 }
 

--- a/ethers-core/src/types/transaction/response.rs
+++ b/ethers-core/src/types/transaction/response.rs
@@ -1,7 +1,7 @@
 //! Transaction types
 use super::{decode_signature, eip2930::AccessList, normalize_v, rlp_opt};
 use crate::{
-    types::{Address, Bloom, Bytes, Log, H256, U256, U64},
+    types::{Address, Bloom, Bytes, Log, Signature, SignatureError, H256, U256, U64},
     utils::keccak256,
 };
 use rlp::{Decodable, DecoderError, RlpStream};
@@ -32,6 +32,7 @@ pub struct Transaction {
     pub transaction_index: Option<U64>,
 
     /// Sender
+    #[serde(default = "crate::types::Address::zero")]
     pub from: Address,
 
     /// Recipient (None when contract creation)
@@ -310,6 +311,11 @@ impl Transaction {
         self.input = Bytes::from(input.to_vec());
         *offset += 1;
         Ok(())
+    }
+
+    pub fn recover_from(&self) -> Result<Address, SignatureError> {
+        let signature = Signature { r: self.r, s: self.s, v: self.v.as_u64() };
+        signature.recover(self.hash)
     }
 }
 
@@ -635,5 +641,47 @@ mod tests {
 
         // we compare hash because the hash depends on the rlp encoding
         assert_eq!(decoded_transaction.hash(), tx.hash());
+    }
+
+    #[test]
+    fn recover_from() {
+        let tx = Transaction {
+            hash: H256::from_str(
+                "5e2fc091e15119c97722e9b63d5d32b043d077d834f377b91f80d32872c78109",
+            )
+            .unwrap(),
+            nonce: 65.into(),
+            block_hash: Some(
+                H256::from_str("f43869e67c02c57d1f9a07bb897b54bec1cfa1feb704d91a2ee087566de5df2c")
+                    .unwrap(),
+            ),
+            block_number: Some(6203173.into()),
+            transaction_index: Some(10.into()),
+            from: Address::from_str("e66b278fa9fbb181522f6916ec2f6d66ab846e04").unwrap(),
+            to: Some(Address::from_str("11d7c2ab0d4aa26b7d8502f6a7ef6844908495c2").unwrap()),
+            value: 0.into(),
+            gas_price: Some(1500000007.into()),
+            gas: 106703.into(),
+            input: hex::decode("e5225381").unwrap().into(),
+            v: 1.into(),
+            r: U256::from_str_radix(
+                "12010114865104992543118914714169554862963471200433926679648874237672573604889",
+                10,
+            )
+            .unwrap(),
+            s: U256::from_str_radix(
+                "22830728216401371437656932733690354795366167672037272747970692473382669718804",
+                10,
+            )
+            .unwrap(),
+            transaction_type: Some(2.into()),
+            access_list: Some(AccessList::default()),
+            max_priority_fee_per_gas: Some(1500000000.into()),
+            max_fee_per_gas: Some(1500000009.into()),
+            chain_id: Some(5.into()),
+        };
+
+        assert_eq!(tx.hash, tx.hash());
+        assert_eq!(tx.from, tx.recover_from().unwrap());
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Txs may not always have the `from` field set, make it optional and add method for being able to recover the same from signature and set it on the tx.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Allow txs that do not have a `from` field by defaulting to `Address::zero()` instead of making it optional to not break compat. Add method to recover the sender from signature and also set the same on the tx.


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
