### PR TITLE
feat: function debug data in extra output

### DIFF
--- a/ethers-solc/src/artifact_output/configurable.rs
+++ b/ethers-solc/src/artifact_output/configurable.rs
@@ -159,6 +159,7 @@ impl ConfigurableArtifacts {
     /// Returns the output selection corresponding to this configuration
     pub fn output_selection(&self) -> Vec<ContractOutputSelection> {
         let mut selection = ContractOutputSelection::basic();
+
         if self.additional_values.ir {
             selection.push(ContractOutputSelection::Ir);
         }
@@ -185,6 +186,12 @@ impl ConfigurableArtifacts {
         }
         if self.additional_values.ewasm || self.additional_files.ewasm {
             selection.push(EwasmOutputSelection::All.into());
+        }
+        if self.additional_values.function_debug_data {
+            selection.push(BytecodeOutputSelection::FunctionDebugData.into());
+        }
+        if self.additional_values.method_identifiers {
+            selection.push(EvmOutputSelection::MethodIdentifiers.into());
         }
         selection
     }

--- a/ethers-solc/src/artifact_output/configurable.rs
+++ b/ethers-solc/src/artifact_output/configurable.rs
@@ -270,7 +270,8 @@ impl ArtifactOutput for ConfigurableArtifacts {
             } = evm;
 
             if self.additional_values.function_debug_data {
-                artifact_function_debug_data = bytecode.map(|b| b.function_debug_data);
+                artifact_function_debug_data =
+                    bytecode.as_ref().map(|b| b.function_debug_data.clone());
             }
 
             artifact_bytecode = bytecode.map(Into::into);
@@ -400,12 +401,9 @@ impl ExtraOutputValues {
                     EvmOutputSelection::GasEstimates => {
                         config.gas_estimates = true;
                     }
-                    EvmOutputSelection::ByteCode(bytecode) => match bytecode {
-                        BytecodeOutputSelection::FunctionDebugData => {
-                            config.function_debug_data = true;
-                        }
-                        _ => {}
-                    },
+                    EvmOutputSelection::ByteCode(BytecodeOutputSelection::FunctionDebugData) => {
+                        config.function_debug_data = true;
+                    }
                     _ => {}
                 },
                 ContractOutputSelection::Ewasm(_) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

https://github.com/foundry-rs/foundry/issues/1381

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add it

Also, it seems like the AST is always present and is not configurable - it's not present in `OutputSelection` and is enabled by default.

`ExtraOutputValues::compact_format` also seems to be unused?
