### PR TITLE
feat(solc): Use IndexedPathBuf for CompilerInput Sources

### DIFF
--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -56,12 +56,10 @@ impl Ord for IndexedPathBuf {
     fn cmp(&self, other: &Self) -> Ordering {
         if self.path == other.path {
             Ordering::Equal // PathBuf deduplication
+        } else if self.index >= other.index {
+            Ordering::Greater
         } else {
-            if self.index >= other.index {
-                Ordering::Greater
-            } else {
-                Ordering::Less
-            }
+            Ordering::Less
         }
     }
 }

--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -40,7 +40,7 @@ pub type Contracts = FileToContractsMap<Contract>;
 
 /// A pair of PathBuf and their index
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(into = "PathBuf")]
+#[serde(into = "PathBuf", from = "PathBuf")]
 pub struct IndexedPathBuf {
     pub path: PathBuf,
     pub index: usize,
@@ -79,6 +79,12 @@ impl Eq for IndexedPathBuf {}
 impl From<IndexedPathBuf> for PathBuf {
     fn from(i: IndexedPathBuf) -> Self {
         i.path
+    }
+}
+
+impl From<PathBuf> for IndexedPathBuf {
+    fn from(p: PathBuf) -> Self {
+        IndexedPathBuf::new(p, 0)
     }
 }
 

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -636,7 +636,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
         // separates all source files that fit the criteria (dirty) from those that don't (clean)
         let (mut filtered_sources, clean_sources) = sources
             .into_iter()
-            .map(|(file, source)| self.filter_source(file, source, version))
+            .map(|(file, source)| self.filter_source(file.path, source, version))
             .fold(
                 (BTreeMap::default(), Vec::new()),
                 |(mut dirty_sources, mut clean_sources), source| {
@@ -735,7 +735,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
     /// Adds the file's hashes to the set if not set yet
     fn fill_hashes(&mut self, sources: &Sources) {
         for (file, source) in sources {
-            if let hash_map::Entry::Vacant(entry) = self.content_hashes.entry(file.clone()) {
+            if let hash_map::Entry::Vacant(entry) = self.content_hashes.entry(file.path.clone()) {
                 entry.insert(source.content_hash());
             }
         }

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -449,7 +449,7 @@ impl Solc {
     /// ```
     pub fn compile_exact(&self, input: &CompilerInput) -> Result<CompilerOutput> {
         let mut out = self.compile(input)?;
-        out.retain_files(input.sources.keys().filter_map(|p| p.to_str()));
+        out.retain_files(input.sources.keys().filter_map(|p| p.path.to_str()));
         Ok(out)
     }
 

--- a/ethers-solc/src/filter.rs
+++ b/ethers-solc/src/filter.rs
@@ -3,7 +3,7 @@
 use crate::{
     artifacts::{output_selection::OutputSelection, Settings},
     resolver::GraphEdges,
-    Source, Sources,
+    IndexedPathBuf, Source, Sources,
 };
 use std::{
     collections::BTreeMap,
@@ -227,13 +227,20 @@ impl FilteredSources {
 
 impl From<FilteredSources> for Sources {
     fn from(sources: FilteredSources) -> Self {
-        sources.0.into_iter().map(|(k, v)| (k, v.into_source())).collect()
+        sources
+            .0
+            .into_iter()
+            .enumerate()
+            .map(|(i, (k, v))| (IndexedPathBuf::new(k, i), v.into_source()))
+            .collect()
     }
 }
 
 impl From<Sources> for FilteredSources {
     fn from(s: Sources) -> Self {
-        FilteredSources(s.into_iter().map(|(key, val)| (key, FilteredSource::Dirty(val))).collect())
+        FilteredSources(
+            s.into_iter().map(|(key, val)| (key.path, FilteredSource::Dirty(val))).collect(),
+        )
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Based on https://github.com/foundry-rs/foundry/issues/1283 it seems that Etherscan is not automatically detect main contract to be displayed as the first source on the list. 

After learning how `hardhat-etherscan` [verification works](https://gist.github.com/pyk/7eff86450abb92f86c3e712f741d1802) turns out that hardhat always place the main contract as the first key of the `sources`.

This behaviour is currently not possible in `ethers-solc` due to CompilerInput sources is using `BTreeMap<PathBuf, Source>`. When compiler input is [serialized as JSON](https://github.com/foundry-rs/foundry/blob/b6451a5c501475892453ee4aadd681de78d7b6ec/cli/src/cmd/forge/verify.rs#L340), it always ordered alphabetically (`PathBuf` default), not by their insertion order.



<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This changes propose `Sources` to be defined as `BTreeMap<IndexedPathBuf, Source>` instead of `BTreeMap<PathBuf, Source>`. `IndexedPathBuf` contains `index` field which we can use to determine how the key is sorted by just simply assign the `index` value.

In the case of verification, the `sources` key will be ordered by source code for main contract first then followed by the imported source codes.

Results:
- [Contract Verified without IndexedPathBuf](https://rinkeby.etherscan.io/address/0xcc544ecdc8b0f00fe8e4e7f796032c3919d3d83f#code)
- [Contract Verified with IndexedPathBuf](https://rinkeby.etherscan.io/address/0x356a7bb15a898e7265f377a71825d21072202123#code)

(`SimpleERC20` is on top of the list and followed by the imports)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
