### PR TITLE
feat: add TryFrom String reference for http provider

### DIFF
--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1298,6 +1298,14 @@ impl TryFrom<String> for Provider<HttpProvider> {
     }
 }
 
+impl<'a> TryFrom<&'a String> for Provider<HttpProvider> {
+    type Error = ParseError;
+
+    fn try_from(src: &'a String) -> Result<Self, Self::Error> {
+        Provider::try_from(src.as_str())
+    }
+}
+
 /// A middleware supporting development-specific JSON RPC methods
 ///
 /// # Example


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
This is useful because 

```
let url = format!("...");
let provider = Provider::try_from(&url);
```

does not work, we can also can't use `TryFrom<T:AsRef<str>>` because of some blanket conflicting impl in rust core that does not allow this.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
