### PR TITLE
fix(solc): emit empty bytecode objects for standalone sol files

### DIFF
--- a/ethers-solc/src/artifact_output/configurable.rs
+++ b/ethers-solc/src/artifact_output/configurable.rs
@@ -339,6 +339,8 @@ impl ArtifactOutput for ConfigurableArtifacts {
         file.source_file.ast.clone().map(|ast| ConfigurableContractArtifact {
             id: Some(file.source_file.id),
             ast: Some(ast),
+            bytecode: Some(CompactBytecode::empty()),
+            deployed_bytecode: Some(CompactDeployedBytecode::empty()),
             ..Default::default()
         })
     }

--- a/ethers-solc/src/artifacts/bytecode.rs
+++ b/ethers-solc/src/artifacts/bytecode.rs
@@ -46,6 +46,11 @@ pub struct CompactBytecode {
 }
 
 impl CompactBytecode {
+    /// Returns a new `CompactBytecode` object that contains nothing, as it's the case for
+    /// interfaces and standalone solidity files that don't contain any contract definitions
+    pub fn empty() -> Self {
+        Self { object: Default::default(), source_map: None, link_references: Default::default() }
+    }
     /// Returns the parsed source map
     ///
     /// See also <https://docs.soliditylang.org/en/v0.8.10/internals/source_mappings.html>
@@ -398,6 +403,14 @@ pub struct CompactDeployedBytecode {
         skip_serializing_if = "::std::collections::BTreeMap::is_empty"
     )]
     pub immutable_references: BTreeMap<String, Vec<Offsets>>,
+}
+
+impl CompactDeployedBytecode {
+    /// Returns a new `CompactDeployedBytecode` object that contains nothing, as it's the case for
+    /// interfaces and standalone solidity files that don't contain any contract definitions
+    pub fn empty() -> Self {
+        Self { bytecode: Some(CompactBytecode::empty()), immutable_references: Default::default() }
+    }
 }
 
 impl From<DeployedBytecode> for CompactDeployedBytecode {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/1736

emit an empty bytecode object if file doesn't contain any contract definitions, same behavior as solc does with interfaces.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
