### PR TITLE
fix(solc): flatten import aliases

### DIFF
--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -290,7 +290,7 @@ impl ProjectPathsConfig {
                 SolImportAlias::Contract(alias, target) => (alias.clone(), target.clone()),
                 _ => continue,
             };
-            let name_regex = utils::create_contract_or_lib_name_regex(&alias);
+            let name_regex = utils::CREATE_RE_CONTRACT_OR_LIB_NAME(&alias);
             let target_len = target.len() as isize;
             let mut replace_offset = 0;
             for cap in name_regex.captures_iter(&content.clone()) {

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -290,7 +290,7 @@ impl ProjectPathsConfig {
                 SolImportAlias::Contract(alias, target) => (alias.clone(), target.clone()),
                 _ => continue,
             };
-            let name_regex = utils::CREATE_RE_CONTRACT_OR_LIB_NAME(&alias);
+            let name_regex = utils::create_contract_or_lib_name_regex(&alias);
             let target_len = target.len() as isize;
             let mut replace_offset = 0;
             for cap in name_regex.captures_iter(&content.clone()) {

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 
 use crate::artifacts::output_selection::ContractOutputSelection;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeSet, HashSet},

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -286,8 +286,8 @@ impl ProjectPathsConfig {
         let mut content = target_node.content().to_owned();
 
         for alias in imports.iter().flat_map(|i| i.data().aliases()) {
-            let (alias, target) = match alias.clone() {
-                SolImportAlias::Contract(alias, target) => (alias, target),
+            let (alias, target) = match alias {
+                SolImportAlias::Contract(alias, target) => (alias.clone(), target.clone()),
                 _ => continue,
             };
             let name_regex = utils::create_contract_or_lib_name_regex(&alias);

--- a/ethers-solc/src/resolver/parse.rs
+++ b/ethers-solc/src/resolver/parse.rs
@@ -67,8 +67,9 @@ impl SolData {
                             let sol_import = SolImport::new(PathBuf::from(import.string))
                                 .set_aliases(
                                     ids.into_iter()
-                                        .filter_map(|(id, alias)| {
-                                            alias.map(|a| SolImportAlias::Contract(a.name, id.name))
+                                        .map(|(id, alias)| match alias {
+                                            Some(al) => SolImportAlias::Contract(al.name, id.name),
+                                            None => SolImportAlias::File(id.name),
                                         })
                                         .collect(),
                                 );

--- a/ethers-solc/src/resolver/parse.rs
+++ b/ethers-solc/src/resolver/parse.rs
@@ -282,7 +282,6 @@ pub fn capture_imports(content: &str) -> Vec<SolDataUnit<SolImport>> {
             }
             let sol_import =
                 SolImport::new(PathBuf::from(name_match.as_str())).set_aliases(aliases);
-            println!("{:?}", sol_import);
             imports.push(SolDataUnit::new(sol_import, statement_match.range()));
         }
     }

--- a/ethers-solc/src/resolver/parse.rs
+++ b/ethers-solc/src/resolver/parse.rs
@@ -229,8 +229,8 @@ impl<T> SolDataUnit<T> {
     }
 
     /// Returns the location of the given data unit
-    pub fn loc(&self) -> &Range<usize> {
-        &self.loc
+    pub fn loc(&self) -> Range<usize> {
+        self.loc.clone()
     }
 
     /// Returns the location of the given data unit adjusted by an offset.

--- a/ethers-solc/src/resolver/parse.rs
+++ b/ethers-solc/src/resolver/parse.rs
@@ -263,14 +263,13 @@ fn capture_outer_and_inner<'a>(
         })
         .collect()
 }
-
-// TODO:
+/// Capture the import statement information together with aliases
 pub fn capture_imports(content: &str) -> Vec<SolDataUnit<SolImport>> {
     let mut imports = vec![];
-    let mut cap_names = utils::RE_SOL_IMPORT.capture_names().filter_map(|n| n);
     for cap in utils::RE_SOL_IMPORT.captures_iter(content) {
-        let name_match = cap_names.find_map(|name| cap.name(name));
-        if let Some(name_match) = name_match {
+        if let Some(name_match) =
+            vec!["p1", "p2", "p3", "p4"].iter().find_map(|name| cap.name(name))
+        {
             let statement_match = cap.get(0).unwrap();
             let mut aliases = vec![];
             for alias_cap in utils::RE_SOL_IMPORT_ALIAS.captures_iter(statement_match.as_str()) {

--- a/ethers-solc/src/resolver/parse.rs
+++ b/ethers-solc/src/resolver/parse.rs
@@ -75,8 +75,6 @@ impl SolData {
                                         })
                                         .collect(),
                                 );
-                            println!("sol import {:?}", sol_import);
-
                             imports.push(SolDataUnit::from_loc(sol_import, loc));
                         }
                         SourceUnitPart::ContractDefinition(def) => {

--- a/ethers-solc/src/utils.rs
+++ b/ethers-solc/src/utils.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::HashSet,
+    ops::Range,
     path::{Component, Path, PathBuf},
 };
 
@@ -16,12 +17,11 @@ use walkdir::WalkDir;
 /// A regex that matches the import path and identifier of a solidity import
 /// statement with the named groups "path", "id".
 // Adapted from <https://github.com/nomiclabs/hardhat/blob/cced766c65b25d3d0beb39ef847246ac9618bdd9/packages/hardhat-core/src/internal/solidity/parse.ts#L100>
-pub static RE_SOL_IMPORT_OLD: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"import\s+(?:(?:"(?P<p1>[^;]*)"|'(?P<p2>[^;]*)')(?:;|\s+as\s+(?P<id1>\w+);)|(?:(?:\w+|\*)\s+(as\s+(?P<id2>\w)\s+)?)from\s+(?:"(?P<p3>.*)"|'(?P<p4>.*)');)"#).unwrap()
-});
 pub static RE_SOL_IMPORT: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r#"import\s+(?:(?:"(?P<p1>.*)"|'(?P<p2>.*)')(?:\s+as\s+\w+)?|(?:(?:\w+(?:\s+as\s+\w+)?|\*\s+as\s+\w+|\{\s*(?:\w+(?:\s+as\s+\w+)?(?:\s*,\s*)?)+\s*\})\s+from\s+(?:"(?P<p3>.*)"|'(?P<p4>.*)')))\s*;"#).unwrap()
 });
+
+/// A regex that matches an alias within an import statement
 pub static RE_SOL_IMPORT_ALIAS: Lazy<Regex> =
     Lazy::new(|| Regex::new(r#"(?:(?P<target>\w+)|\*|'|")\s+as\s+(?P<alias>\w+)"#).unwrap());
 
@@ -39,6 +39,19 @@ pub static RE_SOL_SDPX_LICENSE_IDENTIFIER: Lazy<Regex> =
 
 /// A regex used to remove extra lines in flatenned files
 pub static RE_THREE_OR_MORE_NEWLINES: Lazy<Regex> = Lazy::new(|| Regex::new("\n{3,}").unwrap());
+
+/// Create a regex that matches any library or contract name inside a file
+pub fn create_contract_or_lib_name_regex(name: &str) -> Regex {
+    regex::Regex::new(&format!(r#"(?:using\s+(?P<n1>{name})\s+|is\s+(?:\w+\s*,\s*)*(?P<n2>{name})(?:\s*,\s*\w+)*|(?:(?P<ignore>(?:function|error|as)\s+|\n[^\n]*(?:"([^"\n]|\\")*|'([^'\n]|\\')*))|\W+)(?P<n3>{name})(?:\.|\(| ))"#, name = name)).unwrap()
+}
+
+/// Move a range by a specified offset
+pub fn range_by_offset(range: &Range<usize>, offset: isize) -> Range<usize> {
+    Range {
+        start: offset.saturating_add(range.start as isize) as usize,
+        end: offset.saturating_add(range.end as isize) as usize,
+    }
+}
 
 /// Returns all path parts from any solidity import statement in a string,
 /// `import "./contracts/Contract.sol";` -> `"./contracts/Contract.sol"`.

--- a/ethers-solc/src/utils.rs
+++ b/ethers-solc/src/utils.rs
@@ -41,11 +41,9 @@ pub static RE_SOL_SDPX_LICENSE_IDENTIFIER: Lazy<Regex> =
 pub static RE_THREE_OR_MORE_NEWLINES: Lazy<Regex> = Lazy::new(|| Regex::new("\n{3,}").unwrap());
 
 /// Create a regex that matches any library or contract name inside a file
-pub static CREATE_RE_CONTRACT_OR_LIB_NAME: Lazy<fn(s: &str) -> Regex> = Lazy::new(|| {
-    |name: &str| {
-        regex::Regex::new(&format!(r#"(?:using\s+(?P<n1>{name})\s+|is\s+(?:\w+\s*,\s*)*(?P<n2>{name})(?:\s*,\s*\w+)*|(?:(?P<ignore>(?:function|error|as)\s+|\n[^\n]*(?:"([^"\n]|\\")*|'([^'\n]|\\')*))|\W+)(?P<n3>{name})(?:\.|\(| ))"#, name = name)).unwrap()
-    }
-});
+pub fn create_contract_or_lib_name_regex(name: &str) -> Regex {
+    Regex::new(&format!(r#"(?:using\s+(?P<n1>{name})\s+|is\s+(?:\w+\s*,\s*)*(?P<n2>{name})(?:\s*,\s*\w+)*|(?:(?P<ignore>(?:function|error|as)\s+|\n[^\n]*(?:"([^"\n]|\\")*|'([^'\n]|\\')*))|\W+)(?P<n3>{name})(?:\.|\(| ))"#, name = name)).unwrap()
+}
 
 /// Move a range by a specified offset
 pub fn range_by_offset(range: &Range<usize>, offset: isize) -> Range<usize> {

--- a/ethers-solc/src/utils.rs
+++ b/ethers-solc/src/utils.rs
@@ -16,9 +16,14 @@ use walkdir::WalkDir;
 /// A regex that matches the import path and identifier of a solidity import
 /// statement with the named groups "path", "id".
 // Adapted from <https://github.com/nomiclabs/hardhat/blob/cced766c65b25d3d0beb39ef847246ac9618bdd9/packages/hardhat-core/src/internal/solidity/parse.ts#L100>
-pub static RE_SOL_IMPORT: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"import\s+(?:(?:"(?P<p1>[^;]*)"|'(?P<p2>[^;]*)')(?:;|\s+as\s+(?P<id>[^;]*);)|.+from\s+(?:"(?P<p3>.*)"|'(?P<p4>.*)');)"#).unwrap()
+pub static RE_SOL_IMPORT_OLD: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"import\s+(?:(?:"(?P<p1>[^;]*)"|'(?P<p2>[^;]*)')(?:;|\s+as\s+(?P<id1>\w+);)|(?:(?:\w+|\*)\s+(as\s+(?P<id2>\w)\s+)?)from\s+(?:"(?P<p3>.*)"|'(?P<p4>.*)');)"#).unwrap()
 });
+pub static RE_SOL_IMPORT: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"import\s+(?:(?:"(?P<p1>.*)"|'(?P<p2>.*)')(?:\s+as\s+\w+)?|(?:(?:\w+(?:\s+as\s+\w+)?|\*\s+as\s+\w+|\{\s*(?:\w+(?:\s+as\s+\w+)?(?:\s*,\s*)?)+\s*\})\s+from\s+(?:"(?P<p3>.*)"|'(?P<p4>.*)')))\s*;"#).unwrap()
+});
+pub static RE_SOL_IMPORT_ALIAS: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"(?:(?P<target>\w+)|\*|'|")\s+as\s+(?P<alias>\w+)"#).unwrap());
 
 /// A regex that matches the version part of a solidity pragma
 /// as follows: `pragma solidity ^0.5.2;` => `^0.5.2`

--- a/ethers-solc/src/utils.rs
+++ b/ethers-solc/src/utils.rs
@@ -41,9 +41,11 @@ pub static RE_SOL_SDPX_LICENSE_IDENTIFIER: Lazy<Regex> =
 pub static RE_THREE_OR_MORE_NEWLINES: Lazy<Regex> = Lazy::new(|| Regex::new("\n{3,}").unwrap());
 
 /// Create a regex that matches any library or contract name inside a file
-pub fn create_contract_or_lib_name_regex(name: &str) -> Regex {
-    regex::Regex::new(&format!(r#"(?:using\s+(?P<n1>{name})\s+|is\s+(?:\w+\s*,\s*)*(?P<n2>{name})(?:\s*,\s*\w+)*|(?:(?P<ignore>(?:function|error|as)\s+|\n[^\n]*(?:"([^"\n]|\\")*|'([^'\n]|\\')*))|\W+)(?P<n3>{name})(?:\.|\(| ))"#, name = name)).unwrap()
-}
+pub static CREATE_RE_CONTRACT_OR_LIB_NAME: Lazy<fn(s: &str) -> Regex> = Lazy::new(|| {
+    |name: &str| {
+        regex::Regex::new(&format!(r#"(?:using\s+(?P<n1>{name})\s+|is\s+(?:\w+\s*,\s*)*(?P<n2>{name})(?:\s*,\s*\w+)*|(?:(?P<ignore>(?:function|error|as)\s+|\n[^\n]*(?:"([^"\n]|\\")*|'([^'\n]|\\')*))|\W+)(?P<n3>{name})(?:\.|\(| ))"#, name = name)).unwrap()
+    }
+});
 
 /// Move a range by a specified offset
 pub fn range_by_offset(range: &Range<usize>, offset: isize) -> Range<usize> {

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -732,6 +732,7 @@ import { ParentContract as Parent } from "./Parent.sol";
 import { AnotherParentContract as AnotherParent } from "./AnotherParent.sol";
 import { PeerContract as Peer } from "./Peer.sol";
 import { MathLibrary as Math } from "./Math.sol";
+import * as Lib from "./SomeLib.sol";
 
 contract Contract is Parent,
     AnotherParent {
@@ -806,6 +807,15 @@ library MathLibrary {
         )
         .unwrap();
 
+    project
+        .add_source(
+            "SomeLib",
+            r#"pragma solidity ^0.8.10;
+library SomeLib { }
+"#,
+        )
+        .unwrap();
+
     let result = project.flatten(&f).unwrap();
     assert_eq!(
         result,
@@ -830,6 +840,8 @@ library MathLibrary {
         return type(uint256).max - value;
     }
 }
+
+library SomeLib { }
 
 contract Contract is ParentContract,
     AnotherParentContract {

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -721,6 +721,41 @@ contract A { }
 }
 
 #[test]
+fn can_flatten_with_alias() {
+    let project = TempProject::dapptools().unwrap();
+
+    let f = project
+        .add_source(
+            "A",
+            r#"pragma solidity ^0.8.10;
+import { B as SomeAlias } from "./B.sol";
+contract A is SomeAlias { }
+"#,
+        )
+        .unwrap();
+
+    project
+        .add_source(
+            "B",
+            r#"pragma solidity ^0.8.10;
+contract B { }
+"#,
+        )
+        .unwrap();
+
+    let result = project.flatten(&f).unwrap();
+    assert_eq!(
+        result,
+        r#"pragma solidity ^0.8.10;
+
+contract SomeAlias { }
+
+contract A is SomeAlias { }
+"#
+    );
+}
+
+#[test]
 fn can_detect_type_error() {
     let project = TempProject::<ConfigurableArtifacts>::dapptools().unwrap();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
addresses [foundry#1440](https://github.com/foundry-rs/foundry/issues/1440)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR includes: 
- More robust regex for import statement parsing in case of `solang` failure
- Partial support for import aliases: any explicit import alias will be replaced with its original name 

Known Issues: 
- Since alias replacement rewrites the contents of the file, any previous data unit location might be incorrect. This is a temporary solution and is based on the assumption that any usage of an alias happens after all of the import statements. 

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
