### PR TITLE
fix(signer): use wallet chainid for tx signing

### DIFF
--- a/ethers-signers/src/wallet/private_key.rs
+++ b/ethers-signers/src/wallet/private_key.rs
@@ -253,6 +253,47 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "celo"))]
+    fn signs_tx_empty_chain_id_sync() {
+        use crate::TypedTransaction;
+        use ethers_core::types::TransactionRequest;
+
+        let chain_id = 1337u64;
+        // retrieved test vector from:
+        // https://web3js.readthedocs.io/en/v1.2.0/web3-eth-accounts.html#eth-accounts-signtransaction
+        let tx: TypedTransaction = TransactionRequest {
+            from: None,
+            to: Some("F0109fC8DF283027b6285cc889F5aA624EaC1F55".parse::<Address>().unwrap().into()),
+            value: Some(1_000_000_000u64.into()),
+            gas: Some(2_000_000u64.into()),
+            nonce: Some(0u64.into()),
+            gas_price: Some(21_000_000_000u128.into()),
+            data: None,
+            chain_id: None,
+        }
+        .into();
+        let wallet: Wallet<SigningKey> =
+            "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318".parse().unwrap();
+        let wallet = wallet.with_chain_id(chain_id);
+
+        // this should populate the tx chain_id as the signer's chain_id (1337) before signing and
+        // normalize the v
+        let sig = wallet.sign_transaction_sync(&tx);
+
+        // ensure correct v given the chain - first extract recid
+        let recid = (sig.v - 35) % 2;
+        // eip155 check
+        assert_eq!(sig.v, chain_id * 2 + 35 + recid);
+
+        // since we initialize with None we need to re-set the chain_id for the sighash to be
+        // correct
+        let mut tx = tx;
+        tx.set_chain_id(chain_id);
+        let sighash = tx.sighash();
+        assert!(sig.verify(sighash, wallet.address).is_ok());
+    }
+
+    #[test]
     fn key_to_address() {
         let wallet: Wallet<SigningKey> =
             "0000000000000000000000000000000000000000000000000000000000000001".parse().unwrap();


### PR DESCRIPTION
## Motivation

In `sign_transaction_sync`, if a transaction `chain_id` was `None`, the wallet would sign a transaction without serializing the chain id. However, the signature's `v` would encode the proper chain.

## Solution

Use the signer's `chain_id` if the transaction does not specify one, before hashing the transaction in `sign_transaction_sync`.

Adds a test checking that `sign_transaction_sync` outputs a correct `v` when signing a transaction with an empty chain.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
