### PR TITLE
Add Arithmetic Shift Right operation for I256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
   [#1184](https://github.com/gakonst/ethers-rs/pull/1184)
 - Add `From<H160>` and From<Vec<H160>> traits to `ValueOrArray<H160>` [#1199](https://github.com/gakonst/ethers-rs/pull/1200)
 - Fix handling of Websocket connection errors [#1287](https://github.com/gakonst/ethers-rs/pull/1287)
+- Add Arithmetic Shift Right operation for I256 [#1323](https://github.com/gakonst/ethers-rs/issues/1323)
 
 ## ethers-contract-abigen
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Add the arithmetic shift right operation for I256 type.

## Solution
Add a function to perform asr.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
