### PR TITLE
make abigen-ed modules pub

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -50,7 +50,7 @@ impl ExpandedContract {
             pub use #module::*;
 
             #[allow(clippy::too_many_arguments, non_camel_case_types)]
-            mod #module {
+            pub mod #module {
                 #imports
                 #contract
                 #events


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Allows end-users to work around https://github.com/gakonst/ethers-rs/issues/867

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This makes it possible to refer directly to generated types when they have the same name (as occurs with event filter types when one contract inherits another).

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
