### PR TITLE
fix(core): removed Cronos mainnet beta from `is_legacy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Removed Cronos mainnet beta from `is_legacy` [1246](https://github.com/gakonst/ethers-rs/pull/1246)
 - Fix RLP decoding of `from` field for `Eip1559TransactionRequest` and
   `Eip2930TransactionRequest`, remove `Eip1559TransactionRequest` `sighash`
   method [1180](https://github.com/gakonst/ethers-rs/pull/1180)

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -176,8 +176,7 @@ impl Chain {
                 Chain::BinanceSmartChain |
                 Chain::BinanceSmartChainTestnet |
                 Chain::Arbitrum |
-                Chain::ArbitrumTestnet |
-                Chain::Cronos,
+                Chain::ArbitrumTestnet,
         )
     }
 }


### PR DESCRIPTION
## Motivation

it now supports EIP1559 after the network upgrade at the height 2693800

## Solution

removed Cronos mainnet beta from `is_legacy`

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog



