### PR TITLE
feat(solc): use relative paths and --base-path option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@
 
 ### Unreleased
 
+- Use relative source paths and `solc --base-path`
+  [#1317](https://github.com/gakonst/ethers-rs/pull/1317)
 - Save cache entry objects with relative paths
   [#1307](https://github.com/gakonst/ethers-rs/pull/1307)
 - Bundle svm, svm-builds and sha2 dependencies in new `svm-solc` feature

--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -1,21 +1,18 @@
 //! Solc artifact types
-use ethers_core::abi::Abi;
-
+use crate::{
+    compile::*, error::SolcIoError, remappings::Remapping, utils, ProjectPathsConfig, SolcError,
+};
 use colored::Colorize;
+use ethers_core::abi::Abi;
 use md5::Digest;
 use semver::{Version, VersionReq};
+use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     collections::{BTreeMap, HashSet},
     fmt, fs,
     path::{Path, PathBuf},
     str::FromStr,
 };
-
-use crate::{
-    compile::*, error::SolcIoError, remappings::Remapping, utils, ProjectPathsConfig, SolcError,
-};
-
-use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use tracing::warn;
 
 pub mod ast;
@@ -189,9 +186,19 @@ impl CompilerInput {
         self.sources = self
             .sources
             .into_iter()
-            .map(|(path, s)| (path.strip_prefix(base).map(|p| p.to_path_buf()).unwrap_or(path), s))
+            .map(|(path, s)| (path.strip_prefix(base).map(Into::into).unwrap_or(path), s))
             .collect();
         self
+    }
+
+    /// Similar to `Self::strip_prefix()`. Remove a base path from all
+    /// sources _and_ all paths in solc settings such as remappings
+    ///
+    /// See also `solc --base-path`
+    pub fn with_base_path(mut self, base: impl AsRef<Path>) -> Self {
+        let base = base.as_ref();
+        self.settings = self.settings.with_base_path(base);
+        self.strip_prefix(base)
     }
 }
 
@@ -383,6 +390,30 @@ impl Settings {
         let output =
             self.output_selection.as_mut().entry("*".to_string()).or_insert_with(BTreeMap::default);
         output.insert("".to_string(), vec!["ast".to_string()]);
+        self
+    }
+
+    /// Strips `base` from all paths
+    pub fn with_base_path(mut self, base: impl AsRef<Path>) -> Self {
+        let base = base.as_ref();
+        self.remappings.iter_mut().for_each(|r| {
+            r.strip_prefix(base);
+        });
+        self.output_selection = OutputSelection(
+            self.output_selection
+                .0
+                .into_iter()
+                .map(|(file, selection)| {
+                    (
+                        Path::new(&file)
+                            .strip_prefix(base)
+                            .map(|p| format!("{}", p.display()))
+                            .unwrap_or(file),
+                        selection,
+                    )
+                })
+                .collect(),
+        );
         self
     }
 }

