### PR TITLE
fix: proper fantom api urls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,8 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/ethers-etherscan/Cargo.toml
+++ b/ethers-etherscan/Cargo.toml
@@ -21,11 +21,13 @@ serde = { version = "1.0.124", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.64", default-features = false }
 serde-aux = { version = "3.0.1", default-features = false }
 thiserror = "1.0.29"
+tracing = "0.1.34"
 
 [dev-dependencies]
 tempfile = "3.3.0"
 tokio = { version = "1.5", features = ["macros", "rt-multi-thread", "time"] }
 serial_test = "0.6.0"
+tracing-subscriber = {version = "0.3", default-features = false, features = ["env-filter", "fmt"]}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ethers-etherscan/Cargo.toml
+++ b/ethers-etherscan/Cargo.toml
@@ -27,7 +27,7 @@ tracing = "0.1.34"
 tempfile = "3.3.0"
 tokio = { version = "1.5", features = ["macros", "rt-multi-thread", "time"] }
 serial_test = "0.6.0"
-tracing-subscriber = {version = "0.3", default-features = false, features = ["env-filter", "fmt"]}
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ethers-etherscan/src/contract.rs
+++ b/ethers-etherscan/src/contract.rs
@@ -307,6 +307,7 @@ impl Client {
             }
             return Err(EtherscanError::ContractCodeNotVerified(address))
         }
+        dbg!(resp.result.clone());
         let abi = serde_json::from_str(&resp.result)?;
 
         if let Some(ref cache) = self.cache {
@@ -364,14 +365,34 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use std::{path::PathBuf, time::Duration};
-
-    use serial_test::serial;
-
+    use crate::{contract::VerifyContract, tests::run_at_least_duration, Client, EtherscanError};
     use ethers_core::types::Chain;
     use ethers_solc::{Project, ProjectPathsConfig};
+    use serial_test::serial;
+    use std::{path::PathBuf, time::Duration};
 
-    use crate::{contract::VerifyContract, tests::run_at_least_duration, Client, EtherscanError};
+    #[allow(unused)]
+    fn init_tracing() {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .init();
+    }
+
+    #[tokio::test]
+    #[serial]
+    #[ignore]
+    async fn can_fetch_ftm_contract_abi() {
+        init_tracing();
+        run_at_least_duration(Duration::from_millis(250), async {
+            let client = Client::new_from_env(Chain::Fantom).unwrap();
+
+            let _abi = client
+                .contract_abi("0x80AA7cb0006d5DDD91cce684229Ac6e398864606".parse().unwrap())
+                .await
+                .unwrap();
+        })
+        .await;
+    }
 
     #[tokio::test]
     #[serial]

--- a/ethers-etherscan/src/contract.rs
+++ b/ethers-etherscan/src/contract.rs
@@ -307,7 +307,6 @@ impl Client {
             }
             return Err(EtherscanError::ContractCodeNotVerified(address))
         }
-        dbg!(resp.result.clone());
         let abi = serde_json::from_str(&resp.result)?;
 
         if let Some(ref cache) = self.cache {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Use correct fantom API URLs

**NOTE** API env for fantom is now `FTMSCAN_*` or `FANTOM_SCAN`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
