### PR TITLE
feat(solc): emit build info files if configured

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -1403,6 +1404,7 @@ name = "ethers-solc"
 version = "0.3.0"
 dependencies = [
  "cfg-if 1.0.0",
+ "chrono",
  "colored",
  "criterion",
  "dunce",
@@ -3822,6 +3824,16 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
@@ -4520,7 +4532,7 @@ dependencies = [
  "signature",
  "subtle",
  "thiserror",
- "time",
+ "time 0.3.7",
  "uuid",
  "zeroize",
 ]

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -40,6 +40,7 @@ rayon = "1.5.3"
 rand = { version = "0.8.5", optional = true }
 path-slash = "0.1.4"
 cfg-if = "1.0.0"
+chrono = "0.4.19"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 home = "0.5.3"

--- a/ethers-solc/src/artifacts/serde_helpers.rs
+++ b/ethers-solc/src/artifacts/serde_helpers.rs
@@ -78,7 +78,7 @@ pub mod json_string_opt {
 pub mod empty_json_object_opt {
     use serde::{
         de::{self, DeserializeOwned},
-        ser, Deserialize, Deserializer, Serialize, Serializer,
+        Deserialize, Deserializer, Serialize, Serializer,
     };
 
     pub fn serialize<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
@@ -87,8 +87,7 @@ pub mod empty_json_object_opt {
         T: Serialize,
     {
         if let Some(value) = value {
-            let value = serde_json::to_string(value).map_err(ser::Error::custom)?;
-            serializer.serialize_str(&value)
+            value.serialize(serializer)
         } else {
             let empty = serde_json::Value::Object(Default::default());
             serde_json::Value::serialize(&empty, serializer)

--- a/ethers-solc/src/buildinfo.rs
+++ b/ethers-solc/src/buildinfo.rs
@@ -1,0 +1,72 @@
+//! Represents an entire build
+
+use crate::{utils, CompilerInput, CompilerOutput, SolcError};
+use semver::Version;
+use serde::{ser::SerializeStruct, Deserialize, Serialize, Serializer};
+use std::path::Path;
+
+pub const ETHERS_FORMAT_VERSION: &str = "ethers-rs-sol-build-info-1";
+
+// A hardhat compatible build info representation
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildInfo {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(rename = "_format")]
+    pub format: String,
+    pub solc_version: Version,
+    pub solc_long_version: Version,
+    pub input: CompilerInput,
+    pub output: CompilerOutput,
+}
+
+impl BuildInfo {
+    /// Deserializes the `BuildInfo` object from the given file
+    pub fn read(path: impl AsRef<Path>) -> Result<Self, SolcError> {
+        utils::read_json_file(path)
+    }
+
+    /// Serializes a `BuildInfo` object as String
+    pub fn serialize_to_string(
+        input: &CompilerInput,
+        output: &CompilerOutput,
+        version: &Version,
+    ) -> serde_json::Result<String> {
+        let mut w = Vec::with_capacity(128);
+        let mut serializer = serde_json::Serializer::pretty(&mut w);
+        let mut s = serializer.serialize_struct("BuildInfo", 5)?;
+        s.serialize_field("_format", &ETHERS_FORMAT_VERSION)?;
+        let solc_short = format!("{}.{}.{}", version.major, version.minor, version.patch);
+        s.serialize_field("solcVersion", &solc_short)?;
+        s.serialize_field("solcLongVersion", &version)?;
+        s.serialize_field("input", input)?;
+        s.serialize_field("output", output)?;
+        s.end()?;
+
+        let string = unsafe {
+            // serde_json does not emit non UTF8
+            String::from_utf8_unchecked(w)
+        };
+        Ok(string)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Source;
+    use std::{collections::BTreeMap, path::PathBuf};
+
+    #[test]
+    fn build_info_serde() {
+        let inputs = CompilerInput::with_sources(BTreeMap::from([(
+            PathBuf::from("input.sol"),
+            Source { content: "".to_string() },
+        )]));
+        let output = CompilerOutput::default();
+        let v: Version = "0.8.4+commit.c7e474f2".parse().unwrap();
+        let content = BuildInfo::serialize_to_string(&inputs[0], &output, &v).unwrap();
+        let _info: BuildInfo = serde_json::from_str(&content).unwrap();
+    }
+}

--- a/ethers-solc/src/compile/project.rs
+++ b/ethers-solc/src/compile/project.rs
@@ -104,6 +104,7 @@
 use crate::{
     artifact_output::Artifacts,
     artifacts::{Settings, VersionedFilteredSources, VersionedSources},
+    buildinfo::BuildInfo,
     cache::ArtifactsCache,
     error::Result,
     filter::SparseOutputFilter,
@@ -240,11 +241,13 @@ impl<'a, T: ArtifactOutput> PreprocessedState<'a, T> {
     /// advance to the next state by compiling all sources
     fn compile(self) -> Result<CompiledState<'a, T>> {
         let PreprocessedState { sources, cache, sparse_output } = self;
+        let project = cache.project();
         let mut output = sources.compile(
-            &cache.project().solc_config.settings,
-            &cache.project().paths,
+            &project.solc_config.settings,
+            &project.paths,
             sparse_output,
             cache.graph(),
+            project.build_info,
         )?;
 
         // source paths get stripped before handing them over to solc, so solc never uses absolute
@@ -288,11 +291,16 @@ impl<'a, T: ArtifactOutput> CompiledState<'a, T> {
                 output.sources.len()
             );
             // this emits the artifacts via the project's artifacts handler
-            project.artifacts_handler().on_output(
+            let artifacts = project.artifacts_handler().on_output(
                 &output.contracts,
                 &output.sources,
                 &project.paths,
-            )?
+            )?;
+
+            // emits all the build infos, if they exist
+            output.write_build_infos(project.build_info_path())?;
+
+            artifacts
         };
 
         Ok(ArtifactsState { output, cache, compiled_artifacts })
@@ -391,13 +399,14 @@ impl FilteredCompilerSources {
         paths: &ProjectPathsConfig,
         sparse_output: SparseOutputFilter,
         graph: &GraphEdges,
+        create_build_info: bool,
     ) -> Result<AggregatedCompilerOutput> {
         match self {
             FilteredCompilerSources::Sequential(input) => {
-                compile_sequential(input, settings, paths, sparse_output, graph)
+                compile_sequential(input, settings, paths, sparse_output, graph, create_build_info)
             }
             FilteredCompilerSources::Parallel(input, j) => {
-                compile_parallel(input, j, settings, paths, sparse_output, graph)
+                compile_parallel(input, j, settings, paths, sparse_output, graph, create_build_info)
             }
         }
     }
@@ -419,6 +428,7 @@ fn compile_sequential(
     paths: &ProjectPathsConfig,
     sparse_output: SparseOutputFilter,
     graph: &GraphEdges,
+    create_build_info: bool,
 ) -> Result<AggregatedCompilerOutput> {
     let mut aggregated = AggregatedCompilerOutput::default();
     tracing::trace!("compiling {} jobs sequentially", input.len());
@@ -484,6 +494,13 @@ fn compile_sequential(
             report::solc_success(&solc, &version, &output, &start.elapsed());
             tracing::trace!("compiled input, output has error: {}", output.has_error());
             tracing::trace!("received compiler output: {:?}", output.contracts.keys());
+
+            // if configured also create the build info
+            if create_build_info {
+                let build_info = BuildInfo::serialize_to_string(&input, &output, &version)?;
+                aggregated.build_infos.insert(version.clone(), build_info);
+            }
+
             aggregated.extend(version.clone(), output);
         }
     }
@@ -498,6 +515,7 @@ fn compile_parallel(
     paths: &ProjectPathsConfig,
     sparse_output: SparseOutputFilter,
     graph: &GraphEdges,
+    create_build_info: bool,
 ) -> Result<AggregatedCompilerOutput> {
     debug_assert!(num_jobs > 1);
     tracing::trace!(
@@ -580,14 +598,21 @@ fn compile_parallel(
                 report::solc_spawn(&solc, &version, &input, &actually_dirty);
                 solc.compile(&input).map(move |output| {
                     report::solc_success(&solc, &version, &output, &start.elapsed());
-                    (version, output)
+                    (version, input, output)
                 })
             })
             .collect::<Result<Vec<_>>>()
     })?;
 
     let mut aggregated = AggregatedCompilerOutput::default();
-    aggregated.extend_all(outputs);
+    for (version, input, output) in outputs {
+        // if configured also create the build info
+        if create_build_info {
+            let build_info = BuildInfo::serialize_to_string(&input, &output, &version)?;
+            aggregated.build_infos.insert(version.clone(), build_info);
+        }
+        aggregated.extend(version, output);
+    }
 
     Ok(aggregated)
 }

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    io,
+    fs, io,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -13,6 +13,7 @@ use ethers_solc::{
         BytecodeHash, Libraries, ModelCheckerEngine::CHC, ModelCheckerSettings, UserDoc,
         UserDocNotice,
     },
+    buildinfo::BuildInfo,
     cache::{SolFilesCache, SOLIDITY_FILES_CACHE_FILENAME},
     project_util::*,
     remappings::Remapping,
@@ -308,6 +309,45 @@ fn can_compile_dapp_detect_changes_in_sources() {
         let other = artifacts.remove(&p).unwrap();
         assert_ne!(artifact, other);
     }
+}
+
+#[test]
+fn can_emit_build_info() {
+    let mut project = TempProject::dapptools().unwrap();
+    project.project_mut().build_info = true;
+    project
+        .add_source(
+            "A",
+            r#"
+pragma solidity ^0.8.10;
+import "./B.sol";
+contract A { }
+"#,
+        )
+        .unwrap();
+
+    project
+        .add_source(
+            "B",
+            r#"
+pragma solidity ^0.8.10;
+contract B { }
+"#,
+        )
+        .unwrap();
+
+    let compiled = project.compile().unwrap();
+    assert!(!compiled.has_compiler_errors());
+
+    let info_dir = project.project().build_info_path();
+    assert!(info_dir.exists());
+
+    let mut build_info_count = 0;
+    for entry in fs::read_dir(info_dir).unwrap() {
+        let _info = BuildInfo::read(entry.unwrap().path()).unwrap();
+        build_info_count += 1;
+    }
+    assert_eq!(build_info_count, 1);
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Emit build-info files that include the whole compiler(input, output) and version.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

* Create bindings for `BuildInfo`
* If configured in the project we create a `BuildInfo` instance for each solc invocation.
* build-infos are stored as `<root>/build-info/<solc>-<timestamp>.json`, this differs from hardhat which uses the content hash as file name, like `0.8.14+commit.80d49f37.Darwin.appleclang-2022-06-02T12:17:16.944469+00:00.json`

wdyt @tynes ?

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
