### PR TITLE
return instead of ignore error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - Add `TransactionReceipt::to` and `TransactionReceipt::from`
   [#1184](https://github.com/gakonst/ethers-rs/pull/1184)
 - Add `From<H160>` and From<Vec<H160>> traits to `ValueOrArray<H160>` [#1199](https://github.com/gakonst/ethers-rs/pull/1200)
+- Fix handling of Websocket connection errors [#1287](https://github.com/gakonst/ethers-rs/pull/1287)
 
 ## ethers-contract-abigen
 

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -401,8 +401,9 @@ where
             // Handle ws messages
             resp = self.ws.next() => match resp {
                 Some(Ok(resp)) => self.handle(resp).await?,
-                // TODO: Log the error?
-                Some(Err(_)) => {},
+                Some(Err(_)) => {
+                    return Err(ClientError::UnexpectedClose);
+                }
                 None => {
                     return Err(ClientError::UnexpectedClose);
                 },


### PR DESCRIPTION
## Motivation

I noticed that occasionally my program would get stuck with one thread spinning at near 100% CPU. After a bunch of investigation with rust-gdb and tokio-console and stripping it down to a much [smaller program](https://github.com/SatoshiAndKin/web3-proxy/tree/c3d1d14f1628e415729e55809e3037b422ef16ad/web3-proxy-minimal), I narrowed it down to a websocket task being very active doing nothing.

Here you can see the spawned future stuck running:

![IMAGE 2022-05-19 18:30:24](https://user-images.githubusercontent.com/624221/169430653-945fdac2-9f21-49ff-9218-97b189da0a7d.jpg)

It is being woken up ~253k times per second, so that explains the 100% CPU:

![IMAGE 2022-05-19 18:29:44](https://user-images.githubusercontent.com/624221/169430590-7f279703-03f5-460d-b5d7-50e5b0434271.jpg)

After some digging, I found this related code:

https://github.com/gakonst/ethers-rs/blob/3df1527cef7a7de8cbb26a8c98de74348203176b/ethers-providers/src/transports/ws.rs#L402-L408

Dropping that error is bad because it might be an `Io(Kind(UnexpectedEof))`. If that's the case, the websocket needs to reconnect.

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


## Solution

Quick fix is to just return an error when the socket gives an error.

I think a more robust fix might be to use something like https://docs.rs/stubborn-io/latest/stubborn_io/.

## PR Checklist

I'm not sure how to write a test for this.

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
