### PR TITLE
fix(solc): adjust flatten format

### DIFF
--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -250,7 +250,9 @@ impl ProjectPathsConfig {
     pub fn flatten(&self, target: &Path) -> Result<String> {
         tracing::trace!("flattening file");
         let graph = Graph::resolve(self)?;
-        self.flatten_node(target, &graph, &mut Default::default(), false, false, false)
+        self.flatten_node(target, &graph, &mut Default::default(), false, false, false).map(|x| {
+            format!("{}\n", utils::RE_THREE_OR_MORE_NEWLINES.replace_all(&x, "\n\n").trim())
+        })
     }
 
     /// Flattens a single node from the dependency graph
@@ -321,7 +323,6 @@ impl ProjectPathsConfig {
         let result = String::from_utf8(content).map_err(|err| {
             SolcError::msg(format!("failed to convert extended bytes to string: {}", err))
         })?;
-        let result = utils::RE_THREE_OR_MORE_NEWLINES.replace_all(&result, "\n\n").into_owned();
 
         Ok(result)
     }

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -490,8 +490,7 @@ contract C { }
 
     assert_eq!(
         result,
-        r#"
-pragma solidity ^0.8.10;
+        r#"pragma solidity ^0.8.10;
 
 contract C { }
 
@@ -547,8 +546,7 @@ contract C { }
 
     assert_eq!(
         result,
-        r#"
-pragma solidity ^0.8.10;
+        r#"pragma solidity ^0.8.10;
 pragma experimental ABIEncoderV2;
 
 contract C { }
@@ -656,7 +654,7 @@ contract C { }
 
     let result = project.flatten(&f).unwrap();
     assert_eq!(
-        result.trim(),
+        result,
         r#"pragma solidity ^0.8.10;
 
 contract C { }
@@ -664,7 +662,8 @@ contract C { }
 error IllegalArgument();
 error IllegalState();
 
-contract A { }"#
+contract A { }
+"#
     );
 }
 
@@ -707,7 +706,7 @@ contract C { }
 
     let result = project.flatten(&f).unwrap();
     assert_eq!(
-        result.trim(),
+        result,
         r#"pragma solidity ^0.8.10;
 
 contract C { }
@@ -716,7 +715,8 @@ contract C { }
 
 contract B { }
 
-contract A { }"#
+contract A { }
+"#
     );
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Adjust flatten output format so that:
1. no newline at the start of the file, and
2. newline at the end of the last line.

## Solution
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

1. Move regex replace out of recursion (could have slight performance improvement).
2. `trim` and append `\n` at the end before returning result.
3. Adjust tests to reflext the new output formats.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

