### PR TITLE
test: add type check test for abi array tuples

### DIFF
--- a/ethers-core/src/abi/mod.rs
+++ b/ethers-core/src/abi/mod.rs
@@ -270,4 +270,22 @@ mod tests {
             <[u16; 32]>::param_type()
         );
     }
+
+    #[test]
+    fn abi_type_tuples_work() {
+        fn assert_abitype<T: AbiType>() {}
+        fn assert_abiarraytype<T: AbiArrayType>() {}
+
+        assert_abitype::<(u64, u64)>();
+        assert_abiarraytype::<(u64, u64)>();
+
+        assert_abitype::<(u8, u8)>();
+        assert_abiarraytype::<(u8, u8)>();
+
+        assert_abitype::<Vec<(u64, u64)>>();
+        assert_abiarraytype::<Vec<(u64, u64)>>();
+
+        assert_abitype::<Vec<(u8, u8)>>();
+        assert_abiarraytype::<Vec<(u8, u8)>>();
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Followup #1140

@meetmangukiya highlighted that `AbiArrayType` should be implemented for `Vec<T:AbiArrayType>` and tuples are `AbiArrayType`. This PR confirms that, so whatever is causing #1140 is related to a derive macro I think
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
