### PR TITLE
feat: Relax `Clone` requirements when `Arc<M>` is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@
 
 ### Unreleased
 
+- Relax Clone requirements when Arc<Middleware> is used
+  [#1183](https://github.com/gakonst/ethers-rs/pull/1183)
 - Generate a deploy function if bytecode is provided in the abigen! input (json artifact)
   [#1030](https://github.com/gakonst/ethers-rs/pull/1030).
 - Generate correct bindings of struct's field names that are reserved words
@@ -192,6 +194,8 @@
 
 ### Unreleased
 
+- Relax Clone requirements when Arc<Middleware> is used
+  [#1183](https://github.com/gakonst/ethers-rs/pull/1183)
 - Add `EventStream::select` to combine streams with different event types
   [#725](https://github.com/gakonst/ethers-rs/pull/725)
 - Substitute output tuples with rust struct types for function calls
@@ -235,6 +239,8 @@
 
 ### Unreleased
 
+- Relax Clone requirements when Arc<Middleware> is used
+  [#1183](https://github.com/gakonst/ethers-rs/pull/1183)
 - Ensure a consistent chain ID between a Signer and Provider in SignerMiddleware
   [#1095](https://gakonst/ethers-rs/pull/1095)
 - Add BlockNative gas oracle [#1175](https://github.com/gakonst/ethers-rs/pull/1175)

--- a/ethers-contract/ethers-contract-abigen/src/contract/common.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/common.rs
@@ -71,9 +71,13 @@ pub(crate) fn struct_declaration(cx: &Context) -> TokenStream {
         #bytecode
 
         // Struct declaration
-        #[derive(Clone)]
         pub struct #name<M>(#ethers_contract::Contract<M>);
 
+        impl<M> Clone for #name<M> {
+            fn clone(&self) -> Self {
+                #name(self.0.clone())
+            }
+        }
 
         // Deref to the inner contract in order to access more specific functions functions
         impl<M> std::ops::Deref for #name<M> {

--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -63,7 +63,7 @@ pub enum ContractError<M: Middleware> {
     ContractNotDeployed,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[must_use = "contract calls do nothing unless you `send` or `call` them"]
 /// Helper for managing a transaction before submitting it to a node
 pub struct ContractCall<M, D> {
@@ -75,6 +75,18 @@ pub struct ContractCall<M, D> {
     pub block: Option<BlockId>,
     pub(crate) client: Arc<M>,
     pub(crate) datatype: PhantomData<D>,
+}
+
+impl<M, D> Clone for ContractCall<M, D> {
+    fn clone(&self) -> Self {
+        ContractCall {
+            tx: self.tx.clone(),
+            function: self.function.clone(),
+            block: self.block,
+            client: self.client.clone(),
+            datatype: self.datatype,
+        }
+    }
 }
 
 impl<M, D: Detokenize> ContractCall<M, D> {

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -150,11 +150,21 @@ use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 /// [`Abigen` builder]: crate::Abigen
 /// [`event`]: method@crate::Contract::event
 /// [`method`]: method@crate::Contract::method
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Contract<M> {
     base_contract: BaseContract,
     client: Arc<M>,
     address: Address,
+}
+
+impl<M> Clone for Contract<M> {
+    fn clone(&self) -> Self {
+        Contract {
+            base_contract: self.base_contract.clone(),
+            client: self.client.clone(),
+            address: self.address,
+        }
+    }
 }
 
 impl<M: Middleware> Contract<M> {

--- a/ethers-contract/src/factory.rs
+++ b/ethers-contract/src/factory.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 ///
 /// This is just a wrapper type for [Deployer] with an additional type to convert the [Contract]
 /// that the deployer returns when sending the transaction.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[must_use = "Deployer does nothing unless you `send` it"]
 pub struct ContractDeployer<M, C> {
     /// the actual deployer, exposed for overriding the defaults
@@ -28,6 +28,12 @@ pub struct ContractDeployer<M, C> {
     ///
     /// this type will be used to construct it via `From::from(Contract)`
     _contract: PhantomData<C>,
+}
+
+impl<M, C> Clone for ContractDeployer<M, C> {
+    fn clone(&self) -> Self {
+        ContractDeployer { deployer: self.deployer.clone(), _contract: self._contract }
+    }
 }
 
 impl<M: Middleware, C: From<Contract<M>>> ContractDeployer<M, C> {
@@ -89,7 +95,7 @@ impl<M: Middleware, C: From<Contract<M>>> ContractDeployer<M, C> {
 }
 
 /// Helper which manages the deployment transaction of a smart contract
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 #[must_use = "Deployer does nothing unless you `send` it"]
 pub struct Deployer<M> {
     /// The deployer's transaction, exposed for overriding the defaults
@@ -98,6 +104,18 @@ pub struct Deployer<M> {
     client: Arc<M>,
     confs: usize,
     block: BlockNumber,
+}
+
+impl<M> Clone for Deployer<M> {
+    fn clone(&self) -> Self {
+        Deployer {
+            tx: self.tx.clone(),
+            abi: self.abi.clone(),
+            client: self.client.clone(),
+            confs: self.confs,
+            block: self.block,
+        }
+    }
 }
 
 impl<M: Middleware> Deployer<M> {
@@ -222,11 +240,21 @@ impl<M: Middleware> Deployer<M> {
 /// println!("{}", contract.address());
 /// # Ok(())
 /// # }
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ContractFactory<M> {
     client: Arc<M>,
     abi: Abi,
     bytecode: Bytes,
+}
+
+impl<M> Clone for ContractFactory<M> {
+    fn clone(&self) -> Self {
+        ContractFactory {
+            client: self.client.clone(),
+            abi: self.abi.clone(),
+            bytecode: self.bytecode.clone(),
+        }
+    }
 }
 
 impl<M: Middleware> ContractFactory<M> {

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -120,12 +120,22 @@ pub static ADDRESS_BOOK: Lazy<HashMap<U256, Address>> = Lazy::new(|| {
 /// [`new`]: method@crate::Multicall::new
 /// [`block`]: method@crate::Multicall::block
 /// [`add_call`]: method@crate::Multicall::add_call
-#[derive(Clone)]
 pub struct Multicall<M> {
     calls: Vec<Call>,
     block: Option<BlockNumber>,
     contract: MulticallContract<M>,
     legacy: bool,
+}
+
+impl<M> Clone for Multicall<M> {
+    fn clone(&self) -> Self {
+        Multicall {
+            calls: self.calls.clone(),
+            block: self.block,
+            contract: self.contract.clone(),
+            legacy: self.legacy,
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/ethers-contract/src/multicall/multicall_contract.rs
+++ b/ethers-contract/src/multicall/multicall_contract.rs
@@ -16,8 +16,12 @@ mod multicallcontract_mod {
     pub static MULTICALLCONTRACT_ABI: Lazy<Abi> = Lazy::new(|| {
         serde_json :: from_str ( "[{\"inputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"callData\",\"type\":\"bytes\"}],\"internalType\":\"struct MulticallContract.Call[]\",\"name\":\"calls\",\"type\":\"tuple[]\"}],\"name\":\"aggregate\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"},{\"internalType\":\"bytes[]\",\"name\":\"returnData\",\"type\":\"bytes[]\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"name\":\"getBlockHash\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"blockHash\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getCurrentBlockCoinbase\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"coinbase\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getCurrentBlockDifficulty\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"difficulty\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getCurrentBlockGasLimit\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"gaslimit\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getCurrentBlockTimestamp\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"timestamp\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"getEthBalance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"balance\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getLastBlockHash\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"blockHash\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]" ) . expect ( "invalid abi" )
     });
-    #[derive(Clone)]
     pub struct MulticallContract<M>(Contract<M>);
+    impl<M> Clone for MulticallContract<M> {
+        fn clone(&self) -> Self {
+            MulticallContract(self.0.clone())
+        }
+    }
     impl<M> std::ops::Deref for MulticallContract<M> {
         type Target = Contract<M>;
         fn deref(&self) -> &Self::Target {

--- a/ethers-middleware/src/gas_escalator/mod.rs
+++ b/ethers-middleware/src/gas_escalator/mod.rs
@@ -38,7 +38,7 @@ pub enum Frequency {
     Duration(u64),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 /// A Gas escalator allows bumping transactions' gas price to avoid getting them
 /// stuck in the memory pool.
 ///
@@ -70,6 +70,17 @@ pub struct GasEscalatorMiddleware<M, E> {
     #[allow(clippy::type_complexity)]
     pub txs: Arc<Mutex<Vec<(TxHash, TransactionRequest, Instant, Option<BlockId>)>>>,
     frequency: Frequency,
+}
+
+impl<M, E: Clone> Clone for GasEscalatorMiddleware<M, E> {
+    fn clone(&self) -> Self {
+        GasEscalatorMiddleware {
+            inner: self.inner.clone(),
+            escalator: self.escalator.clone(),
+            txs: self.txs.clone(),
+            frequency: self.frequency.clone(),
+        }
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]

--- a/ethers-middleware/src/transformer/ds_proxy/factory.rs
+++ b/ethers-middleware/src/transformer/ds_proxy/factory.rs
@@ -46,8 +46,12 @@ mod dsproxyfactory_mod {
     pub static DSPROXYFACTORY_ABI: Lazy<Abi> = Lazy::new(|| {
         serde_json :: from_str ("[{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"address\"}],\"name\":\"isProxy\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"cache\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"build\",\"outputs\":[{\"name\":\"proxy\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"build\",\"outputs\":[{\"name\":\"proxy\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"sender\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"proxy\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"cache\",\"type\":\"address\"}],\"name\":\"Created\",\"type\":\"event\"}]\n") . expect ("invalid abi")
     });
-    #[derive(Clone)]
     pub struct DsProxyFactory<M>(Contract<M>);
+    impl<M> Clone for DsProxyFactory<M> {
+        fn clone(&self) -> Self {
+            DsProxyFactory(self.0.clone())
+        }
+    }
     impl<M> std::ops::Deref for DsProxyFactory<M> {
         type Target = Contract<M>;
         fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
`#[derive(Clone)]` was implementing `Clone` only if `M` was `Clone`, however because of `Arc<M>` this can be relaxed.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

I was implementing a `Signer` and I was getting a misleading error because it wasn't clonable.
However since the whole middleware was wrapped in an `Arc`, then `Clone` shouldn't be a requirement.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

When `#[derive(Clone)]` is used on a generic struct, then `Clone` is implemented if generic parameters are also `Clone`.
In the case of a middleware we can avoid this because it is always wrapped in an `Arc`.

A solution is to manually implement `Clone` for structs that take `Middleware` as a generic parameter.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
