### PR TITLE
fix(ethers-etherscan): Broken Etherscan URL Construction

### DIFF
--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -144,22 +144,22 @@ impl Client {
 
     /// Return the URL for the given block number
     pub fn block_url(&self, block: u64) -> String {
-        format!("{}/block/{}", self.etherscan_url, block)
+        format!("{}block/{}", self.etherscan_url, block)
     }
 
     /// Return the URL for the given address
     pub fn address_url(&self, address: Address) -> String {
-        format!("{}/address/{}", self.etherscan_url, address)
+        format!("{}address/{}", self.etherscan_url, address)
     }
 
     /// Return the URL for the given transaction hash
     pub fn transaction_url(&self, tx_hash: impl AsRef<str>) -> String {
-        format!("{}/tx/{}", self.etherscan_url, tx_hash.as_ref())
+        format!("{}tx/{}", self.etherscan_url, tx_hash.as_ref())
     }
 
     /// Return the URL for the given token hash
     pub fn token_url(&self, token_hash: impl AsRef<str>) -> String {
-        format!("{}/token/{}", self.etherscan_url, token_hash.as_ref())
+        format!("{}token/{}", self.etherscan_url, token_hash.as_ref())
     }
 
     /// Execute an API POST request with a form
@@ -231,7 +231,7 @@ mod tests {
         time::{Duration, SystemTime},
     };
 
-    use ethers_core::types::Chain;
+    use ethers_core::types::{Chain, Address};
 
     use crate::{Client, EtherscanError};
 
@@ -241,6 +241,38 @@ mod tests {
 
         assert!(matches!(err, EtherscanError::ChainNotSupported(_)));
         assert_eq!(err.to_string(), "chain xdai not supported");
+    }
+
+    #[test]
+    fn stringifies_block_url() {
+        let etherscan = Client::new_from_env(Chain::Mainnet).unwrap();
+        let block: u64 = 1;
+        let block_url: String = etherscan.block_url(block);
+        assert_eq!(block_url, format!("https://etherscan.io/block/{}", block));
+    }
+
+    #[test]
+    fn stringifies_address_url() {
+        let etherscan = Client::new_from_env(Chain::Mainnet).unwrap();
+        let addr: Address = Address::zero();
+        let address_url: String = etherscan.address_url(addr);
+        assert_eq!(address_url, format!("https://etherscan.io/address/{}", addr));
+    }
+
+    #[test]
+    fn stringifies_transaction_url() {
+        let etherscan = Client::new_from_env(Chain::Mainnet).unwrap();
+        let tx_hash = "0x0";
+        let tx_url: String = etherscan.transaction_url(tx_hash);
+        assert_eq!(tx_url, format!("https://etherscan.io/tx/{}", tx_hash));
+    }
+
+    #[test]
+    fn stringifies_token_url() {
+        let etherscan = Client::new_from_env(Chain::Mainnet).unwrap();
+        let token_hash = "0x0";
+        let token_url: String = etherscan.token_url(token_hash);
+        assert_eq!(token_url, format!("https://etherscan.io/token/{}", token_hash));
     }
 
     #[test]

--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -231,7 +231,7 @@ mod tests {
         time::{Duration, SystemTime},
     };
 
-    use ethers_core::types::{Chain, Address};
+    use ethers_core::types::{Address, Chain};
 
     use crate::{Client, EtherscanError};
 


### PR DESCRIPTION
## Motivation

The `ethers-etherscan` crate constructs string urls with an additional slash, creating an invalid URL. For example, when running a `forge verify-contract`, the generated etherscan url contains an extra slash.

**Example 1**
<img width="446" alt="Screen Shot 2022-03-31 at 11 28 27 AM" src="https://user-images.githubusercontent.com/21288394/161128721-01cc40ff-f205-4cf5-b88f-0611c995543f.png">

**Example 2**
<img width="459" alt="Screen Shot 2022-03-31 at 11 35 37 AM" src="https://user-images.githubusercontent.com/21288394/161128726-b475a827-2a91-403d-b6de-0333371f05ed.png">
 

## Solution

Remove the additional slash in the url construction functions returning strings.

## PR Checklist

- [x] Added Tests

❌ (NOT NEEDED) Added Documentation
❌ (`ethers-etherscan` not included in changelog ?) Updated the changelog
