### PR TITLE
fix: aws signer does not throw error on unnormalized sig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Fix aws signer bug which maps un-normalized signature to error if no normalization occurs (in `aws::utils::decode_signature`)
 - `Transaction::from` will default to `Address::zero()`. Add `recover_from` and
   `recover_from_mut` methods for recovering the sender from signature, and also
   setting the same on tx [1075](https://github.com/gakonst/ethers-rs/pull/1075).

--- a/ethers-signers/src/aws/utils.rs
+++ b/ethers-signers/src/aws/utils.rs
@@ -93,8 +93,6 @@ pub(super) fn decode_signature(resp: SignResponse) -> Result<KSig, AwsSignerErro
         .signature
         .ok_or_else(|| AwsSignerError::from("Signature not found in response".to_owned()))?;
 
-    let sig = KSig::from_der(&raw)?
-        .normalize_s()
-        .ok_or_else(|| AwsSignerError::from("Could not normalize `s`".to_owned()))?;
-    Ok(sig)
+    let sig = KSig::from_der(&raw)?;
+    Ok(sig.normalize_s().unwrap_or(sig))
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

[This commit](https://github.com/gakonst/ethers-rs/commit/568d9c8697bf6ba4944543a21c9456c0c11f0caf) introduced a bug in use of `k256::ecdsa::Signature::normalize_s` in the aws signer’s utils. The signature for normalize_s now returns an Option<Self>, which is None if no normalization action is taken. Commit maps non-normalized sig to error.

## Solution

If no normalization occurs (normalize returns `None`), returned unnormalized signature instead of error.

## PR Checklist
- [x] Updated the changelog
