### PR TITLE
fix(solc): remove compile_exact restriction

### DIFF
--- a/ethers-solc/src/compile/project.rs
+++ b/ethers-solc/src/compile/project.rs
@@ -480,7 +480,7 @@ fn compile_sequential(
 
             let start = Instant::now();
             report::solc_spawn(&solc, &version, &input, &actually_dirty);
-            let output = solc.compile_exact(&input)?;
+            let output = solc.compile(&input)?;
             report::solc_success(&solc, &version, &output, &start.elapsed());
             tracing::trace!("compiled input, output has error: {}", output.has_error());
             tracing::trace!("received compiler output: {:?}", output.contracts.keys());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/1776

this removes the `compile_exact` restriction, which after some investigation can cause some issues in following circumstances:
* paths (or keys) of the contracts in the output differ from the input keys on windows
* if we failed to resolve the complete graph properly (likely due to some parser limitations) this can filter out those contracts we missed but solc includes in the output.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
