### PR TITLE
refactors ipc transport internals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,7 @@ dependencies = [
  "futures-core",
  "futures-timer",
  "futures-util",
+ "hashers",
  "hex",
  "http",
  "once_cell",
@@ -1635,6 +1636,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,6 +1734,15 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hashers"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
+dependencies = [
+ "fxhash",
+]
 
 [[package]]
 name = "heck"

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -40,6 +40,7 @@ tracing-futures = { version = "0.2.5", default-features = false, features = ["st
 
 bytes = { version  = "1.1.0", default-features = false, optional = true }
 once_cell = "1.10.0"
+hashers = "1.0.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # tokio

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -11,10 +11,7 @@ use futures_util::{
     sink::{Sink, SinkExt},
     stream::{Fuse, Stream, StreamExt},
 };
-use serde::{
-    de::{DeserializeOwned, Error},
-    Serialize,
-};
+use serde::{de::DeserializeOwned, Serialize};
 use serde_json::value::RawValue;
 use std::{
     collections::{btree_map::Entry, BTreeMap},
@@ -26,7 +23,7 @@ use std::{
 };
 use thiserror::Error;
 
-use super::common::{Notification, Response};
+use super::common::{Params, Response};
 
 if_wasm! {
     use wasm_bindgen::prelude::*;
@@ -320,35 +317,34 @@ where
     }
 
     async fn handle_text(&mut self, inner: String) -> Result<(), ClientError> {
-        if let Ok(response) = serde_json::from_str::<Response<'_>>(&inner) {
-            if let Some(request) = self.pending.remove(&response.id()) {
-                if !request.is_canceled() {
-                    request.send(response.into_result()).map_err(to_client_error)?;
-                }
-            }
+        let (id, result) = match serde_json::from_str(&inner)? {
+            Response::Success { id, result } => (id, Ok(result.to_owned())),
+            Response::Error { id, error } => (id, Err(error)),
+            Response::Notification { params, .. } => return self.handle_notification(params),
+        };
 
-            return Ok(())
+        if let Some(request) = self.pending.remove(&id) {
+            if !request.is_canceled() {
+                request.send(result).map_err(to_client_error)?;
+            }
         }
 
-        if let Ok(notification) = serde_json::from_str::<Notification<'_>>(&inner) {
-            let id = notification.params.subscription;
-            if let Entry::Occupied(stream) = self.subscriptions.entry(id) {
-                if let Err(err) = stream.get().unbounded_send(notification.params.result.to_owned())
-                {
-                    if err.is_disconnected() {
-                        // subscription channel was closed on the receiver end
-                        stream.remove();
-                    }
-                    return Err(to_client_error(err))
-                }
-            }
+        Ok(())
+    }
 
-            return Ok(())
+    fn handle_notification(&mut self, params: Params<'_>) -> Result<(), ClientError> {
+        let id = params.subscription;
+        if let Entry::Occupied(stream) = self.subscriptions.entry(id) {
+            if let Err(err) = stream.get().unbounded_send(params.result.to_owned()) {
+                if err.is_disconnected() {
+                    // subscription channel was closed on the receiver end
+                    stream.remove();
+                }
+                return Err(to_client_error(err))
+            }
         }
 
-        Err(ClientError::JsonError(serde_json::Error::custom(
-            "response is neither a valid jsonrpc response nor notification",
-        )))
+        return Ok(())
     }
 
     #[cfg(target_arch = "wasm32")]

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -344,7 +344,7 @@ where
             }
         }
 
-        return Ok(())
+        Ok(())
     }
 
     #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
ran cargo +nightly fmt

fixes typo

remove some commented out code

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The current IPC server code has two issues:

https://github.com/gakonst/ethers-rs/blob/77bd9d49c88ca8bdced37f7554919e3c3d584310/ethers-providers/src/transports/ipc.rs#L163-L186

This is the main IPC server loop (the function is called in a loop). Since the IPC `UnixStream` is split into read & write halves, I assume the intention was to allow reads & writes to happen concurrently, but due to the await in line 169 this is broken: The `await` on the write action (the first arm of the select expression) prevents any reads to be processed while the write is incomplete.

The second issue is in the `handle_request` method itself:

https://github.com/gakonst/ethers-rs/blob/77bd9d49c88ca8bdced37f7554919e3c3d584310/ethers-providers/src/transports/ipc.rs#L195-L199

Here, a call to `tokio::io::AsyncWriteExt::write` is made, which does **not** guarantee all bytes from the given `buf` are actually written (the fix is basically to call `write_all`). 

## Solution

Since the code for the IPC server was fairly convoluted and the error handling in many cases rather questionable (hard errors logged as warnings, normal events logged as errors, etc) I opted to basically rewrite the IPC server part.

Instead of spawning a tokio task, I instead to chose to spawn a regular thread with a single-threaded tokio runtime on it (avoids synchronization overhead, otherwise the hash maps of pending requests and subscriptions would need a mutex) and replaced the `select!` with a simpler `try_join!`, which does allow fully concurrent reads & writes.
I also replaced the manual buffer management with a more straight-forward use of the `bytes` crate (which was already used before, just not using its main advantages).

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
