### PR TITLE
feat(solc): include source file ast in artifact

### DIFF
--- a/ethers-solc/src/artifact_output/configurable.rs
+++ b/ethers-solc/src/artifact_output/configurable.rs
@@ -47,6 +47,8 @@ pub struct ConfigurableContractArtifact {
     pub ir_optimized: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ewasm: Option<Ewasm>,
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub ast: serde_json::Value,
 }
 
 impl ConfigurableContractArtifact {
@@ -276,6 +278,7 @@ impl ArtifactOutput for ConfigurableArtifacts {
             ir: artifact_ir,
             ir_optimized: artifact_ir_optimized,
             ewasm: artifact_ewasm,
+            ast: serde_json::Value::Null,
         }
     }
 }

--- a/ethers-solc/src/artifact_output/configurable.rs
+++ b/ethers-solc/src/artifact_output/configurable.rs
@@ -8,7 +8,7 @@ use crate::{
         CompactContractBytecodeCow, CompactEvm, DevDoc, Ewasm, GasEstimates, LosslessAbi, Metadata,
         Offsets, Settings, StorageLayout, UserDoc,
     },
-    ArtifactOutput, SolcConfig, SolcError,
+    ArtifactOutput, SolcConfig, SolcError, SourceFile,
 };
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::BTreeMap, fs, path::Path};
@@ -192,7 +192,13 @@ impl ArtifactOutput for ConfigurableArtifacts {
         self.additional_files.write_extras(contract, file)
     }
 
-    fn contract_to_artifact(&self, _file: &str, _name: &str, contract: Contract) -> Self::Artifact {
+    fn contract_to_artifact(
+        &self,
+        _file: &str,
+        _name: &str,
+        contract: Contract,
+        source_file: Option<&SourceFile>,
+    ) -> Self::Artifact {
         let mut artifact_userdoc = None;
         let mut artifact_devdoc = None;
         let mut artifact_metadata = None;
@@ -278,7 +284,7 @@ impl ArtifactOutput for ConfigurableArtifacts {
             ir: artifact_ir,
             ir_optimized: artifact_ir_optimized,
             ewasm: artifact_ewasm,
-            ast: serde_json::Value::Null,
+            ast: source_file.map(|s| s.ast.clone()).unwrap_or_default(),
         }
     }
 }

