### PR TITLE
Fix: Ledger should have correct signature v value for chains with large chain ID

### DIFF
--- a/ethers-signers/src/ledger/app.rs
+++ b/ethers-signers/src/ledger/app.rs
@@ -119,7 +119,31 @@ impl LedgerEthereum {
     pub async fn sign_tx(&self, tx: &TypedTransaction) -> Result<Signature, LedgerError> {
         let mut payload = Self::path_to_bytes(&self.derivation);
         payload.extend_from_slice(tx.rlp().as_ref());
-        self.sign_payload(INS::SIGN, payload).await
+        
+        let mut signature = self.sign_payload(INS::SIGN, payload).await?;
+
+        // modify `v` value of signature to match EIP-155 for chains with large chain ID
+        // The logic is derived from Ledger's library
+        // https://github.com/LedgerHQ/ledgerjs/blob/e78aac4327e78301b82ba58d63a72476ecb842fc/packages/hw-app-eth/src/Eth.ts#L300 
+        let eip155_chain_id = self.chain_id * 2 + 35;
+        if eip155_chain_id + 1 > 255 {
+            let one_byte_chain_id = eip155_chain_id % 256;
+            // May use `let ecc_parity = signature.v.abs_diff(one_byte_chain_id)` instead after updated to Rust 1.60
+            let ecc_parity = if signature.v > one_byte_chain_id {
+                signature.v - one_byte_chain_id
+            } else {
+                one_byte_chain_id - signature.v
+            };
+
+            signature.v = match tx {
+                TypedTransaction::Eip2930(_) | TypedTransaction::Eip1559(_) => {
+                    if ecc_parity % 2 == 1 { 0 } else { 1 }
+                },
+                TypedTransaction::Legacy(_) => eip155_chain_id + ecc_parity,
+            };
+        }
+
+        Ok(signature)
     }
 
     /// Signs an ethereum personal message


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Since Ledger only return one byte of `signature.v` as stated in #1198, This issue prevent from sending transaction to chain that has large chain ID, such as, Arbitrum One (chain ID: 42161).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

I have derived a part of code from Ledger's JavaScript library and implement it as Rust. This part of code re-calculate signature's `v` value to fit with target chain.

The reference of Ledger's library can be found here: https://github.com/LedgerHQ/ledgerjs/blob/e78aac4327e78301b82ba58d63a72476ecb842fc/packages/hw-app-eth/src/Eth.ts#L298-L314

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
