### PR TITLE
Adds From<H160> trait to ValueOrArray<H160>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
   [#996](https://github.com/gakonst/ethers-rs/pull/996)
 - Add `TransactionReceipt::to` and `TransactionReceipt::from`
   [#1184](https://github.com/gakonst/ethers-rs/pull/1184)
-- Add `From<H160>` trait to `ValueOrArray<H160>` [#1199](https://github.com/gakonst/ethers-rs/pull/1200)
+- Add `From<H160>` and From<Vec<H160>> traits to `ValueOrArray<H160>` [#1199](https://github.com/gakonst/ethers-rs/pull/1200)
 
 ## ethers-contract-abigen
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Unreleased
 
-- Fix RLP decoding of `from` field for `Eip1559TransactionRequest` and 
+- Fix RLP decoding of `from` field for `Eip1559TransactionRequest` and
   `Eip2930TransactionRequest`, remove `Eip1559TransactionRequest` `sighash`
   method [1180](https://github.com/gakonst/ethers-rs/pull/1180)
 - Fix RLP encoding of absent access list in `Transaction` [1137](https://github.com/gakonst/ethers-rs/pull/1137)
@@ -62,6 +62,7 @@
   [#996](https://github.com/gakonst/ethers-rs/pull/996)
 - Add `TransactionReceipt::to` and `TransactionReceipt::from`
   [#1184](https://github.com/gakonst/ethers-rs/pull/1184)
+- Add `From<H160>` trait to `ValueOrArray<H160>` [#1199](https://github.com/gakonst/ethers-rs/pull/1200)
 
 ## ethers-contract-abigen
 

--- a/ethers-core/src/types/log.rs
+++ b/ethers-core/src/types/log.rs
@@ -306,7 +306,31 @@ impl Filter {
         self.block_option = self.block_option.set_hash(hash.into());
         self
     }
-
+    /// Sets the inner filter object
+    ///
+    /// *NOTE:* ranges are always inclusive
+    ///
+    /// # Examples
+    ///
+    /// Match only a specific address `("0xAc4b3DacB91461209Ae9d41EC517c2B9Cb1B7DAF")`
+    ///
+    /// ```rust
+    /// # use ethers_core::types::{Filter, Address};
+    /// # fn main() {
+    /// let filter = Filter::new().address("0xAc4b3DacB91461209Ae9d41EC517c2B9Cb1B7DAF".parse::<Address>().unwrap());
+    /// # }
+    /// ```
+    ///
+    /// Match all addresses in array `(vec!["0xAc4b3DacB91461209Ae9d41EC517c2B9Cb1B7DAF",
+    /// "0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8"])`
+    ///
+    /// ```rust
+    /// # use ethers_core::types::{Filter, Address, ValueOrArray};
+    /// # fn main() {
+    /// let addresses = vec!["0xAc4b3DacB91461209Ae9d41EC517c2B9Cb1B7DAF".parse::<Address>().unwrap(),"0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8".parse::<Address>().unwrap()];
+    /// let filter = Filter::new().address(addresses);
+    /// # }
+    /// ```
     #[must_use]
     pub fn address<T: Into<ValueOrArray<Address>>>(mut self, address: T) -> Self {
         self.address = Some(address.into());
@@ -363,6 +387,12 @@ pub enum ValueOrArray<T> {
 impl From<H160> for ValueOrArray<H160> {
     fn from(src: H160) -> Self {
         ValueOrArray::Value(src)
+    }
+}
+
+impl From<Vec<H160>> for ValueOrArray<H160> {
+    fn from(src: Vec<H160>) -> Self {
+        ValueOrArray::Array(src)
     }
 }
 

--- a/ethers-core/src/types/log.rs
+++ b/ethers-core/src/types/log.rs
@@ -1,6 +1,6 @@
 // Adapted from https://github.com/tomusdrw/rust-web3/blob/master/src/types/log.rs
 use crate::{
-    types::{Address, BlockNumber, Bytes, H256, U256, U64},
+    types::{Address, BlockNumber, Bytes, H160, H256, U256, U64},
     utils::keccak256,
 };
 use serde::{
@@ -359,6 +359,12 @@ pub enum ValueOrArray<T> {
 }
 
 // TODO: Implement more common types - or adjust this to work with all Tokenizable items
+
+impl From<H160> for ValueOrArray<H160> {
+    fn from(src: H160) -> Self {
+        ValueOrArray::Value(src)
+    }
+}
 
 impl From<H256> for ValueOrArray<H256> {
     fn from(src: H256) -> Self {


### PR DESCRIPTION
## Motivation

The trait `From<H160>` for `ValueOrArray<H160>` is not implemented which prevents compilation when using `pub fn address<T: Into<ValueOrArray<Address>>>(self, address: T) -> Self` for `ethers_core::types::Filter`.

Cargo.toml used in both examples:
```
[dependencies]
ethers = { git = "https://github.com/gakonst/ethers-rs" }
eyre = "0.6.8"
tokio = { version = "1", features = ["full"] }
```

Example that should compile but doesn't:
```
use ethers::prelude::*;
use eyre::Result;

fn main() -> Result<()> {
    let address = "0x1F98431c8aD98523631AE4a59f267346ea31F984".parse::<Address>()?;
    let _filter = Filter::new().address(address);
    Ok(())
}
```
Compilation error from trying to compile the example above:
```
error[E0277]: the trait bound `ValueOrArray<H160>: From<H160>` is not satisfied
   --> src/main.rs:6:41
    |
6   |     let _filter = Filter::new().address(address);
    |                                 ------- ^^^^^^^ the trait `From<H160>` is not implemented for `ValueOrArray<H160>`
    |                                 |
    |                                 required by a bound introduced by this call
    |
    = help: the following other types implement trait `From<T>`:
              <ValueOrArray<H256> as From<H160>>
              <ValueOrArray<H256> as From<H256>>
              <ValueOrArray<H256> as From<U256>>
    = note: required because of the requirements on the impl of `Into<ValueOrArray<H160>>` for `H160`
```
Full example that should compile and print the PoolCreated log for creating the APE/WETH Uniswap v3 pool:
```
use ethers::prelude::*;
use eyre::Result;
use std::sync::Arc;

#[tokio::main]
async fn main() -> Result<()> {
    let client = Provider::<Http>::try_from(
        "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27",
    )?;
    let client = Arc::new(client);

    let address = "0x1F98431c8aD98523631AE4a59f267346ea31F984".parse::<Address>()?;
    let filter = Filter::new()
        .address(address)
        .select(14403763)
        .event("PoolCreated(address,address,uint24,int24,address)");
    let logs = client.get_logs(&filter).await?;

    for log in logs {
        println!("{:?}", log);
    }

    Ok(())
}
```
Expected output from full example:
```
Log { address: 0x1f98431c8ad98523631ae4a59f267346ea31f984, topics: [0x783cca1c0412dd0d695e784568c96da2e9c22ff989357a2e8b1d9b2b4e6b7118, 0x0000000000000000000000004d224452801aced8b2f0aebe155379bb5d594381, 0x000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2, 0x0000000000000000000000000000000000000000000000000000000000000bb8], data: Bytes(b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0<\0\0\0\0\0\0\0\0\0\0\0\0\xacK=\xac\xb9\x14a \x9a\xe9\xd4\x1e\xc5\x17\xc2\xb9\xcb\x1b}\xaf"), block_hash: Some(0x7bd551cf0ccdb0a19591b9212b663af51b4b2591ad45f6fed094aa1e685b8d7a), block_number: Some(14403763), transaction_hash: Some(0x7e1cb512516337180d3542aadc815d1e8ff4084561847e2d602e2875fb7bcbc9), transaction_index: Some(1), log_index: Some(7), transaction_log_index: None, log_type: None, removed: Some(false) }
```
Actual output from full example is the same compilation error previously listed.

### Cargo Version / Platform
cargo `cargo 1.62.0-nightly (f63f23ff1 2022-04-28)`
platform `Darwin MacBook-Pro-4.local 21.4.0 Darwin Kernel Version 21.4.0: Fri Mar 18 00:45:05 PDT 2022; root:xnu-8020.101.4~15/RELEASE_X86_64 x86_64`

## Solution
Implement the From<H160> trait for ValueOrArray<H160> inside `ethers-core/src/types/log.rs`

```
impl From<H160> for ValueOrArray<H160> {
    fn from(src: H160) -> Self {
        ValueOrArray::Value(src)
    }
}
```
I'm new to rust so I'm not sure if there is a better way to do this, but it did resolve my issue. After adding this, both my examples aboved compiled and ran successfully.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog