### PR TITLE
chore(core): derive default for log

### DIFF
--- a/ethers-core/src/types/log.rs
+++ b/ethers-core/src/types/log.rs
@@ -9,7 +9,7 @@ use serde::{
 use std::ops::{Range, RangeFrom, RangeTo};
 
 /// A log produced by a transaction.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct Log {
     /// H160. the contract that emitted the log
     pub address: Address,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This is a minor change mainly aimed at making it more convenient to instantiate a `Log` without the need to mark all the optional fields as `None`. For instance:
```rust
let log = Log {
    address: Address::random(),
    bloom: Bloom(rand_bytes(256)),
    topics: vec![H256::random(), H256::random()],
    ..Default::default()
};
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Derive `Default` for `Log`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
