### PR TITLE
fix: fix deploy tx RLP decoding

### DIFF
--- a/ethers-core/src/types/transaction/eip1559.rs
+++ b/ethers-core/src/types/transaction/eip1559.rs
@@ -1,4 +1,4 @@
-use super::{eip2930::AccessList, normalize_v, rlp_opt};
+use super::{decode_to, eip2930::AccessList, normalize_v, rlp_opt};
 use crate::{
     types::{Address, Bytes, NameOrAddress, Signature, Transaction, H256, U256, U64},
     utils::keccak256,
@@ -199,19 +199,7 @@ impl Eip1559TransactionRequest {
         *offset += 1;
         self.gas = Some(rlp.val_at(*offset)?);
         *offset += 1;
-        self.to = {
-            let to = rlp.at(*offset)?;
-            if to.is_empty() {
-                if to.is_data() {
-                    None
-                } else {
-                    return Err(DecoderError::RlpExpectedToBeData)
-                }
-            } else {
-                Some(to.as_val()?)
-            }
-        };
-        *offset += 1;
+        self.to = decode_to(rlp, offset)?;
         self.value = Some(rlp.val_at(*offset)?);
         *offset += 1;
         let data = rlp::Rlp::new(rlp.at(*offset)?.as_raw()).data()?;

--- a/ethers-core/src/types/transaction/eip1559.rs
+++ b/ethers-core/src/types/transaction/eip1559.rs
@@ -199,7 +199,18 @@ impl Eip1559TransactionRequest {
         *offset += 1;
         self.gas = Some(rlp.val_at(*offset)?);
         *offset += 1;
-        self.to = Some(rlp.val_at(*offset)?);
+        self.to = {
+            let to = rlp.at(*offset)?;
+            if to.is_empty() {
+                if to.is_data() {
+                    None
+                } else {
+                    return Err(DecoderError::RlpExpectedToBeData)
+                }
+            } else {
+                Some(to.as_val()?)
+            }
+        };
         *offset += 1;
         self.value = Some(rlp.val_at(*offset)?);
         *offset += 1;

--- a/ethers-core/src/types/transaction/eip2718.rs
+++ b/ethers-core/src/types/transaction/eip2718.rs
@@ -455,4 +455,12 @@ mod tests {
         let decoded_transaction = TypedTransaction::decode(&expected_rlp).unwrap();
         assert_eq!(tx.sighash(), decoded_transaction.sighash());
     }
+
+    #[test]
+    fn test_eip1559_deploy_tx_decode() {
+        let typed_tx_hex =
+            hex::decode("02dc8205058193849502f90085010c388d00837a120080808411223344c0").unwrap();
+        let tx_rlp = rlp::Rlp::new(typed_tx_hex.as_slice());
+        TypedTransaction::decode(&tx_rlp).unwrap();
+    }
 }

--- a/ethers-core/src/types/transaction/eip2930.rs
+++ b/ethers-core/src/types/transaction/eip2930.rs
@@ -1,4 +1,4 @@
-use super::{normalize_v, request::TransactionRequest};
+use super::{decode_to, normalize_v, request::TransactionRequest};
 use crate::types::{Address, Bytes, Signature, Transaction, H256, U256, U64};
 
 use rlp::{Decodable, DecoderError, RlpStream};
@@ -117,19 +117,7 @@ impl Eip2930TransactionRequest {
 
         self.tx.gas = Some(rlp.val_at(*offset)?);
         *offset += 1;
-        self.tx.to = {
-            let to = rlp.at(*offset)?;
-            if to.is_empty() {
-                if to.is_data() {
-                    None
-                } else {
-                    return Err(DecoderError::RlpExpectedToBeData)
-                }
-            } else {
-                Some(to.as_val()?)
-            }
-        };
-        *offset += 1;
+        self.tx.to = decode_to(rlp, offset)?;
         self.tx.value = Some(rlp.val_at(*offset)?);
         *offset += 1;
         let data = rlp::Rlp::new(rlp.at(*offset)?.as_raw()).data()?;

--- a/ethers-core/src/types/transaction/eip2930.rs
+++ b/ethers-core/src/types/transaction/eip2930.rs
@@ -117,7 +117,18 @@ impl Eip2930TransactionRequest {
 
         self.tx.gas = Some(rlp.val_at(*offset)?);
         *offset += 1;
-        self.tx.to = Some(rlp.val_at(*offset)?);
+        self.tx.to = {
+            let to = rlp.at(*offset)?;
+            if to.is_empty() {
+                if to.is_data() {
+                    None
+                } else {
+                    return Err(DecoderError::RlpExpectedToBeData)
+                }
+            } else {
+                Some(to.as_val()?)
+            }
+        };
         *offset += 1;
         self.tx.value = Some(rlp.val_at(*offset)?);
         *offset += 1;

--- a/ethers-core/src/types/transaction/mod.rs
+++ b/ethers-core/src/types/transaction/mod.rs
@@ -60,6 +60,30 @@ fn decode_signature(
     Ok(sig)
 }
 
+/// Decodes the `to` field of the RLP encoding based on the RLP offset passed. Increments the offset
+/// by one.
+#[inline]
+fn decode_to(
+    rlp: &rlp::Rlp,
+    offset: &mut usize,
+) -> Result<Option<super::NameOrAddress>, rlp::DecoderError> {
+    let to = {
+        let to = rlp.at(*offset)?;
+        if to.is_empty() {
+            if to.is_data() {
+                None
+            } else {
+                return Err(rlp::DecoderError::RlpExpectedToBeData)
+            }
+        } else {
+            Some(to.as_val()?)
+        }
+    };
+    *offset += 1;
+
+    Ok(to)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::types::{transaction::rlp_opt, U64};

--- a/ethers-core/src/types/transaction/request.rs
+++ b/ethers-core/src/types/transaction/request.rs
@@ -217,7 +217,18 @@ impl TransactionRequest {
             *offset += 1;
         }
 
-        txn.to = Some(rlp.at(*offset)?.as_val()?);
+        txn.to = {
+            let to = rlp.at(*offset)?;
+            if to.is_empty() {
+                if to.is_data() {
+                    None
+                } else {
+                    return Err(rlp::DecoderError::RlpExpectedToBeData)
+                }
+            } else {
+                Some(to.as_val()?)
+            }
+        };
         *offset += 1;
         txn.value = Some(rlp.at(*offset)?.as_val()?);
         *offset += 1;

--- a/ethers-core/src/types/transaction/request.rs
+++ b/ethers-core/src/types/transaction/request.rs
@@ -1,5 +1,5 @@
 //! Transaction types
-use super::{extract_chain_id, rlp_opt, NUM_TX_FIELDS};
+use super::{decode_to, extract_chain_id, rlp_opt, NUM_TX_FIELDS};
 use crate::{
     types::{Address, Bytes, NameOrAddress, Signature, Transaction, H256, U256, U64},
     utils::keccak256,
@@ -217,19 +217,7 @@ impl TransactionRequest {
             *offset += 1;
         }
 
-        txn.to = {
-            let to = rlp.at(*offset)?;
-            if to.is_empty() {
-                if to.is_data() {
-                    None
-                } else {
-                    return Err(rlp::DecoderError::RlpExpectedToBeData)
-                }
-            } else {
-                Some(to.as_val()?)
-            }
-        };
-        *offset += 1;
+        txn.to = decode_to(rlp, offset)?;
         txn.value = Some(rlp.at(*offset)?.as_val()?);
         *offset += 1;
 


### PR DESCRIPTION
The transaction RLP decoding logic assumes `to` is present but it's actually not true for contract deployment transactions. The library fails to decode such transactions as a result.

This PR fixes it.