### PR TITLE
fix(solc): compute content hashes first

### DIFF
--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -728,6 +728,8 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
                 return false
             }
             tracing::trace!("Missing cache entry for {}", file.display());
+        } else {
+            tracing::trace!("Missing content hash for {}", file.display());
         }
         true
     }

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -630,8 +630,6 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
     /// so that their [OutputSelection] can be optimized in the [CompilerOutput] and their (empty)
     /// artifacts ignored.
     fn filter(&mut self, sources: Sources, version: &Version) -> FilteredSources {
-        self.fill_hashes(&sources);
-
         // all files that are not dirty themselves, but are pulled from a dirty file
         let mut imports_of_dirty = HashSet::new();
 
@@ -832,6 +830,14 @@ impl<'a, T: ArtifactOutput> ArtifactsCache<'a, T> {
         match self {
             ArtifactsCache::Ephemeral(_, project) => project,
             ArtifactsCache::Cached(cache) => cache.project,
+        }
+    }
+
+    /// Adds the file's hashes to the set if not set yet
+    pub fn fill_content_hashes(&mut self, sources: &Sources) {
+        match self {
+            ArtifactsCache::Ephemeral(_, _) => {}
+            ArtifactsCache::Cached(cache) => cache.fill_hashes(sources),
         }
     }
 

--- a/ethers-solc/src/compile/project.rs
+++ b/ethers-solc/src/compile/project.rs
@@ -331,6 +331,11 @@ impl CompilerSources {
             sources: VersionedSources,
             cache: &mut ArtifactsCache<T>,
         ) -> VersionedFilteredSources {
+            // fill all content hashes first so they're available for all source sets
+            sources.iter().for_each(|(_, (_, sources))| {
+                cache.fill_content_hashes(sources);
+            });
+
             sources
                 .into_iter()
                 .map(|(solc, (version, sources))| {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
compute the content hashes for all source sets first so they#re available when filtering individual sets

supersedes #1141
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
