### PR TITLE
fix(solc): make scoped reporter work in parallel

### DIFF
--- a/ethers-solc/src/compile/project.rs
+++ b/ethers-solc/src/compile/project.rs
@@ -543,11 +543,20 @@ fn compile_parallel(
         }
     }
 
+    // need to get the currently installed reporter before installing the pool, otherwise each new
+    // thread in the pool will get initialized with the default value of the `thread_local!`
+    // localkey. This way we keep access to the reporter in the rayon pool
+    let scoped_report = report::get_default(|reporter| reporter.clone());
+
     // start a rayon threadpool that will execute all `Solc::compile()` processes
     let pool = rayon::ThreadPoolBuilder::new().num_threads(num_jobs).build().unwrap();
+
     let outputs = pool.install(move || {
         jobs.into_par_iter()
-            .map(|(solc, version, input, actually_dirty)| {
+            .map(move |(solc, version, input, actually_dirty)| {
+                // set the reporter on this thread
+                let _guard = report::set_scoped(&scoped_report);
+
                 tracing::trace!(
                     "calling solc `{}` {:?} with {} sources: {:?}",
                     version,

--- a/ethers-solc/src/compile/project.rs
+++ b/ethers-solc/src/compile/project.rs
@@ -544,7 +544,7 @@ fn compile_parallel(
     }
 
     // need to get the currently installed reporter before installing the pool, otherwise each new
-    // thread in the pool will get initialized with the default value of the `thread_local!`
+    // thread in the pool will get initialized with the default value of the `thread_local!`'s
     // localkey. This way we keep access to the reporter in the rayon pool
     let scoped_report = report::get_default(|reporter| reporter.clone());
 

--- a/ethers-solc/src/report/mod.rs
+++ b/ethers-solc/src/report/mod.rs
@@ -93,7 +93,7 @@ where
 /// print custom messages to `stdout`.
 ///
 /// A `Reporter` is entirely passive and only listens to incoming "events".
-pub trait Reporter: 'static {
+pub trait Reporter: 'static + std::fmt::Debug {
     /// Callback invoked right before [`Solc::compile()`] is called
     ///
     /// This contains the [Solc] its [Version] the complete [CompilerInput] and all files that
@@ -453,6 +453,7 @@ mod tests {
 
     #[test]
     fn scoped_reporter_works() {
+        #[derive(Debug)]
         struct TestReporter;
         impl Reporter for TestReporter {}
 
@@ -468,6 +469,7 @@ mod tests {
         });
 
         set_global_reporter(Report::new(BasicStdoutReporter::default())).unwrap();
+        #[derive(Debug)]
         struct TestReporter;
         impl Reporter for TestReporter {}
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Previously the scoped reporter (set in forge) got lost in when compiled in parallel, due to the thread_local! initialisation.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
when compiling in parallel clone the current default reporter and use it as the scoped reporter on the rayon thread.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
