### PR TITLE
More gas oracles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,18 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7862e21c893d65a1650125d157eaeec691439379a1cee17ee49031b79236ada4"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "auto_impl"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a8c1df849285fbacd587de7818cc7d13be6cd2cbcd47a04fb1801b0e2706e33"
@@ -1365,7 +1377,7 @@ name = "ethers-middleware"
 version = "0.17.0"
 dependencies = [
  "async-trait",
- "auto_impl",
+ "auto_impl 0.5.0",
  "ethers-contract",
  "ethers-core",
  "ethers-etherscan",
@@ -1394,7 +1406,7 @@ name = "ethers-providers"
 version = "0.17.0"
 dependencies = [
  "async-trait",
- "auto_impl",
+ "auto_impl 1.0.1",
  "base64 0.13.0",
  "bytes",
  "ethers-core",
@@ -1548,7 +1560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "089263294bb1c38ac73649a6ad563dd9a5142c8dc0482be15b8b9acb22a1611e"
 dependencies = [
  "arrayvec 0.7.2",
- "auto_impl",
+ "auto_impl 1.0.1",
  "bytes",
  "ethereum-types",
  "fastrlp-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,7 @@ name = "ethers-middleware"
 version = "0.17.0"
 dependencies = [
  "async-trait",
+ "auto_impl",
  "ethers-contract",
  "ethers-core",
  "ethers-etherscan",

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -21,6 +21,7 @@ ethers-providers = { version = "^0.17.0", path = "../ethers-providers", default-
 ethers-signers = { version = "^0.17.0", path = "../ethers-signers", default-features = false }
 
 async-trait = { version = "0.1.50", default-features = false }
+auto_impl = { version = "0.5.0", default-features = false }
 serde = { version = "1.0.124", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0", default-features = false }
 futures-util = { version = "^0.3" }

--- a/ethers-middleware/src/gas_oracle/gas_now.rs
+++ b/ethers-middleware/src/gas_oracle/gas_now.rs
@@ -23,7 +23,7 @@ struct GasNowResponseWrapper {
     data: GasNowResponse,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GasNowResponse {
     pub rapid: u64,
     pub fast: u64,

--- a/ethers-middleware/src/gas_oracle/gas_now.rs
+++ b/ethers-middleware/src/gas_oracle/gas_now.rs
@@ -41,7 +41,7 @@ impl GasNow {
     pub fn with_client(client: Client) -> Self {
         let url = Url::parse(GAS_NOW_URL).expect("invalid url");
 
-        Self { url, gas_category: GasCategory::Standard }
+        Self { client, url, gas_category: GasCategory::Standard }
     }
 
     /// Sets the gas price category to be used when fetching the gas price.
@@ -64,7 +64,7 @@ impl GasNow {
 
 impl Default for GasNow {
     fn default() -> Self {
-        Self::new(Client::new())
+        Self::new()
     }
 }
 

--- a/ethers-middleware/src/gas_oracle/mod.rs
+++ b/ethers-middleware/src/gas_oracle/mod.rs
@@ -22,6 +22,12 @@ pub use cache::Cache;
 mod polygon;
 pub use polygon::Polygon;
 
+mod gas_now;
+pub use gas_now::GasNow;
+
+mod provider_oracle;
+pub use provider_oracle::ProviderOracle;
+
 use ethers_core::types::U256;
 
 use async_trait::async_trait;
@@ -74,6 +80,10 @@ pub enum GasOracleError {
 
     #[error("Chain is not supported by the oracle")]
     UnsupportedChain,
+
+    /// Error thrown when the provider failed.
+    #[error("Chain is not supported by the oracle")]
+    ProviderError(#[from] Box<dyn Error + Send + Sync>),
 }
 
 /// `GasOracle` is a trait that an underlying gas oracle needs to implement.

--- a/ethers-middleware/src/gas_oracle/mod.rs
+++ b/ethers-middleware/src/gas_oracle/mod.rs
@@ -33,6 +33,7 @@ use ethers_core::types::U256;
 use async_trait::async_trait;
 use auto_impl::auto_impl;
 use reqwest::Error as ReqwestError;
+use std::error::Error;
 use thiserror::Error;
 
 const GWEI_TO_WEI: u64 = 1000000000;

--- a/ethers-middleware/src/gas_oracle/mod.rs
+++ b/ethers-middleware/src/gas_oracle/mod.rs
@@ -25,6 +25,7 @@ pub use polygon::Polygon;
 use ethers_core::types::U256;
 
 use async_trait::async_trait;
+use auto_impl::auto_impl;
 use reqwest::Error as ReqwestError;
 use thiserror::Error;
 
@@ -95,6 +96,7 @@ pub enum GasOracleError {
 /// ```
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[auto_impl(&, Box, Arc)]
 pub trait GasOracle: Send + Sync + std::fmt::Debug {
     /// Makes an asynchronous HTTP query to the underlying `GasOracle`
     ///

--- a/ethers-middleware/src/gas_oracle/provider_oracle.rs
+++ b/ethers-middleware/src/gas_oracle/provider_oracle.rs
@@ -1,0 +1,40 @@
+use crate::gas_oracle::{GasOracle, GasOracleError};
+use async_trait::async_trait;
+use ethers_core::types::U256;
+use ethers_providers::Middleware;
+use std::fmt::Debug;
+
+/// Gas oracle from a [`Middleware`] implementation such as an
+/// Ethereum RPC provider.
+#[derive(Debug)]
+pub struct ProviderOracle<M: Middleware> {
+    provider: M,
+}
+
+impl<M: Middleware> ProviderOracle<M> {
+    pub fn new(provider: M) -> Self {
+        Self { provider }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl<M: Middleware> GasOracle for ProviderOracle<M>
+where
+    <M as Middleware>::Error: 'static,
+{
+    async fn fetch(&self) -> Result<U256, GasOracleError> {
+        self.provider
+            .get_gas_price()
+            .await
+            .map_err(|err| GasOracleError::ProviderError(Box::new(err)))
+    }
+
+    async fn estimate_eip1559_fees(&self) -> Result<(U256, U256), GasOracleError> {
+        // TODO: Allow configuring different estimation functions.
+        self.provider
+            .estimate_eip1559_fees(None)
+            .await
+            .map_err(|err| GasOracleError::ProviderError(Box::new(err)))
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

This adds the `ProviderOracle` that allows runtime selection between provider gas methods and gas oracles. Such runtime selection is very useful for building stacks that work on multiple chains, such as production and local test.

~~It also adds a `default_for_chain` constructor that looks at the `chain_id` and tries to build a sensible default. This is a bit proof-of-concept. It would be nice to add a builder pattern where you can provide api-keys.~~

Architecturally this all feels a bit off to me. `ProviderOracle` exists basically because `GasOracle` and `Middleware` overlap in functionality. The `Provider` implementation also does quite a bit of magic under the hood to get EIP1559 estimates. IMHO it would be cleaner if this was all done through something like GasOracle's. But simply factoring it out doesn't work because gas prices are required to sign transactions, and at least currently Provider provides a complete implementation. Makes me think the Middleware really should be broken up in separate parts relating to the transaction lifecycle (gas pricing, gas estimation, gas escalation, nonce, signing, broadcasting, monitoring, etc). (Also seems related to #592)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
