### PR TITLE
feat(provider): Add batching for JSON-RPC requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Unreleased
 
-- Add batching of JSON-RPC requests via the addition of `BathRequest`.
+- Add batching of JSON-RPC requests via the addition of `BatchRequest`.
   [#1339](https://github.com/gakonst/ethers-rs/pull/1339)
 - Add `as_*_mut` methods on `TypedTransaction`
   [#1310](https://github.com/gakonst/ethers-rs/pull/1310)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Unreleased
 
+- Add batching of JSON-RPC requests via the addition of `BathRequest`.
+  [#1339](https://github.com/gakonst/ethers-rs/pull/1339)
 - Add `as_*_mut` methods on `TypedTransaction`
   [#1310](https://github.com/gakonst/ethers-rs/pull/1310)
 - AWS EIP712 data signing no longer signs with EIP155

--- a/ethers-providers/src/transports/common.rs
+++ b/ethers-providers/src/transports/common.rs
@@ -1,8 +1,9 @@
 // Code adapted from: https://github.com/althea-net/guac_rs/tree/master/web3/src/jsonrpc
-use std::fmt;
+
+use std::{boxed::Box, fmt};
 
 use serde::{
-    de::{self, MapAccess, Unexpected, Visitor},
+    de::{self, DeserializeOwned, MapAccess, Unexpected, Visitor},
     Deserialize, Serialize,
 };
 use serde_json::{value::RawValue, Value};
@@ -54,6 +55,199 @@ pub enum Response<'a> {
     Success { id: u64, result: &'a RawValue },
     Error { id: u64, error: JsonRpcError },
     Notification { method: &'a str, params: Params<'a> },
+}
+
+/// Error thrown when handling batches of JSON-RPC request and responses.
+#[derive(Error, Debug)]
+pub enum BatchError {
+    /// Thrown if deserialization failed
+    #[error(transparent)]
+    JsonError(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    /// Thrown if a response could not be parsed
+    JsonRpcError(#[from] JsonRpcError),
+
+    /// Thrown if the batch is empty.
+    EmptyBatch,
+}
+
+impl std::fmt::Display for BatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyBatch => write!(f, "The batch is empty."),
+            other => other.fmt(f),
+        }
+    }
+}
+
+/// A batch of JSON-RPC requests.
+#[derive(Clone, Debug, Default)]
+pub struct BatchRequest {
+    requests: Vec<Value>,
+}
+
+impl BatchRequest {
+    /// Creates a new empty batch of JSON-RPC requests.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ethers_providers::BatchRequest;
+    /// // Creates an empty batch.
+    /// let batch = BatchRequest::new();
+    /// ```
+    pub fn new() -> Self {
+        Self { requests: Vec::new() }
+    }
+
+    /// Creates a new empty batch with the specified capacity.
+    ///
+    /// # Arguments
+    ///
+    /// `capacity` -  capacity of the new empty batch of JSON-RPC requests.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ethers_providers::BatchRequest;
+    /// // Creates an empty batch with a pre-allocated capacity of 10.
+    /// let batch = BatchRequest::with_capacity(10);
+    /// ```
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self { requests: Vec::with_capacity(capacity) }
+    }
+
+    /// Returns the number of requests in the batch.
+    pub fn len(&self) -> usize {
+        self.requests.len()
+    }
+
+    /// Adds a new request to the batch.
+    ///
+    /// # Arguments
+    ///
+    /// * `method` - method for the JSON-RPC RPC request.
+    ///
+    /// * `params` - parameters for the JSON-RPC request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() -> Result<(), ethers_providers::BatchError> {
+    /// use ethers_providers::BatchRequest;
+    /// # use ethers_core::types::{Address, H256, BlockNumber};
+    /// # let address: Address = "0xd5a37dC5C9A396A03dd1136Fc76A1a02B1c88Ffa".parse().unwrap();
+    /// # let pos = H256::from_low_u64_be(8);
+    /// // Creates an empty batch.
+    /// let mut batch = BatchRequest::new();
+    /// // Adds a request to the batch.
+    /// batch.add_request("eth_getStorageAt", (address, pos, BlockNumber::Latest))?;
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn add_request<T>(&mut self, method: &str, params: T) -> Result<(), BatchError>
+    where
+        T: Serialize,
+    {
+        self.requests.push(serde_json::to_value(&Request::new(0, method, params))?);
+
+        Ok(())
+    }
+
+    /// Sets the ids of the requests.
+    ///
+    /// # Arguments
+    ///
+    /// `first` - id for the first request in the batch.
+    ///
+    /// # Panics
+    ///
+    /// If one of the requests is malformed.
+    pub(crate) fn set_ids(&mut self, mut first: u64) -> Result<(), BatchError> {
+        for request in self.requests_mut()? {
+            *request
+                .get_mut("id")
+                .expect("Malformed JSON-RPC request: {request}, id is missing.") = first.into();
+            first += 1;
+        }
+
+        Ok(())
+    }
+
+    /// Returns a mutable reference to the underlying JSON-RPC requests.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BatchError::EmptyBatch` if the batch is empty.
+    pub(crate) fn requests_mut(&mut self) -> Result<&mut [Value], BatchError> {
+        (self.requests.len() > 0).then(move || &mut self.requests[..]).ok_or(BatchError::EmptyBatch)
+    }
+
+    /// Returns an immutable reference to the underlying JSON-RPC requests.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BatchError::EmptyBatch` if the batch is empty.
+    pub(crate) fn requests(&self) -> Result<&[Value], BatchError> {
+        (self.requests.len() > 0).then(|| &self.requests[..]).ok_or(BatchError::EmptyBatch)
+    }
+}
+
+/// A batch of JSON-RPC responses.
+#[derive(Clone, Debug)]
+pub struct BatchResponse {
+    responses: Vec<(u64, Result<Box<RawValue>, JsonRpcError>)>,
+}
+
+impl BatchResponse {
+    /// Creates a new batch of JSON-RPC responses.
+    ///
+    /// # Arguments
+    ///
+    /// `responses` - vector of JSON-RPC responses.
+    pub(crate) fn new(responses: Vec<Response>) -> Self {
+        let mut responses = responses
+            .into_iter()
+            .map(|response| match response {
+                Response::Success { id, result } => (id, Ok(result.to_owned())),
+                Response::Error { id, error } => (id, Err(error)),
+                _ => unreachable!(),
+            })
+            .collect::<Vec<(u64, Result<Box<RawValue>, JsonRpcError>)>>();
+        // Sort the responses by descending id, as the order the requests were issued and the order
+        // the responses were given may differ. Order is reversed because we pop elements when
+        // retrieving the responses.
+        responses.sort_by_key(|(id, _)| std::cmp::Reverse(*id));
+
+        Self { responses }
+    }
+
+    /// Returns the id of the batch, that is the id of the first response.
+    pub(crate) fn id(&self) -> Result<u64, BatchError> {
+        // The id of the first request in the batch, be it successful or not, corresponds to the
+        // id of the channel to send the response into.
+        self.responses.last().map(|(id, _)| *id).ok_or(BatchError::EmptyBatch)
+    }
+
+    /// Returns the next response in the batch or `None` if the batch is empty.
+    ///
+    /// # Errors
+    ///
+    /// Returns the error corresponding to a given JSON-RPC request if it failed.
+    pub fn next_response<T>(&mut self) -> Option<Result<T, BatchError>>
+    where
+        T: DeserializeOwned,
+    {
+        // The order is reversed.
+        let item = self.responses.pop();
+        // Deserializes and returns the response.
+        item.map(|(_, body)| {
+            body.map_err(Into::into)
+                .and_then(|res| serde_json::from_str::<T>(res.get()).map_err(Into::into))
+        })
+    }
 }
 
 #[derive(Deserialize, Debug)]

--- a/ethers-providers/src/transports/common.rs
+++ b/ethers-providers/src/transports/common.rs
@@ -123,6 +123,11 @@ impl BatchRequest {
         self.requests.len()
     }
 
+    /// Returns whether the batch is empty or not.
+    pub fn is_empty(&self) -> bool {
+        self.requests.is_empty()
+    }
+
     /// Adds a new request to the batch.
     ///
     /// # Arguments
@@ -166,7 +171,8 @@ impl BatchRequest {
     ///
     /// If one of the requests is malformed.
     pub(crate) fn set_ids(&mut self, mut first: u64) -> Result<(), BatchError> {
-        for request in self.requests_mut()? {
+        let requests = self.requests_mut()?;
+        for request in requests {
             *request
                 .get_mut("id")
                 .expect("Malformed JSON-RPC request: {request}, id is missing.") = first.into();
@@ -182,7 +188,7 @@ impl BatchRequest {
     ///
     /// Returns `BatchError::EmptyBatch` if the batch is empty.
     pub(crate) fn requests_mut(&mut self) -> Result<&mut [Value], BatchError> {
-        (self.requests.len() > 0).then(move || &mut self.requests[..]).ok_or(BatchError::EmptyBatch)
+        (!self.is_empty()).then(move || &mut self.requests[..]).ok_or(BatchError::EmptyBatch)
     }
 
     /// Returns an immutable reference to the underlying JSON-RPC requests.
@@ -191,7 +197,7 @@ impl BatchRequest {
     ///
     /// Returns `BatchError::EmptyBatch` if the batch is empty.
     pub(crate) fn requests(&self) -> Result<&[Value], BatchError> {
-        (self.requests.len() > 0).then(|| &self.requests[..]).ok_or(BatchError::EmptyBatch)
+        (!self.is_empty()).then(|| &self.requests[..]).ok_or(BatchError::EmptyBatch)
     }
 }
 
@@ -247,6 +253,16 @@ impl BatchResponse {
             body.map_err(Into::into)
                 .and_then(|res| serde_json::from_str::<T>(res.get()).map_err(Into::into))
         })
+    }
+
+    /// Returns the number of responses contained in the batch.
+    pub fn len(&self) -> usize {
+        self.responses.len()
+    }
+
+    /// Returns whether the batch is empty or not.
+    pub fn is_empty(&self) -> bool {
+        self.responses.is_empty()
     }
 }
 

--- a/ethers-providers/src/transports/mod.rs
+++ b/ethers-providers/src/transports/mod.rs
@@ -1,5 +1,5 @@
 mod common;
-pub use common::Authorization;
+pub use common::{Authorization, BatchError, BatchRequest, BatchResponse};
 
 // only used with WS
 #[cfg(feature = "ws")]

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -460,7 +460,7 @@ where
         futures_util::select! {
             // Handle requests
             instruction = self.instructions.select_next_some() => {
-                self.service(instruction).await?;
+                self.service(instruction).await;
             },
             // Handle ws messages
             resp = self.ws.next() => match resp {


### PR DESCRIPTION
The `BatchRequest` struct is added and it allows for sending multiple JSON-RPC requests in a single batch.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

ethers-rs is currently lacking batching of multiple JSON-RPC requests. There are many use-cases for such functionality and hereby an implementation is proposed.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

A new struct, namely, `BatchRequest`, is introduced.  `BatchRequest` acts a simple, generic, container of JSON-RPC requests. 

Batches are created as follows:

```rust
use ethers::prelude::*;
// Creates a new, empty, batch.
let batch = BatchRequest::new();
```

If the user already knows the number of requests it is going to send, `BatchRequest::with_capacity` can be used instead:

```rust
use ethers::prelude::*;
// Creates a new, empty, batch, with a pre-allocated capacity of 10.
let batch = BatchRequest::with_capacity(10);
```

`BatchRequest` is agnostic of the underlying requests, both in terms of parameters and return types, as long as they can be serialised and deserialised. Adding JSON-RPC requests to batches is as simple as:

```rust
use ethers::prelude::*;

let address1: Address = "0xd5a37dC5C9A396A03dd1136Fc76A1a02B1c88Ffa".parse()?;
let address2: Address = "0x4d7450da3abc67663c6C3989B4c84F35e5D0B5fC".parse()?;

let pos = H256::from_low_u64_be(8);

let mut batch: BatchRequest = BatchRequest::with_capacity(2);
// All kinds of JSON-RPC requests can go here.
batch.add_request("eth_getStorageAt", (address1, pos, BlockNumber::Latest))?;
batch.add_request("eth_getStorageAt", (address2, pos, BlockNumber::Latest))?;
```

Furthermore, batches created with `BatchRequest` can be executed by providers. The same batch can be executed by manyfold providers, as shown in the following example:

```rust
use ethers::prelude::*;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let address1: Address = "0xd5a37dC5C9A396A03dd1136Fc76A1a02B1c88Ffa".parse()?;
    let address2: Address = "0x4d7450da3abc67663c6C3989B4c84F35e5D0B5fC".parse()?;

    let pos = H256::from_low_u64_be(8);

    let mut batch = BatchRequest::with_capacity(2);
    batch.add_request("eth_getStorageAt", (address1, pos, BlockNumber::Latest))?;
    batch.add_request("eth_getStorageAt", (address2, pos, BlockNumber::Latest))?;

    let http_client = Provider::<Http>::try_from("https://api.avax.network/ext/bc/C/rpc")?;
    let ws_client = Provider::<Ws>::connect(
        "wss://speedy-nodes-nyc.moralis.io/bdc23feb8c3bd2b3e8d6a716/avalanche/mainnet/ws",
    )
    .await?;

    let mut ws_responses: BatchResponse = ws_client.as_ref().execute_batch(&mut batch).await?;
    let mut http_responses: BatchResponse = http_client.as_ref().execute_batch(&mut batch).await?;

    while let Some(Ok(storage)) = ws_responses.next_response::<H256>() {
        println!("{storage:?}")
    }

    while let Some(Ok(storage)) = http_responses.next_response::<H256>() {
        println!("{storage:?}")
    }

    Ok(())
}
```

out:

```text
0x6298ae7d00000000399dcf6078402dab87ab000000000000000000050ae7bd47
0x6298af7d0000000000d41171d7825e495f8e00000421fcd185b36af97a5abe6e
0x6298ae7d00000000399dcf6078402dab87ab000000000000000000050ae7bd47
0x6298af7d0000000000d41171d7825e495f8e00000421fcd185b36af97a5abe6e
```

As shown, batches can be re-used and cached.

The user gets back a `BatchResponse` struct, which implements the `next_response` method. Responses are retrieved and deserialised, as also shown.

I implemented a `.execute_batch()` method for the `Provider` struct, more precisely, such method is implemented for 3 transports: http, ws and icp. I did not put it in the `JsonRpcClient` trait, as to proceed in that direction I felt that someone else's opinion was needed.

Transports implementation needed only minor modifications to accommodate such change.

### Request and response ids

To match requests and responses in the transport layer, and to preserve the order of issued responses with respect to requests, the following solution is adopted, in order:

1. The provider's `id` is incremented by the length of the batch and fetched.
2. `BatchRequest` sequentially populates the ids of the inner requests starting from the latter id.
3. Such id is then attached to the batch instruction, which is sent by the provider to the inner transport.
4. `BatchResponse` sorts the responses in descending order with respect to their ids. 
5. The id of the first response in the batch is used to uniquely determine the channel to send the response into in the transport layer. 


It's important to note that we forbid the user from sending empty batches by raising `BatchError::EmptyBatch`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
