### PR TITLE
feat(ethers-core/abi): impl AbiArrayType for u8

### DIFF
--- a/ethers-core/src/abi/mod.rs
+++ b/ethers-core/src/abi/mod.rs
@@ -100,12 +100,7 @@ impl<T: AbiArrayType, const N: usize> AbiType for [T; N] {
 
 impl<T: AbiArrayType, const N: usize> AbiArrayType for [T; N] {}
 
-impl<const N: usize> AbiType for [u8; N] {
-    fn param_type() -> ParamType {
-        ParamType::FixedBytes(N)
-    }
-}
-impl<const N: usize> AbiArrayType for [u8; N] {}
+impl AbiArrayType for u8 {}
 
 macro_rules! impl_abi_type {
     ($($name:ty => $var:ident $(($value:expr))? ),*) => {
@@ -123,7 +118,6 @@ macro_rules! impl_abi_type {
 
 impl_abi_type!(
     Bytes => Bytes,
-    Vec<u8> =>  Array(Box::new(ParamType::Uint(8))),
     Address => Address,
     bool => Bool,
     String => String,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Had a compilation error earlier in abigen:
```
1198 |         pub pairs_to_swap: ::std::vec::Vec<(u8, u8)>,
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `AbiArrayType` is not implemented for `u8`
```
So implementing it.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
