### PR TITLE
fix(solc): remapping aware libraries

### DIFF
--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -425,7 +425,7 @@ impl Libraries {
                 SolcError::msg(format!("failed to parse library name: {}", lib))
             })?;
             let addr = items.next().ok_or_else(|| {
-                SolcError::msg(format!("failed to parse invalid library: {}", lib))
+                SolcError::msg(format!("failed to parse library address: {}", lib))
             })?;
             if items.next().is_some() {
                 return Err(SolcError::msg(format!("failed to parse, too many arguments passed: {}", lib)))

--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -419,7 +419,7 @@ impl Libraries {
         for lib in libs {
             let mut items = lib.split(':');
             let file = items.next().ok_or_else(|| {
-                SolcError::msg(format!("failed to parse invalid library: {}", lib))
+                SolcError::msg(format!("failed to parse path to library file: {}", lib))
             })?;
             let lib = items.next().ok_or_else(|| {
                 SolcError::msg(format!("failed to parse invalid library: {}", lib))

--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -422,7 +422,7 @@ impl Libraries {
                 SolcError::msg(format!("failed to parse path to library file: {}", lib))
             })?;
             let lib = items.next().ok_or_else(|| {
-                SolcError::msg(format!("failed to parse invalid library: {}", lib))
+                SolcError::msg(format!("failed to parse library name: {}", lib))
             })?;
             let addr = items.next().ok_or_else(|| {
                 SolcError::msg(format!("failed to parse invalid library: {}", lib))

--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -428,7 +428,7 @@ impl Libraries {
                 SolcError::msg(format!("failed to parse invalid library: {}", lib))
             })?;
             if items.next().is_some() {
-                return Err(SolcError::msg(format!("failed to parse invalid library: {}", lib)))
+                return Err(SolcError::msg(format!("failed to parse, too many arguments passed: {}", lib)))
             }
             libraries
                 .entry(file.into())

--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -421,14 +421,17 @@ impl Libraries {
             let file = items.next().ok_or_else(|| {
                 SolcError::msg(format!("failed to parse path to library file: {}", lib))
             })?;
-            let lib = items.next().ok_or_else(|| {
-                SolcError::msg(format!("failed to parse library name: {}", lib))
-            })?;
+            let lib = items
+                .next()
+                .ok_or_else(|| SolcError::msg(format!("failed to parse library name: {}", lib)))?;
             let addr = items.next().ok_or_else(|| {
                 SolcError::msg(format!("failed to parse library address: {}", lib))
             })?;
             if items.next().is_some() {
-                return Err(SolcError::msg(format!("failed to parse, too many arguments passed: {}", lib)))
+                return Err(SolcError::msg(format!(
+                    "failed to parse, too many arguments passed: {}",
+                    lib
+                )))
             }
             libraries
                 .entry(file.into())

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -650,7 +650,7 @@ impl<T: Into<PathBuf>> From<T> for Solc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::CompilerInput;
+    use crate::{Artifact, CompilerInput};
 
     fn solc() -> Solc {
         Solc::default()
@@ -690,6 +690,18 @@ mod tests {
         for (_, c) in out.split().1.contracts_iter() {
             assert!(c.metadata.is_some());
         }
+    }
+
+    #[test]
+    fn can_compile_with_remapped_links() {
+        let input: CompilerInput =
+            serde_json::from_str(include_str!("../../test-data/library-remapping-in.json"))
+                .unwrap();
+        let out = solc().compile(&input).unwrap();
+        let (_, mut contracts) = out.split();
+        let contract = contracts.remove("LinkTest").unwrap();
+        let bytecode = &contract.get_bytecode().unwrap().object;
+        assert!(!bytecode.is_unlinked());
     }
 
     #[cfg(feature = "async")]

--- a/ethers-solc/test-data/library-remapping-in.json
+++ b/ethers-solc/test-data/library-remapping-in.json
@@ -1,0 +1,39 @@
+{
+  "language": "Solidity",
+  "sources": {
+    "/private/var/folders/l5/lprhf87s6xv8djgd017f0b2h0000gn/T/tmp_dappPyXsdD/lib/remapping/MyLib.sol": {
+      "content": "\n// SPDX-License-Identifier: MIT\nlibrary MyLib {\n    function foobar(uint256 a) public view returns (uint256) {\n    \treturn a * 100;\n    }\n}\n"
+    },
+    "/private/var/folders/l5/lprhf87s6xv8djgd017f0b2h0000gn/T/tmp_dappPyXsdD/src/LinkTest.sol": {
+      "content": "\n// SPDX-License-Identifier: MIT\nimport \"remapping/MyLib.sol\";\ncontract LinkTest {\n    function foo() public returns (uint256) {\n        return MyLib.foobar(1);\n    }\n}\n"
+    }
+  },
+  "settings": {
+    "remappings": [
+      "remapping/=/private/var/folders/l5/lprhf87s6xv8djgd017f0b2h0000gn/T/tmp_dappPyXsdD/lib/remapping/"
+    ],
+    "optimizer": {
+      "enabled": false,
+      "runs": 200
+    },
+    "outputSelection": {
+      "*": {
+        "": [
+          "ast"
+        ],
+        "*": [
+          "abi",
+          "evm.bytecode",
+          "evm.deployedBytecode",
+          "evm.methodIdentifiers"
+        ]
+      }
+    },
+    "evmVersion": "london",
+    "libraries": {
+      "/private/var/folders/l5/lprhf87s6xv8djgd017f0b2h0000gn/T/tmp_dappPyXsdD/lib/remapping/MyLib.sol": {
+        "MyLib": "0x0000000000000000000000000000000000000000"
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
The solc docs say about libraries

```json
"libraries": {
      // The top level key is the the name of the source file where the library is used.
      // If remappings are used, this source file should match the global path
      // after remappings were applied.
      // If this key is an empty string, that refers to a global level.
      "myFile.sol": {
        "MyLib": "0x123123..."
      }
    },
```

currently we're not able to apply remappings, this adds support for this

Ref https://github.com/foundry-rs/foundry/issues/1338

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* add `Libraries` wrapper type with support for applying remappings
* add more tests
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
