### PR TITLE
fix(solc): strip root path from remappings and sources for standard json

### DIFF
--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -144,6 +144,25 @@ impl CompilerInput {
         self.settings.remappings = remappings;
         self
     }
+
+    /// Sets the path of the source files to `root` adjoined to the existing path
+    #[must_use]
+    pub fn join_path(mut self, root: impl AsRef<Path>) -> Self {
+        let root = root.as_ref();
+        self.sources = self.sources.into_iter().map(|(path, s)| (root.join(path), s)).collect();
+        self
+    }
+
+    /// Removes the `base` path from all source files
+    pub fn strip_prefix(mut self, base: impl AsRef<Path>) -> Self {
+        let base = base.as_ref();
+        self.sources = self
+            .sources
+            .into_iter()
+            .map(|(path, s)| (path.strip_prefix(base).map(|p| p.to_path_buf()).unwrap_or(path), s))
+            .collect();
+        self
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -13,7 +13,7 @@ use ethers_solc::{
     project_util::*,
     remappings::Remapping,
     ConfigurableArtifacts, ExtraOutputValues, Graph, Project, ProjectCompileOutput,
-    ProjectPathsConfig, TestFileFilter,
+    ProjectPathsConfig, Solc, TestFileFilter,
 };
 use pretty_assertions::assert_eq;
 
@@ -954,4 +954,22 @@ fn can_sanitize_bytecode_hash() {
     let compiled = tmp.compile().unwrap();
     assert!(!compiled.has_compiler_errors());
     assert!(compiled.find("A").is_some());
+}
+
+#[test]
+fn can_compile_std_json_input() {
+    let tmp = TempProject::dapptools_init().unwrap();
+    tmp.assert_no_errors();
+    let source = tmp.list_source_files().remove(1);
+    let input = tmp.project().standard_json_input(source).unwrap();
+
+    assert!(input.settings.remappings.contains(&"ds-test/=lib/ds-test/src/".parse().unwrap()));
+    assert!(input.sources.contains_key(Path::new("lib/ds-test/src/test.sol")));
+
+    // should be installed
+    if let Some(solc) = Solc::find_svm_installed_version("0.8.10").ok().flatten() {
+        let out = solc.compile(&input).unwrap();
+        assert!(!out.has_error());
+        assert!(out.sources.contains_key("lib/ds-test/src/test.sol"));
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Ensures only project layout is included in the standard json compiler input used for verification
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
strip root dir from remappings and source paths
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
