### PR TITLE
feat(solc): pass compile time to reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Pass compilation time as additional argument to `Reporter::on_solc_success` [1098](https://github.com/gakonst/ethers-rs/pull/1098)
 - Fix aws signer bug which maps un-normalized signature to error if no normalization occurs (in `aws::utils::decode_signature`)
 - `Transaction::from` will default to `Address::zero()`. Add `recover_from` and
   `recover_from_mut` methods for recovering the sender from signature, and also

--- a/ethers-solc/src/report/mod.rs
+++ b/ethers-solc/src/report/mod.rs
@@ -27,6 +27,7 @@ use std::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
+    time::Duration,
 };
 
 mod compiler;
@@ -115,7 +116,14 @@ pub trait Reporter: 'static {
     }
 
     /// Invoked with the `CompilerOutput` if [`Solc::compile()`] was successful
-    fn on_solc_success(&self, _solc: &Solc, _version: &Version, _output: &CompilerOutput) {}
+    fn on_solc_success(
+        &self,
+        _solc: &Solc,
+        _version: &Version,
+        _output: &CompilerOutput,
+        _duration: &Duration,
+    ) {
+    }
 
     /// Invoked before a new [`Solc`] bin is installed
     fn on_solc_installation_start(&self, _version: &Version) {}
@@ -181,8 +189,13 @@ pub(crate) fn solc_spawn(
     get_default(|r| r.reporter.on_solc_spawn(solc, version, input, dirty_files));
 }
 
-pub(crate) fn solc_success(solc: &Solc, version: &Version, output: &CompilerOutput) {
-    get_default(|r| r.reporter.on_solc_success(solc, version, output));
+pub(crate) fn solc_success(
+    solc: &Solc,
+    version: &Version,
+    output: &CompilerOutput,
+    duration: &Duration,
+) {
+    get_default(|r| r.reporter.on_solc_success(solc, version, output, duration));
 }
 
 #[allow(unused)]


### PR DESCRIPTION
## Motivation

We'd like to show time spent compiling a project in Forge. Other reporters could probably use this information, too.

## Solution

Track elapsed compile time as a `std::time::Duration` and pass it through to the configured `Reporter` as an extra arg to `on_solc_success`. See also https://github.com/gakonst/foundry/pull/1145.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
