### PR TITLE
fix: all request ids start at 1

### DIFF
--- a/ethers-providers/src/transports/common.rs
+++ b/ethers-providers/src/transports/common.rs
@@ -212,6 +212,8 @@ impl fmt::Display for Authorization {
 
 #[cfg(test)]
 mod tests {
+    use ethers_core::types::U64;
+
     use super::*;
 
     #[test]
@@ -247,10 +249,28 @@ mod tests {
             }
             _ => panic!("expected `Error` response"),
         }
+
+        let response: Response<'_> =
+            serde_json::from_str(r#"{"jsonrpc":"2.0","result":"0xfa","id":0}"#).unwrap();
+
+        match response {
+            Response::Success { id, result } => {
+                assert_eq!(id, 0);
+                let result: U64 = serde_json::from_str(result.get()).unwrap();
+                assert_eq!(result.as_u64(), 250);
+            }
+            _ => panic!("expected `Success` response"),
+        }
     }
 
     #[test]
     fn ser_request() {
+        let request: Request<()> = Request::new(0, "eth_chainId", ());
+        assert_eq!(
+            &serde_json::to_string(&request).unwrap(),
+            r#"{"id":0,"jsonrpc":"2.0","method":"eth_chainId"}"#
+        );
+
         let request: Request<()> = Request::new(300, "method_name", ());
         assert_eq!(
             &serde_json::to_string(&request).unwrap(),

--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -149,7 +149,7 @@ impl Provider {
     /// let provider = Http::new_with_client(url, client);
     /// ```
     pub fn new_with_client(url: impl Into<Url>, client: reqwest::Client) -> Self {
-        Self { id: AtomicU64::new(0), client, url: url.into() }
+        Self { id: AtomicU64::new(1), client, url: url.into() }
     }
 }
 
@@ -164,7 +164,7 @@ impl FromStr for Provider {
 
 impl Clone for Provider {
     fn clone(&self) -> Self {
-        Self { id: AtomicU64::new(0), client: self.client.clone(), url: self.url.clone() }
+        Self { id: AtomicU64::new(1), client: self.client.clone(), url: self.url.clone() }
     }
 }
 

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -114,7 +114,7 @@ impl Ws {
         // Spawn the server
         WsServer::new(ws, stream).spawn();
 
-        Self { id: Arc::new(AtomicU64::new(0)), instructions: sink }
+        Self { id: Arc::new(AtomicU64::new(1)), instructions: sink }
     }
 
     /// Returns true if the WS connection is active, false otherwise


### PR DESCRIPTION
## Motivation

I came across an issue in foundry trying to deploy a contract to fantom using the official RPC `https://rpc.ftm.tools/`. A call to `eth_chainId` fails to deserialize, because the sent out request has the ID `zero`, to which the response is `{"jsonrpc":"2.0","id":null,"result":"0xfa"}`. For some reason the server fails to unmarshall the request ID and responds with a `null` ID. When sending a request with a non-zero ID, everything works fine. Strictly speaking, this is an error on their side, since nothing in the JSON-RPC forbids a zero ID and I am not entirely sure why this occurs, since go-opera uses the `rpc` package straight from the go-ethereum repo and I don't think geth exhibits this behaviour. Anyways, the fix is simple and the alternative behaviour is consistent with other eth libraries like ethers-js.

## Solution

All request IDs for all transports start at 1.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
