### PR TITLE
fix(signers): aws eip712 does not use eip155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- AWS EIP712 data signing no longer signs with EIP155
 - Added Cronos testnet to etherscan options [1276](https://github.com/gakonst/ethers-rs/pull/1276)
 - Fix parsing of a pending block
   [1272](https://github.com/gakonst/ethers-rs/pull/1272)

--- a/ethers-signers/src/aws/mod.rs
+++ b/ethers-signers/src/aws/mod.rs
@@ -251,10 +251,11 @@ impl<'a> super::Signer for AwsSigner<'a> {
         &self,
         payload: &T,
     ) -> Result<EthSig, Self::Error> {
-        let digest = payload.encode_eip712().map_err(|e| Self::Error::Eip712Error(e.to_string()))?;
+        let digest =
+            payload.encode_eip712().map_err(|e| Self::Error::Eip712Error(e.to_string()))?;
 
-        let sig = self.sign_digest(digest.into()).await?;
-        let sig = utils::rsig_from_digest_bytes_trial_recovery(&sig, digest.into(), &self.pubkey);
+        let sig = self.sign_digest(digest).await?;
+        let sig = utils::rsig_from_digest_bytes_trial_recovery(&sig, digest, &self.pubkey);
         let sig = rsig_to_ethsig(&sig);
 
         Ok(sig)

--- a/ethers-signers/src/aws/mod.rs
+++ b/ethers-signers/src/aws/mod.rs
@@ -251,11 +251,13 @@ impl<'a> super::Signer for AwsSigner<'a> {
         &self,
         payload: &T,
     ) -> Result<EthSig, Self::Error> {
-        let hash = payload.encode_eip712().map_err(|e| Self::Error::Eip712Error(e.to_string()))?;
+        let digest = payload.encode_eip712().map_err(|e| Self::Error::Eip712Error(e.to_string()))?;
 
-        let digest = self.sign_digest_with_eip155(hash.into(), self.chain_id).await?;
+        let sig = self.sign_digest(digest.into()).await?;
+        let sig = utils::rsig_from_digest_bytes_trial_recovery(&sig, digest.into(), &self.pubkey);
+        let sig = rsig_to_ethsig(&sig);
 
-        Ok(digest)
+        Ok(sig)
     }
 
     fn address(&self) -> Address {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

AWS signing typed data (for EIP712) currently signs with EIP155. EIP712 includes `chain_id` when signing data already, thus we do not need EIP155 on top of that.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

AWS signer `signed_typed_data` signs without EIP155.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
