### PR TITLE
chore(source_tree): add .sol extension when missing

### DIFF
--- a/ethers-etherscan/src/source_tree.rs
+++ b/ethers-etherscan/src/source_tree.rs
@@ -21,7 +21,10 @@ impl SourceTree {
     pub fn write_to(&self, dir: &Path) -> Result<()> {
         create_dir_all(&dir)?;
         for entry in &self.entries {
-            let sanitized_path = sanitize_path(&entry.path);
+            let mut sanitized_path = sanitize_path(&entry.path);
+            if sanitized_path.extension().is_none() {
+                sanitized_path.set_extension("sol");
+            }
             let joined = dir.join(sanitized_path);
             if let Some(parent) = joined.parent() {
                 create_dir_all(parent)?;
@@ -45,25 +48,22 @@ mod tests {
     use super::*;
     use std::fs::read_dir;
 
+    /// Ensure that the source tree is written correctly and .sol extension is added to a path with
+    /// no extension.
     #[test]
     fn test_source_tree_write() {
         let tempdir = tempfile::tempdir().unwrap();
         let st = SourceTree {
             entries: vec![
                 SourceTreeEntry { path: PathBuf::from("a/a.sol"), contents: String::from("Test") },
-                SourceTreeEntry {
-                    path: PathBuf::from("b/b.sol"),
-                    contents: String::from("Test 2"),
-                },
+                SourceTreeEntry { path: PathBuf::from("b/b"), contents: String::from("Test 2") },
             ],
         };
         st.write_to(tempdir.path()).unwrap();
-        let written_paths = read_dir(tempdir.path()).unwrap();
-        let paths: Vec<PathBuf> =
-            written_paths.into_iter().filter_map(|x| x.ok()).map(|x| x.path()).collect();
-        assert_eq!(paths.len(), 2);
-        assert!(paths.contains(&tempdir.path().join("a")));
-        assert!(paths.contains(&tempdir.path().join("b")));
+        let a_sol_path = PathBuf::new().join(&tempdir).join("a").join("a.sol");
+        let b_sol_path = PathBuf::new().join(&tempdir).join("b").join("b.sol");
+        assert!(a_sol_path.exists());
+        assert!(b_sol_path.exists());
     }
 
     /// Ensure that the .. are ignored when writing the source tree to disk because of


### PR DESCRIPTION
Just ensure that any paths with no extension default to a .sol

Tests: cargo test --lib ethers-etherscan -- source_tree