### PR TITLE
Update event.rs::parse_log to public

### DIFF
--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -186,7 +186,7 @@ where
         Ok(events)
     }
 
-    fn parse_log(&self, log: Log) -> Result<D, ContractError<M>> {
+    pub fn parse_log(&self, log: Log) -> Result<D, ContractError<M>> {
         D::decode_log(&RawLog { topics: log.topics, data: log.data.to_vec() }).map_err(From::from)
     }
 }


### PR DESCRIPTION
## Motivation

When doing a transaction, we'd like to know the logs it generated to get the data from those logs. We usually have a `TransactionReceipt` which does contain a vector of `Log`. Unfortunately, the only method available to parse this as the events of one contract is to use `contract.my_event_filter().parse_log()` but this is private.
The other methods like `decode_log` take a `RawLog` and thus can't be used from a TransactionReceipt.

## Solution

Make `parse_log` public.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
