### PR TITLE
fix(timelag): normalize block if block = None

### DIFF
--- a/ethers-middleware/src/timelag/mod.rs
+++ b/ethers-middleware/src/timelag/mod.rs
@@ -58,7 +58,7 @@ where
                 Ok(self.normalize_block_number(Some(n)).await?.map(Into::into))
             }
             None => Ok(self.normalize_block_number(None).await?.map(Into::into)),
-            _ => Ok(id)
+            _ => Ok(id),
         }
     }
 
@@ -227,12 +227,12 @@ where
             .map_err(ethers_providers::FromErr::from)?;
 
         if receipt.is_none() {
-            return Ok(None);
+            return Ok(None)
         }
 
         let receipt = receipt.expect("checked is_none");
         if receipt.block_number.is_none() {
-            return Ok(Some(receipt));
+            return Ok(Some(receipt))
         }
 
         let number = receipt.block_number.expect("checked is_none");

--- a/ethers-middleware/src/timelag/mod.rs
+++ b/ethers-middleware/src/timelag/mod.rs
@@ -57,7 +57,8 @@ where
             Some(BlockId::Number(n)) => {
                 Ok(self.normalize_block_number(Some(n)).await?.map(Into::into))
             }
-            _ => Ok(id),
+            None => Ok(self.normalize_block_number(None).await?.map(Into::into)),
+            _ => Ok(id)
         }
     }
 
@@ -65,16 +66,17 @@ where
         &self,
         number: Option<BlockNumber>,
     ) -> TimeLagResult<Option<BlockNumber>, M> {
-        let tip = self.get_block_number().await?;
+        let lag_tip = self.get_block_number().await?;
         match number {
-            Some(BlockNumber::Latest) => Ok(Some(BlockNumber::Number(tip))),
+            Some(BlockNumber::Latest) => Ok(Some(BlockNumber::Number(lag_tip))),
             Some(BlockNumber::Number(n)) => {
-                if n > tip {
-                    Ok(Some(BlockNumber::Latest))
+                if n < lag_tip {
+                    Ok(Some(BlockNumber::Number(n)))
                 } else {
-                    Ok(number)
+                    Ok(Some(BlockNumber::Number(lag_tip)))
                 }
             }
+            None => Ok(Some(BlockNumber::Number(lag_tip))),
             _ => Ok(number),
         }
     }
@@ -121,7 +123,6 @@ where
         tx: T,
         block: Option<BlockId>,
     ) -> Result<ethers_providers::PendingTransaction<'_, Self::Provider>, Self::Error> {
-        let block = self.normalize_block_id(block).await?;
         self.inner().send_transaction(tx, block).await.map_err(ethers_providers::FromErr::from)
     }
 
@@ -226,12 +227,12 @@ where
             .map_err(ethers_providers::FromErr::from)?;
 
         if receipt.is_none() {
-            return Ok(None)
+            return Ok(None);
         }
 
         let receipt = receipt.expect("checked is_none");
         if receipt.block_number.is_none() {
-            return Ok(Some(receipt))
+            return Ok(Some(receipt));
         }
 
         let number = receipt.block_number.expect("checked is_none");
@@ -271,7 +272,6 @@ where
         tx: &mut TypedTransaction,
         block: Option<BlockId>,
     ) -> Result<(), Self::Error> {
-        let block = self.normalize_block_id(block).await?;
         self.inner().fill_transaction(tx, block).await.map_err(ethers_providers::FromErr::from)
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Timelag not lagging behind for normal state queries (calls), only for block indexing.
- Ethers-contract implementation provides [block = None when building a ContractCall](https://github.com/gakonst/ethers-rs/blob/master/ethers-contract/src/contract.rs#L241)
-[ Contract.call() passes tx and block id (set to None) to provider](https://github.com/gakonst/ethers-rs/blob/master/ethers-contract/src/call.rs#L151-L152)
- Provider passes down the stack of inners
- Timelag middleware applies lag by calling normalize_block_number [BUT it is only called if the provided block is Some (call —> normalize_block_id —> normalize_block_number IFF id is Some)](https://github.com/gakonst/ethers-rs/blob/master/ethers-middleware/src/timelag/mod.rs#L60)
- That block field set by the contract was None so the timelag middleware never applies the lag

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Apply timelag if block = None.

## PR Checklist

- [ ] Added Tests (N/A)
- [ ] Added Documentation (N/A)
- [x] Updated the changelog