--- a/ethers-solc/src/artifact_output/mod.rs
+++ b/ethers-solc/src/artifact_output/mod.rs
@@ -583,8 +583,9 @@ pub trait ArtifactOutput {
     /// Convert a contract to the artifact type
     ///
     /// This is the core conversion function that takes care of converting a `Contract` into the
-    /// associated `Artifact` type
-    fn contract_to_artifact(&self, _file: &str, _name: &str, contract: Contract) -> Self::Artifact;
+    /// associated `Artifact` type.
+    /// The `SourceFile` is also provided
+    fn contract_to_artifact(&self, _file: &str, _name: &str, contract: Contract, source_file: Option<&SourceFile>) -> Self::Artifact;
 
     /// Convert the compiler output into a set of artifacts
     ///
@@ -609,7 +610,7 @@ pub trait ArtifactOutput {
                         Self::output_file(file, name)
                     };
 
-                    let artifact = self.contract_to_artifact(file, name, contract.contract.clone());
+                    let artifact = self.contract_to_artifact(file, name, contract.contract.clone(), source_file);
 
                     contracts.push(ArtifactFile {
                         artifact,

--- a/ethers-solc/src/artifact_output/mod.rs
+++ b/ethers-solc/src/artifact_output/mod.rs
@@ -585,7 +585,13 @@ pub trait ArtifactOutput {
     /// This is the core conversion function that takes care of converting a `Contract` into the
     /// associated `Artifact` type.
     /// The `SourceFile` is also provided
-    fn contract_to_artifact(&self, _file: &str, _name: &str, contract: Contract, source_file: Option<&SourceFile>) -> Self::Artifact;
+    fn contract_to_artifact(
+        &self,
+        _file: &str,
+        _name: &str,
+        contract: Contract,
+        source_file: Option<&SourceFile>,
+    ) -> Self::Artifact;
 
     /// Convert the compiler output into a set of artifacts
     ///
@@ -610,7 +616,12 @@ pub trait ArtifactOutput {
                         Self::output_file(file, name)
                     };
 
-                    let artifact = self.contract_to_artifact(file, name, contract.contract.clone(), source_file);
+                    let artifact = self.contract_to_artifact(
+                        file,
+                        name,
+                        contract.contract.clone(),
+                        source_file,
+                    );
 
                     contracts.push(ArtifactFile {
                         artifact,
@@ -645,7 +656,13 @@ pub struct MinimalCombinedArtifacts {
 impl ArtifactOutput for MinimalCombinedArtifacts {
     type Artifact = CompactContractBytecode;
 
-    fn contract_to_artifact(&self, _file: &str, _name: &str, contract: Contract) -> Self::Artifact {
+    fn contract_to_artifact(
+        &self,
+        _file: &str,
+        _name: &str,
+        contract: Contract,
+        _source_file: Option<&SourceFile>,
+    ) -> Self::Artifact {
         Self::Artifact::from(contract)
     }
 }
@@ -683,8 +700,14 @@ impl ArtifactOutput for MinimalCombinedArtifactsHardhatFallback {
         }
     }
 
-    fn contract_to_artifact(&self, file: &str, name: &str, contract: Contract) -> Self::Artifact {
-        MinimalCombinedArtifacts::default().contract_to_artifact(file, name, contract)
+    fn contract_to_artifact(
+        &self,
+        file: &str,
+        name: &str,
+        contract: Contract,
+        source_file: Option<&SourceFile>,
+    ) -> Self::Artifact {
+        MinimalCombinedArtifacts::default().contract_to_artifact(file, name, contract, source_file)
     }
 }
 

--- a/ethers-solc/src/compile/project.rs
+++ b/ethers-solc/src/compile/project.rs
@@ -266,15 +266,22 @@ impl<'a, T: ArtifactOutput> CompiledState<'a, T> {
 
         // write all artifacts via the handler but only if the build succeeded
         let compiled_artifacts = if cache.project().no_artifacts {
-            cache.project().artifacts_handler().output_to_artifacts(&output.contracts)
-        } else if output.has_error() {
-            tracing::trace!("skip writing cache file due to solc errors: {:?}", output.errors);
-            cache.project().artifacts_handler().output_to_artifacts(&output.contracts)
-        } else {
             cache
                 .project()
                 .artifacts_handler()
-                .on_output(&output.contracts, &cache.project().paths)?
+                .output_to_artifacts(&output.contracts, &output.sources)
+        } else if output.has_error() {
+            tracing::trace!("skip writing cache file due to solc errors: {:?}", output.errors);
+            cache
+                .project()
+                .artifacts_handler()
+                .output_to_artifacts(&output.contracts, &output.sources)
+        } else {
+            cache.project().artifacts_handler().on_output(
+                &output.contracts,
+                &output.sources,
+                &cache.project().paths,
+            )?
         };
 
         Ok(ArtifactsState { output, cache, compiled_artifacts })

--- a/ethers-solc/src/hh.rs
+++ b/ethers-solc/src/hh.rs
@@ -6,7 +6,7 @@ use crate::{
         contract::{CompactContract, CompactContractBytecode, Contract, ContractBytecode},
         CompactContractBytecodeCow, LosslessAbi, Offsets,
     },
-    ArtifactOutput,
+    ArtifactOutput, SourceFile,
 };
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::btree_map::BTreeMap};
@@ -97,7 +97,13 @@ pub struct HardhatArtifacts {
 impl ArtifactOutput for HardhatArtifacts {
     type Artifact = HardhatArtifact;
 
-    fn contract_to_artifact(&self, file: &str, name: &str, contract: Contract) -> Self::Artifact {
+    fn contract_to_artifact(
+        &self,
+        file: &str,
+        name: &str,
+        contract: Contract,
+        _source_file: Option<&SourceFile>,
+    ) -> Self::Artifact {
         let (bytecode, link_references, deployed_bytecode, deployed_link_references) =
             if let Some(evm) = contract.evm {
                 let (deployed_bytecode, deployed_link_references) =

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -23,7 +23,7 @@ mod config;
 pub use config::{AllowedLibPaths, PathStyle, ProjectPathsConfig, SolcConfig};
 
 pub mod remappings;
-use crate::artifacts::Source;
+use crate::artifacts::{Source, SourceFile};
 
 pub mod error;
 mod filter;
@@ -676,9 +676,10 @@ impl<T: ArtifactOutput> ArtifactOutput for Project<T> {
     fn on_output(
         &self,
         contracts: &VersionedContracts,
+        sources: &BTreeMap<String, SourceFile>,
         layout: &ProjectPathsConfig,
     ) -> Result<Artifacts<Self::Artifact>> {
-        self.artifacts_handler().on_output(contracts, layout)
+        self.artifacts_handler().on_output(contracts, sources, layout)
     }
 
     fn write_contract_extras(&self, contract: &Contract, file: &Path) -> Result<()> {
@@ -741,8 +742,12 @@ impl<T: ArtifactOutput> ArtifactOutput for Project<T> {
         self.artifacts_handler().contract_to_artifact(file, name, contract)
     }
 
-    fn output_to_artifacts(&self, contracts: &VersionedContracts) -> Artifacts<Self::Artifact> {
-        self.artifacts_handler().output_to_artifacts(contracts)
+    fn output_to_artifacts(
+        &self,
+        contracts: &VersionedContracts,
+        sources: &BTreeMap<String, SourceFile>,
+    ) -> Artifacts<Self::Artifact> {
+        self.artifacts_handler().output_to_artifacts(contracts, sources)
     }
 }
 

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -739,8 +739,14 @@ impl<T: ArtifactOutput> ArtifactOutput for Project<T> {
         T::read_cached_artifacts(files)
     }
 
-    fn contract_to_artifact(&self, file: &str, name: &str, contract: Contract) -> Self::Artifact {
-        self.artifacts_handler().contract_to_artifact(file, name, contract)
+    fn contract_to_artifact(
+        &self,
+        file: &str,
+        name: &str,
+        contract: Contract,
+        source_file: Option<&SourceFile>,
+    ) -> Self::Artifact {
+        self.artifacts_handler().contract_to_artifact(file, name, contract, source_file)
     }
 
     fn output_to_artifacts(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes #1028

Adds the AST of the source file to the configurable artifact.

this is a bit tricky because ast is a per-file value and inserting this on a per contract/artifact basis is not really ideal.
So currently the `ast` field of an artifact will include the ast for the whole file.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
