### PR TITLE
fix(ethers-solc/ConfigurableArtifacts): output methodIdentifiers by default

### DIFF
--- a/ethers-solc/src/artifact_output/configurable.rs
+++ b/ethers-solc/src/artifact_output/configurable.rs
@@ -113,7 +113,8 @@ impl<'a> From<&'a ConfigurableContractArtifact> for CompactContractBytecodeCow<'
 ///  {
 ///    "abi": [],
 ///    "bytecode": {...},
-///    "deployedBytecode": {...}
+///    "deployedBytecode": {...},
+///    "methodIdentifiers": {...},
 ///    // additional values
 ///  }
 /// ```
@@ -290,12 +291,10 @@ impl ArtifactOutput for ConfigurableArtifacts {
 
             artifact_bytecode = bytecode.map(Into::into);
             artifact_deployed_bytecode = deployed_bytecode.map(Into::into);
+            artifact_method_identifiers = Some(method_identifiers);
 
             if self.additional_values.gas_estimates {
                 artifact_gas_estimates = gas_estimates;
-            }
-            if self.additional_values.method_identifiers {
-                artifact_method_identifiers = Some(method_identifiers);
             }
             if self.additional_values.assembly {
                 artifact_assembly = assembly;


### PR DESCRIPTION

Related https://github.com/foundry-rs/foundry/issues/1497

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

As per https://github.com/gakonst/foundry/blob/0062360706e77a155856e128c3e250264c75f48c/config/src/lib.rs#L199-L214 `methodIdentifiers` should be enabled as extra output by default as well in addition to `abi`, `bytecode` and `deployedBytecode`. Making it default in ethers as other fields, but can also inject `methodIdentifiers` as `extra_output` in `Config::extra_output`.

 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