--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -399,6 +399,14 @@ impl Settings {
         self.remappings.iter_mut().for_each(|r| {
             r.strip_prefix(base);
         });
+
+        self.libraries.libs = self
+            .libraries
+            .libs
+            .into_iter()
+            .map(|(file, libs)| (file.strip_prefix(base).map(Into::into).unwrap_or(file), libs))
+            .collect();
+
         self.output_selection = OutputSelection(
             self.output_selection
                 .0

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -127,6 +127,8 @@ impl fmt::Display for SolcVersion {
 pub struct Solc {
     /// Path to the `solc` executable
     pub solc: PathBuf,
+    /// The base path to set when invoking solc, see also <https://docs.soliditylang.org/en/v0.8.11/path-resolution.html#base-path-and-include-paths>
+    pub base_path: Option<PathBuf>,
     /// Additional arguments passed to the `solc` exectuable
     pub args: Vec<String>,
 }
@@ -163,7 +165,15 @@ impl fmt::Display for Solc {
 impl Solc {
     /// A new instance which points to `solc`
     pub fn new(path: impl Into<PathBuf>) -> Self {
-        Solc { solc: path.into(), args: Vec::new() }
+        Solc { solc: path.into(), base_path: None, args: Vec::new() }
+    }
+
+    /// Sets solc's base path
+    ///
+    /// Ref: <https://docs.soliditylang.org/en/v0.8.11/path-resolution.html#base-path-and-include-paths>
+    pub fn with_base_path(mut self, base_path: impl Into<PathBuf>) -> Self {
+        self.base_path = Some(base_path.into());
+        self
     }
 
     /// Adds an argument to pass to the `solc` command.
@@ -513,6 +523,9 @@ impl Solc {
 
     pub fn compile_output<T: Serialize>(&self, input: &T) -> Result<Vec<u8>> {
         let mut cmd = Command::new(&self.solc);
+        if let Some(ref base_path) = self.base_path {
+            cmd.current_dir(base_path);
+        }
         let mut child = cmd
             .args(&self.args)
             .arg("--standard-json")
@@ -575,7 +588,11 @@ impl Solc {
     pub async fn async_compile_output<T: Serialize>(&self, input: &T) -> Result<Vec<u8>> {
         use tokio::io::AsyncWriteExt;
         let content = serde_json::to_vec(input)?;
-        let mut child = tokio::process::Command::new(&self.solc)
+        let mut cmd = tokio::process::Command::new(&self.solc);
+        if let Some(ref base_path) = self.base_path {
+            cmd.current_dir(base_path);
+        }
+        let mut child = cmd
             .args(&self.args)
             .arg("--standard-json")
             .stdin(Stdio::piped())

--- a/ethers-solc/src/compile/output/contracts.rs
+++ b/ethers-solc/src/compile/output/contracts.rs
@@ -136,7 +136,7 @@ impl VersionedContracts {
         self.0 = std::mem::take(&mut self.0)
             .into_iter()
             .map(|(contract_path, contracts)| {
-                (root.join(contract_path).to_string_lossy().to_string(), contracts)
+                (format!("{}", root.join(contract_path).display()), contracts)
             })
             .collect();
         self

--- a/ethers-solc/src/compile/output/mod.rs
+++ b/ethers-solc/src/compile/output/mod.rs
@@ -366,6 +366,14 @@ impl AggregatedCompilerOutput {
         (self.sources, self.contracts)
     }
 
+    /// Joins all file path with `root`
+    pub fn join_all(&mut self, root: impl AsRef<Path>) -> &mut Self {
+        let root = root.as_ref();
+        self.contracts.join_all(root);
+        self.sources.join_all(root);
+        self
+    }
+
     /// Strips the given prefix from all file paths to make them relative to the given
     /// `base` argument.
     ///

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -141,10 +141,12 @@ impl<T: ArtifactOutput> Project<T> {
     ///
     /// This will set the `--allow-paths` to the paths configured for the `Project`, if any.
     fn configure_solc(&self, mut solc: Solc) -> Solc {
-        if solc.args.is_empty() && !self.allowed_lib_paths.0.is_empty() {
+        if !self.allowed_lib_paths.0.is_empty() &&
+            !solc.args.iter().any(|arg| arg == "--allow-paths")
+        {
             solc = solc.arg("--allow-paths").arg(self.allowed_lib_paths.to_string());
         }
-        solc
+        solc.with_base_path(self.root())
     }
 
     /// Sets the maximum number of parallel `solc` processes to run simultaneously.

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -55,6 +55,14 @@ impl Remapping {
     pub fn into_relative(self, root: impl AsRef<Path>) -> RelativeRemapping {
         RelativeRemapping::new(self, root)
     }
+
+    /// Removes the `base` path from the remapping
+    pub fn strip_prefix(&mut self, base: impl AsRef<Path>) -> &mut Self {
+        if let Ok(stripped) = Path::new(&self.path).strip_prefix(base.as_ref()) {
+            self.path = format!("{}", stripped.display());
+        }
+        self
+    }
 }
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq, PartialOrd)]

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -1434,7 +1434,6 @@ fn can_detect_contract_def_source_files() {
         .unwrap();
 
     let compiled = tmp.compile().unwrap();
-    println!("{}", compiled);
     assert!(!compiled.has_compiler_errors());
 
     let mut sources = compiled.output().sources;
@@ -1750,7 +1749,6 @@ contract D { }
         .unwrap();
 
     let compiled = project.compile().unwrap();
-    println!("{}", compiled);
     assert!(!compiled.has_compiler_errors());
 
     let cache = SolFilesCache::read(project.cache_path()).unwrap();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes #1315

working with paths is hard.

Ideally, we want to work with absolute paths because we resolve them in the Graph anyway and `Project::root` is not guaranteed to be cwd.

however, absolute/relative paths result in different solc metadata, so when invoking solc, we want to be consistent, or rather OS and local disk independent.

with 0.6.9, solc supports a `--base-path` option so we use that instead and also set the cwd of the solc process to `Project::root`.

This also introduces the `CompilerInput::with_base_path` function that will strip `Project::root` from:
* source paths
* output selection
* remappings 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
