### PR TITLE
feat(solc): Strip experimental pragma from all imported contracts

### DIFF
--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -204,7 +204,7 @@ impl ProjectPathsConfig {
                 // (`<name>/=.../contracts`) and the stripped import also starts with `contracts`
                 if let Ok(adjusted_import) = stripped_import.strip_prefix("contracts/") {
                     if r.path.ends_with("contracts/") && !lib_path.exists() {
-                        return Path::new(&r.path).join(adjusted_import);
+                        return Path::new(&r.path).join(adjusted_import)
                     }
                 }
                 lib_path
@@ -272,7 +272,7 @@ impl ProjectPathsConfig {
 
         if imported.contains(target_index) {
             // short circuit nodes that were already imported, if both A.sol and B.sol import C.sol
-            return Ok(String::new());
+            return Ok(String::new())
         }
         imported.insert(*target_index);
 

--- a/ethers-solc/src/resolver/mod.rs
+++ b/ethers-solc/src/resolver/mod.rs
@@ -457,7 +457,7 @@ impl Graph {
             }
             if candidates.is_empty() {
                 // nothing to filter anymore
-                return;
+                return
             }
         }
     }
@@ -571,7 +571,7 @@ impl Graph {
             mut sets: Vec<&HashSet<&'a crate::SolcVersion>>,
         ) -> Vec<&'a crate::SolcVersion> {
             if sets.is_empty() {
-                return Vec::new();
+                return Vec::new()
             }
 
             let mut result = sets.pop().cloned().expect("not empty; qed.").clone();
@@ -609,7 +609,7 @@ impl Graph {
                 "resolved solc version compatible with all sources  \"{}\"",
                 exact_version
             );
-            return HashMap::from([(exact_version, all_nodes)]);
+            return HashMap::from([(exact_version, all_nodes)])
         }
 
         // no version satisfies all nodes
@@ -699,7 +699,7 @@ impl VersionedSources {
                     return Err(SolcError::msg(format!(
                         "missing solc \"{}\" installation in offline mode",
                         version
-                    )));
+                    )))
                 } else {
                     // install missing solc
                     Solc::blocking_install(version.as_ref())?

--- a/ethers-solc/src/resolver/mod.rs
+++ b/ethers-solc/src/resolver/mod.rs
@@ -457,7 +457,7 @@ impl Graph {
             }
             if candidates.is_empty() {
                 // nothing to filter anymore
-                return
+                return;
             }
         }
     }
@@ -571,7 +571,7 @@ impl Graph {
             mut sets: Vec<&HashSet<&'a crate::SolcVersion>>,
         ) -> Vec<&'a crate::SolcVersion> {
             if sets.is_empty() {
-                return Vec::new()
+                return Vec::new();
             }
 
             let mut result = sets.pop().cloned().expect("not empty; qed.").clone();
@@ -609,7 +609,7 @@ impl Graph {
                 "resolved solc version compatible with all sources  \"{}\"",
                 exact_version
             );
-            return HashMap::from([(exact_version, all_nodes)])
+            return HashMap::from([(exact_version, all_nodes)]);
         }
 
         // no version satisfies all nodes
@@ -699,7 +699,7 @@ impl VersionedSources {
                     return Err(SolcError::msg(format!(
                         "missing solc \"{}\" installation in offline mode",
                         version
-                    )))
+                    )));
                 } else {
                     // install missing solc
                     Solc::blocking_install(version.as_ref())?
@@ -761,6 +761,10 @@ impl Node {
 
     pub fn version(&self) -> &Option<SolDataUnit<String>> {
         &self.data.version
+    }
+
+    pub fn experimental(&self) -> &Option<SolDataUnit<String>> {
+        &self.data.experimental
     }
 
     pub fn license(&self) -> &Option<SolDataUnit<String>> {

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -500,6 +500,61 @@ contract A { }
 }
 
 #[test]
+fn can_flatten_experimental_pragma() {
+    let project = TempProject::dapptools().unwrap();
+
+    let f = project
+        .add_source(
+            "A",
+            r#"
+pragma solidity ^0.8.10;
+pragma experimental ABIEncoderV2;
+import "./C.sol";
+import "./B.sol";
+contract A { }
+"#,
+        )
+        .unwrap();
+
+    project
+        .add_source(
+            "B",
+            r#"
+pragma solidity ^0.8.10;
+pragma experimental ABIEncoderV2;
+import "./C.sol";
+contract B { }
+"#,
+        )
+        .unwrap();
+
+    project
+        .add_source(
+            "C",
+            r#"
+pragma solidity ^0.8.10;
+pragma experimental ABIEncoderV2;
+import "./A.sol";
+contract C { }
+"#,
+        )
+        .unwrap();
+
+    let result = project.flatten(&f).unwrap();
+
+    assert_eq!(
+        result,
+        r#"
+pragma solidity ^0.8.10;
+pragma experimental ABIEncoderV2;
+contract C { }
+contract B { }
+contract A { }
+"#
+    );
+}
+
+#[test]
 fn can_flatten_file_with_duplicates() {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test-data/test-flatten-duplicates");
     let paths = ProjectPathsConfig::builder().sources(root.join("contracts"));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`forge verify-contract` failed because `flatten` doesn't strip the experimental pragma from imported contracts.

Related issues: 
https://github.com/gakonst/foundry/issues/852
https://github.com/gakonst/ethers-rs/issues/1115

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
This PR enable `solc.flatten` to strip pragma from all imported contracts.

Fix #1115 


## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
