### PR TITLE
fix(abigen): clippy warnings on solidity bindings

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -49,7 +49,7 @@ impl ExpandedContract {
            // export all the created data types
             pub use #module::*;
 
-            #[allow(clippy::too_many_arguments)]
+            #[allow(clippy::too_many_arguments, non_camel_case_types)]
             mod #module {
                 #imports
                 #contract


### PR DESCRIPTION
## Motivation

disable clippy warnings for solidity contracts with non-standard names (yvVaults, console, etc)

```
❯ cargo check
warning: type `console` should have an upper camel case name
  --> bindings/src/console.rs:26:16
   |
26 |     pub struct console<M>(ethers::contract::Contract<M>);
   |                ^^^^^^^ help: convert the identifier to upper camel case (notice the capitalization): `Console`
   |
   = note: `#[warn(non_camel_case_types)]` on by default
```

## Solution

add `allow(non_camel_case_types)` to binding namespace

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
