### PR TITLE
fix: serialize eth_getStorageAt position param as quantity

### DIFF
--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1529,6 +1529,22 @@ mod tests {
     };
     use futures_util::StreamExt;
 
+    #[test]
+    fn convert_h256_u256_quantity() {
+        let hash: H256 = H256::zero();
+        let quantity = U256::from_big_endian(hash.as_bytes());
+        assert_eq!(format!("{quantity:#x}"), "0x0");
+        assert_eq!(utils::serialize(&quantity).to_string(), "\"0x0\"");
+
+        let address: Address = "0x295a70b2de5e3953354a6a8344e616ed314d7251".parse().unwrap();
+        let block = BlockNumber::Latest;
+        let params =
+            [utils::serialize(&address), utils::serialize(&quantity), utils::serialize(&block)];
+
+        let params = serde_json::to_string(&params).unwrap();
+        assert_eq!(params, r#"["0x295a70b2de5e3953354a6a8344e616ed314d7251","0x0","latest"]"#);
+    }
+
     #[tokio::test]
     // Test vector from: https://docs.ethers.io/ethers.js/v5-beta/api-providers.html#id2
     async fn mainnet_resolve_name() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes #1279 https://github.com/foundry-rs/foundry/issues/1590
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
adhere to the spec by converting the location H256 to U256 instead which does not pad
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
