### PR TITLE
fix: use decimal crate for parsing units

### DIFF
--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -40,6 +40,7 @@ cargo_metadata = { version = "0.14.2", optional = true }
 convert_case = { version = "0.5.0", optional = true }
 syn = { version = "1.0.95", optional = true }
 proc-macro2 = { version = "1.0.39", optional = true }
+rust_decimal = "1.23.1"
 
 [dev-dependencies]
 serde_json = { version = "1.0.64", default-features = false }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/1779
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use https://github.com/paupino/rust-decimal when converting units
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
