### PR TITLE
Use EIP155 for all signers with empty transaction `chain_id`

### DIFF
--- a/ethers-signers/src/ledger/app.rs
+++ b/ethers-signers/src/ledger/app.rs
@@ -117,8 +117,13 @@ impl LedgerEthereum {
 
     /// Signs an Ethereum transaction (requires confirmation on the ledger)
     pub async fn sign_tx(&self, tx: &TypedTransaction) -> Result<Signature, LedgerError> {
+        let mut tx_with_chain = tx.clone();
+        if tx_with_chain.chain_id() == None {
+            // in the case we don't have a chain_id, let's use the signer chain id instead
+            tx_with_chain.set_chain_id(self.chain_id);
+        }
         let mut payload = Self::path_to_bytes(&self.derivation);
-        payload.extend_from_slice(tx.rlp().as_ref());
+        payload.extend_from_slice(tx_with_chain.rlp().as_ref());
         self.sign_payload(INS::SIGN, payload).await
     }
 

--- a/ethers-signers/src/ledger/app.rs
+++ b/ethers-signers/src/ledger/app.rs
@@ -118,7 +118,7 @@ impl LedgerEthereum {
     /// Signs an Ethereum transaction (requires confirmation on the ledger)
     pub async fn sign_tx(&self, tx: &TypedTransaction) -> Result<Signature, LedgerError> {
         let mut tx_with_chain = tx.clone();
-        if tx_with_chain.chain_id() == None {
+        if tx_with_chain.chain_id().is_none() {
             // in the case we don't have a chain_id, let's use the signer chain id instead
             tx_with_chain.set_chain_id(self.chain_id);
         }

--- a/ethers-signers/src/ledger/mod.rs
+++ b/ethers-signers/src/ledger/mod.rs
@@ -25,6 +25,11 @@ impl Signer for LedgerEthereum {
 
     /// Signs the transaction
     async fn sign_transaction(&self, message: &TypedTransaction) -> Result<Signature, Self::Error> {
+        let mut tx_with_chain = message.clone();
+        if tx_with_chain.chain_id() == None {
+            // in the case we don't have a chain_id, let's use the signer chain id instead
+            tx_with_chain.set_chain_id(self.chain_id);
+        }
         self.sign_tx(message).await
     }
 

--- a/ethers-signers/src/ledger/mod.rs
+++ b/ethers-signers/src/ledger/mod.rs
@@ -30,7 +30,7 @@ impl Signer for LedgerEthereum {
             // in the case we don't have a chain_id, let's use the signer chain id instead
             tx_with_chain.set_chain_id(self.chain_id);
         }
-        self.sign_tx(message).await
+        self.sign_tx(tx_with_chain).await
     }
 
     /// Signs a EIP712 derived struct

--- a/ethers-signers/src/ledger/mod.rs
+++ b/ethers-signers/src/ledger/mod.rs
@@ -26,7 +26,7 @@ impl Signer for LedgerEthereum {
     /// Signs the transaction
     async fn sign_transaction(&self, message: &TypedTransaction) -> Result<Signature, Self::Error> {
         let mut tx_with_chain = message.clone();
-        if tx_with_chain.chain_id() == None {
+        if tx_with_chain.chain_id().is_none() {
             // in the case we don't have a chain_id, let's use the signer chain id instead
             tx_with_chain.set_chain_id(self.chain_id);
         }

--- a/ethers-signers/src/trezor/app.rs
+++ b/ethers-signers/src/trezor/app.rs
@@ -160,6 +160,8 @@ impl TrezorEthereum {
 
         let transaction = TrezorTransaction::load(tx)?;
 
+        let chain_id = tx.chain_id().map(|id| id.as_u64()).unwrap_or(self.chain_id);
+
         let signature = match tx {
             TypedTransaction::Eip2930(_) | TypedTransaction::Legacy(_) => client.ethereum_sign_tx(
                 arr_path,
@@ -169,7 +171,7 @@ impl TrezorEthereum {
                 transaction.to,
                 transaction.value,
                 transaction.data,
-                self.chain_id,
+                chain_id,
             )?,
             TypedTransaction::Eip1559(eip1559_tx) => client.ethereum_sign_eip1559_tx(
                 arr_path,
@@ -178,7 +180,7 @@ impl TrezorEthereum {
                 transaction.to,
                 transaction.value,
                 transaction.data,
-                self.chain_id,
+                chain_id,
                 transaction.max_fee_per_gas,
                 transaction.max_priority_fee_per_gas,
                 transaction.access_list,

--- a/ethers-signers/src/trezor/mod.rs
+++ b/ethers-signers/src/trezor/mod.rs
@@ -25,7 +25,12 @@ impl Signer for TrezorEthereum {
 
     /// Signs the transaction
     async fn sign_transaction(&self, message: &TypedTransaction) -> Result<Signature, Self::Error> {
-        self.sign_tx(message).await
+        let mut tx_with_chain = message.clone();
+        if tx_with_chain.chain_id() == None {
+            // in the case we don't have a chain_id, let's use the signer chain id instead
+            tx_with_chain.set_chain_id(self.chain_id);
+        }
+        self.sign_tx(&tx_with_chain).await
     }
 
     /// Signs a EIP712 derived struct

--- a/ethers-signers/src/trezor/mod.rs
+++ b/ethers-signers/src/trezor/mod.rs
@@ -26,7 +26,7 @@ impl Signer for TrezorEthereum {
     /// Signs the transaction
     async fn sign_transaction(&self, message: &TypedTransaction) -> Result<Signature, Self::Error> {
         let mut tx_with_chain = message.clone();
-        if tx_with_chain.chain_id() == None {
+        if tx_with_chain.chain_id().is_none() {
             // in the case we don't have a chain_id, let's use the signer chain id instead
             tx_with_chain.set_chain_id(self.chain_id);
         }

--- a/ethers-signers/src/wallet/private_key.rs
+++ b/ethers-signers/src/wallet/private_key.rs
@@ -46,8 +46,6 @@ pub enum WalletError {
     /// Error type from Eip712Error message
     #[error("error encoding eip712 struct: {0:?}")]
     Eip712Error(String),
-    #[error("invalid transaction: {0:?}")]
-    InvalidTransactionError(String),
 }
 
 impl Clone for Wallet<SigningKey> {

--- a/ethers-signers/src/wallet/private_key.rs
+++ b/ethers-signers/src/wallet/private_key.rs
@@ -219,6 +219,39 @@ mod tests {
         assert!(sig.verify(sighash, wallet.address).is_ok());
     }
 
+    #[tokio::test]
+    #[cfg(not(feature = "celo"))]
+    async fn signs_tx_empty_chain_id() {
+        use crate::TypedTransaction;
+        use ethers_core::types::TransactionRequest;
+        // retrieved test vector from:
+        // https://web3js.readthedocs.io/en/v1.2.0/web3-eth-accounts.html#eth-accounts-signtransaction
+        let tx: TypedTransaction = TransactionRequest {
+            from: None,
+            to: Some("F0109fC8DF283027b6285cc889F5aA624EaC1F55".parse::<Address>().unwrap().into()),
+            value: Some(1_000_000_000.into()),
+            gas: Some(2_000_000.into()),
+            nonce: Some(0.into()),
+            gas_price: Some(21_000_000_000u128.into()),
+            data: None,
+            chain_id: None,
+        }
+        .into();
+        let wallet: Wallet<SigningKey> =
+            "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318".parse().unwrap();
+        let wallet = wallet.with_chain_id(1u64);
+
+        // this should populate the tx chain_id as the signer's chain_id (1) before signing
+        let sig = wallet.sign_transaction(&tx).await.unwrap();
+
+        // since we initialize with None we need to re-set the chain_id for the sighash to be
+        // correct
+        let mut tx = tx;
+        tx.set_chain_id(1);
+        let sighash = tx.sighash();
+        assert!(sig.verify(sighash, wallet.address).is_ok());
+    }
+
     #[test]
     fn key_to_address() {
         let wallet: Wallet<SigningKey> =


### PR DESCRIPTION
## Motivation

In #805, `chain_id` was removed from the `sighash` method for `TypedTransaction`. This causes issues like #1189, since transactions with an empty `chain_id` would have an incorrect rlp, sighash, and signature. In case the `chain_id` contained in the transaction is `None`, the signer should use its own `chain_id`.

## Solution

 * All signers will now prefer the transaction `chain_id`, using the signer `chain_id` only if the transaction `chain_id` is `None`.
 * Remove `InvalidTransactionError` in the private key wallet - this would need to be re-introduced if we want to enforce that transactions have a `chain_id` consistent with signers.
 * Refactor the AWS signer's `sign_digest_with_eip155` to include a `chain_id` parameter, rather than using the signer's `chain_id` every time. This way, transactions which specify a `chain_id` will have a correct `v`.
 * Refactor the wallet's `sign_hash` method to just sign hashes, moving eip155 `v` normalization to `sign_transaction_sync`.
 * Add a test for signing a transaction with an empty `chain_id` using a local wallet.

I've tested this locally with `chain_id: 1337` and a ledger, against a local wallet with the same private key. While the ledger _does_ receive the correct `chain_id` (I can see it on the screen), the `v` value of the returned signature is incorrect. The `r` and `s` values of the signature are identical to the signature produced from the local wallet.

Test results for different chains:
 * With `chain_id: 1337`, ledger returns `v: 150`. This is not the correct `v` value, for this message it should be `2710`.
 * With `chain_id: 109`, ledger returns `v: 253`. This is correct.
 * With `chain_id: 110`, ledger returns `v: 0`. This is clearly wrong - for this message it should be `256`.
 * With `chain_id: 111`, ledger returns `v: 2`. This is also wrong, but it seems like it's just an overflow, so we might be able to fix this `v` values.

I think this is because we only have [one byte](https://github.com/gakonst/ethers-rs/blob/81e7fea14b4f9bc4c531856f8cb7cd31a5248918/ethers-signers/src/ledger/app.rs#L194) for the resulting `v` value.
Is there any way for ledger to return a `v` that is over one byte in size? If not, we would have to fix the signature `v` value if the `chain_id > 110`.

Fixes #1189 

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
