### PR TITLE
fix(abi): change abiarraytype type bounds for tuple

### DIFF
--- a/ethers-contract/tests/common/derive.rs
+++ b/ethers-contract/tests/common/derive.rs
@@ -572,3 +572,14 @@ fn can_derive_ethcall_for_bytes() {
 
     assert_ethcall::<BatchCall>();
 }
+
+#[test]
+fn can_derive_array_tuples() {
+    #[derive(Clone, Debug, Default, Eq, PartialEq, EthEvent, EthDisplay)]
+    #[ethevent(name = "DiamondCut", abi = "DiamondCut((address,uint8,bytes4[])[],address,bytes)")]
+    pub struct DiamondCutFilter {
+        pub diamond_cut: Vec<(Address, u8, Vec<[u8; 4]>)>,
+        pub init: Address,
+        pub calldata: Bytes,
+    }
+}

--- a/ethers-core/src/abi/codec.rs
+++ b/ethers-core/src/abi/codec.rs
@@ -252,4 +252,12 @@ mod tests {
         let v = vec![bytes];
         assert_codec(v);
     }
+
+    #[test]
+    fn tuple_array() {
+        let nested: Vec<[u8; 4]> = vec![[0, 0, 0, 1]];
+        assert_codec(nested.clone());
+        let tuple: Vec<(Address, u8, Vec<[u8; 4]>)> = vec![(Address::random(), 0, nested)];
+        assert_codec(tuple);
+    }
 }

--- a/ethers-core/src/abi/mod.rs
+++ b/ethers-core/src/abi/mod.rs
@@ -164,7 +164,7 @@ macro_rules! impl_abi_type_tuple {
 
         impl<$($ty, )+> AbiArrayType for ($($ty,)+) where
             $(
-                $ty: AbiArrayType,
+                $ty: AbiType,
             )+ {}
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes #1076
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
change the type bound from `AbiArrayType` to `AbiType` in the tuple macro
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
