### PR TITLE
fix(solc): only write cache file if build was successful

### DIFF
--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -854,9 +854,10 @@ impl<'a, T: ArtifactOutput> ArtifactsCache<'a, T> {
     /// compiled and written to disk `written_artifacts`.
     ///
     /// Returns all the _cached_ artifacts.
-    pub fn write_cache(
+    pub fn consume(
         self,
         written_artifacts: &Artifacts<T::Artifact>,
+        write_to_disk: bool,
     ) -> Result<Artifacts<T::Artifact>> {
         match self {
             ArtifactsCache::Ephemeral(_, _) => Ok(Default::default()),
@@ -913,8 +914,11 @@ impl<'a, T: ArtifactOutput> ArtifactsCache<'a, T> {
                     .extend(dirty_source_files.into_iter().map(|(file, (entry, _))| (file, entry)));
 
                 cache.strip_artifact_files_prefixes(project.artifacts_path());
+
                 // write to disk
-                cache.write(project.cache_path())?;
+                if write_to_disk {
+                    cache.write(project.cache_path())?;
+                }
 
                 Ok(cached_artifacts)
             }

--- a/ethers-solc/src/compile/project.rs
+++ b/ethers-solc/src/compile/project.rs
@@ -304,7 +304,8 @@ impl<'a, T: ArtifactOutput> ArtifactsState<'a, T> {
     fn write_cache(self) -> Result<ProjectCompileOutput<T>> {
         let ArtifactsState { output, cache, compiled_artifacts } = self;
         let ignored_error_codes = cache.project().ignored_error_codes.clone();
-        let cached_artifacts = cache.write_cache(&compiled_artifacts)?;
+        let skip_write_to_disk = cache.project().no_artifacts || output.has_error();
+        let cached_artifacts = cache.consume(&compiled_artifacts, !skip_write_to_disk)?;
         Ok(ProjectCompileOutput {
             compiler_output: output,
             compiled_artifacts,

--- a/ethers-solc/src/project_util/mod.rs
+++ b/ethers-solc/src/project_util/mod.rs
@@ -34,8 +34,10 @@ pub struct TempProject<T: ArtifactOutput = ConfigurableArtifacts> {
 impl<T: ArtifactOutput> TempProject<T> {
     /// Makes sure all resources are created
     pub fn create_new(root: TempDir, inner: Project<T>) -> std::result::Result<Self, SolcIoError> {
-        let project = Self { _root: root, inner };
+        let mut project = Self { _root: root, inner };
         project.paths().create_all()?;
+        // ignore license warnings
+        project.inner.ignored_error_codes.push(1878);
         Ok(project)
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Applies the same checks used to determine whether to write artifacts (successful build, no ephemeral) to the cache file.

Likely related https://github.com/foundry-rs/foundry/issues/1244
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
only write cache file if build was successful
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
