### PR TITLE
chore: make ipfs the default bytecodehash again

### DIFF
--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -490,7 +490,7 @@ impl From<BytecodeHash> for SettingsMetadata {
 
 /// Determines the hash method for the metadata hash that is appended to the bytecode.
 ///
-/// While solc's default is `Ipfs`, see <https://docs.soliditylang.org/en/latest/using-the-compiler.html#compiler-api>, the default for this type is `None` to ensure deterministic code output.
+/// Solc's default is `Ipfs`, see <https://docs.soliditylang.org/en/latest/using-the-compiler.html#compiler-api>.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BytecodeHash {
     Ipfs,
@@ -500,7 +500,7 @@ pub enum BytecodeHash {
 
 impl Default for BytecodeHash {
     fn default() -> Self {
-        BytecodeHash::None
+        BytecodeHash::Ipfs
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
ipfs as default hash is consistent with solc's defaults
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
