### PR TITLE
feat(etherscan): added Cronos testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Added Cronos testnet to etherscan options [1276](https://github.com/gakonst/ethers-rs/pull/1276)
 - Fix parsing of a pending block
   [1272](https://github.com/gakonst/ethers-rs/pull/1272)
 - Removed Cronos mainnet beta from `is_legacy` [1246](https://github.com/gakonst/ethers-rs/pull/1246)

--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -92,12 +92,13 @@ impl Client {
             Chain::BinanceSmartChainTestnet |
             Chain::Arbitrum |
             Chain::ArbitrumTestnet |
-            Chain::Cronos => std::env::var("ETHERSCAN_API_KEY")?,
+            Chain::Cronos |
+            Chain::CronosTestnet => std::env::var("ETHERSCAN_API_KEY")?,
             Chain::Fantom | Chain::FantomTestnet => {
                 std::env::var("FTMSCAN_API_KEY").or_else(|_| std::env::var("FANTOMSCAN_API_KEY"))?
             }
 
-            Chain::XDai | Chain::Sepolia | Chain::CronosTestnet => String::default(),
+            Chain::XDai | Chain::Sepolia => String::default(),
             Chain::Moonbeam | Chain::MoonbeamDev | Chain::Moonriver => {
                 std::env::var("MOONSCAN_API_KEY")?
             }
@@ -258,6 +259,9 @@ impl ClientBuilder {
                 urls("https://api-testnet.arbiscan.io/api", "https://testnet.arbiscan.io")
             }
             Chain::Cronos => urls("https://api.cronoscan.com/api", "https://cronoscan.com"),
+            Chain::CronosTestnet => {
+                urls("https://api-testnet.cronoscan.com/api", "https://testnet.cronoscan.com")
+            }
             Chain::Moonbeam => {
                 urls("https://api-moonbeam.moonscan.io/api", "https://moonbeam.moonscan.io/")
             }


### PR DESCRIPTION
## Motivation

Cronos testnet has now the Etherscan support:  https://testnet.cronoscan.com

## Solution

Added the respective URLs to the Etherscan chain resolution

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
