### PR TITLE
fix(solc): emit empty vec for empty artifacts

### DIFF
--- a/ethers-solc/src/artifact_output/configurable.rs
+++ b/ethers-solc/src/artifact_output/configurable.rs
@@ -337,6 +337,7 @@ impl ArtifactOutput for ConfigurableArtifacts {
         file: &VersionedSourceFile,
     ) -> Option<Self::Artifact> {
         file.source_file.ast.clone().map(|ast| ConfigurableContractArtifact {
+            abi: Some(LosslessAbi::default()),
             id: Some(file.source_file.id),
             ast: Some(ast),
             bytecode: Some(CompactBytecode::empty()),

--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -1318,12 +1318,18 @@ impl OutputContracts {
 /// ethabi as it would require a redesign of the overall `Param` and `ParamType` types. Instead,
 /// this type keeps a copy of the [`serde_json::Value`] when deserialized from the `solc` json
 /// compiler output and uses it to serialize the `abi` without loss.
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct LosslessAbi {
     /// The complete abi as json value
     pub abi_value: serde_json::Value,
     /// The deserialised version of `abi_value`
     pub abi: Abi,
+}
+
+impl Default for LosslessAbi {
+    fn default() -> Self {
+        LosslessAbi { abi_value: serde_json::json!([]), abi: Default::default() }
+    }
 }
 
 impl From<LosslessAbi> for Abi {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Ref https://github.com/gakonst/ethers-rs/issues/1325#issuecomment-1146226072

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use an empty vec for artifacts without any contract definitions instead of default `null`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
