### PR TITLE
fixed typo when determining to token address

### DIFF
--- a/examples/decode_tx_input.rs
+++ b/examples/decode_tx_input.rs
@@ -14,11 +14,12 @@ fn main() -> Result<()> {
     let tx_input = "0x38ed173900000000000000000000000000000000000000000001a717cc0a3e4f84c00000000000000000000000000000000000000000000000000000000000000283568400000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000201f129111c60401630932d9f9811bd5b5fff34e000000000000000000000000000000000000000000000000000000006227723d000000000000000000000000000000000000000000000000000000000000000200000000000000000000000095ad61b0a150d79219dcf64e1e6cc01f0b64c4ce000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7";
     let calldata: Bytes = tx_input.parse().unwrap();
     let decoded = SwapExactTokensForTokensCall::decode(&calldata)?;
-
-    let from = decoded.path.into_iter().next().unwrap();
+    let mut path = decoded.path.into_iter();
+    let from = path.next().unwrap();
+    let to = path.next().unwrap();
     println!(
         "Swapped {} of token {} for {} of token {}",
-        decoded.amount_in, from, decoded.amount_out_min, decoded.to
+        decoded.amount_in, from, decoded.amount_out_min, to
     );
 
     Ok(())


### PR DESCRIPTION
## Motivation

I wanted to learn how to decode transaction data so I was playing around with this [example](https://github.com/gakonst/ethers-rs/blob/master/examples/decode_tx_input.rs) but I noticed that there was a typo in the output.

## Solution

`decoded.to` is the recipient of the swap but `to` should be the destination token i.e. `path[1]`.

## PR Checklist

- [NA] Added Tests
- [NA] Added Documentation
- [NA] Updated the changelog
