### PR TITLE
fix(abigen): non-snake-case modules out of order

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -558,13 +558,13 @@ serde_json = "1.0.79"
 
     /// Append module declarations to the `lib.rs` or `mod.rs`
     fn append_module_names(&self, mut buf: impl Write) -> Result<()> {
-        let mut mod_names: BTreeSet<_> = self.bindings.keys().collect();
+        let mut mod_names: BTreeSet<_> =
+            self.bindings.keys().map(|name| name.to_snake_case()).collect();
         if let Some(ref shared) = self.shared_types {
-            mod_names.insert(&shared.name);
+            mod_names.insert(shared.name.to_snake_case());
         }
 
-        for module in mod_names.into_iter().map(|name| format!("pub mod {};", name.to_snake_case()))
-        {
+        for module in mod_names.into_iter().map(|name| format!("pub mod {};", name)) {
             writeln!(buf, "{}", module)?;
         }
 


### PR DESCRIPTION
re: #1319 

eg: `console` and `shared_types` were out of order and fail rustfmt check

```diff
❯ cargo +nightly fmt --all -- --check
Diff in ./lib.rs at line 5:
 //! These files may be overwritten by the codegen system at any time.
 pub mod abstract_strategy;
 pub mod account;
+pub mod console;
 pub mod contract_test;
 pub mod ds_test;
 pub mod erc165;
Diff in ./lib.rs at line 21:
 pub mod pool;
 pub mod safe_helper;
+pub mod shared_types;
 pub mod tick_math;
 pub mod vault;
Diff in ./lib.rs at line 27:
-pub mod console;
-pub mod shared_types;
```

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
