### PR TITLE
update documentation to enable ws & rustls / openssl if user wants to use websockets

### DIFF
--- a/ethers-providers/README.md
+++ b/ethers-providers/README.md
@@ -29,7 +29,7 @@ println!("Got code: {}", serde_json::to_string(&code)?);
 
 # Websockets
 
-The crate has support for WebSockets via Tokio.
+The crate has support for WebSockets via Tokio. Please ensure that you have the "ws" and "rustls" / "openssl" features enabled if you wish to use WebSockets.
 
 ```
 # async fn foo() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Motivation

I wanted to use websockets but I kept running into a tungstenite error code 400.

## Solution

A quick search on the ethers-rs telegram chat provided the [solution](https://t.me/ethers_rs/8557). I've tested the solution locally (with these features enabled) and websockets work as intended so I'm updating the documentation to reflect this.

## PR Checklist

- [NA] Added Tests
- [NA] Added Documentation
- [NA] Updated the changelog
