### PR TITLE
test: set nonce explicitly

### DIFF
--- a/ethers-providers/src/call_raw.rs
+++ b/ethers-providers/src/call_raw.rs
@@ -495,10 +495,10 @@ pub mod spoof {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Http, Middleware, Provider};
+    use crate::{Http, Provider};
     use ethers_core::{
         types::TransactionRequest,
-        utils::{get_contract_address, keccak256, parse_ether, Anvil, Geth},
+        utils::{get_contract_address, keccak256, parse_ether, Geth},
     };
     use std::convert::TryFrom;
 
@@ -516,7 +516,7 @@ mod tests {
     }
 
     // Tests "roundtrip" serialization of calls: deserialize(serialize(call)) == call
-    fn test_encode<'a, P>(call: CallBuilder<'a, P>) {
+    fn test_encode<P>(call: CallBuilder<P>) {
         let input = call.unwrap().input;
         let ser = utils::serialize(&input).to_string();
         let de: CallInputOwned = serde_json::from_str(&ser).unwrap();

--- a/ethers-providers/src/pending_escalator.rs
+++ b/ethers-providers/src/pending_escalator.rs
@@ -190,7 +190,7 @@ where
                 poll_broadcast_fut!(cx, this, fut);
             }
             Sleeping(delay) => {
-                let _ready = futures_util::ready!(delay.as_mut().poll(cx));
+                futures_util::ready!(delay.as_mut().poll(cx));
                 // if broadcast timer has elapsed and if we have a TX to
                 // broadcast, broadcast it
                 if this.last.elapsed() > *this.broadcast_interval {

--- a/ethers-providers/src/pending_transaction.rs
+++ b/ethers-providers/src/pending_transaction.rs
@@ -172,7 +172,7 @@ impl<'a, P: JsonRpcClient> Future for PendingTransaction<'a, P> {
 
         match this.state {
             PendingTxState::InitialDelay(fut) => {
-                let _ready = futures_util::ready!(fut.as_mut().poll(ctx));
+                futures_util::ready!(fut.as_mut().poll(ctx));
                 tracing::debug!("Starting to poll pending tx {:?}", *this.tx_hash);
                 let fut = Box::pin(this.provider.get_transaction(*this.tx_hash));
                 rewake_with_new_state!(ctx, this, PendingTxState::GettingTx(fut));

--- a/ethers-providers/src/stream.rs
+++ b/ethers-providers/src/stream.rs
@@ -284,9 +284,13 @@ mod tests {
         let tx = TransactionRequest::new().from(accounts[0]).to(accounts[0]).value(1e18 as u64);
 
         let mut sending = futures_util::future::join_all(
-            std::iter::repeat(tx.clone()).take(num_txs).map(|tx| async {
-                provider.send_transaction(tx, None).await.unwrap().await.unwrap().unwrap()
-            }),
+            std::iter::repeat(tx.clone())
+                .take(num_txs)
+                .enumerate()
+                .map(|(nonce, tx)| tx.nonce(nonce))
+                .map(|tx| async {
+                    provider.send_transaction(tx, None).await.unwrap().await.unwrap().unwrap()
+                }),
         )
         .fuse();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
gets rid of a flaky test as seen here https://github.com/gakonst/ethers-rs/runs/6740032643?check_suite_focus=true
by explicitly setting the nonce

there's a possible race condition rn on anvil if multiple tx without nonce are sent via `eth_sendTransaction` because the next nonce is determined by `onchain +num(pool)`
however if multiple tx are sent at the same time they might get the same nonce if the `nextNonce` for an additional tx is determined before the previous was added to the pool.


https://github.com/foundry-rs/foundry/blob/25241a63db896c88b1717c5522ac284724003eb8/anvil/src/eth/api.rs#L547


https://github.com/foundry-rs/foundry/blob/25241a63db896c88b1717c5522ac284724003eb8/anvil/src/eth/api.rs#L569

this could be prevented via an import lock or some additional check against the `Already Imported` error but not sure if that's worth it @gakonst ?

the former would have some performance impact because we need to lock for the entire `sendTransaction` function, for the latter we can try to implement an additional attempt: if `tx.nonce` was `None` and we received an `Already Imported error` try again with new nonce until not `Already Imported error`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* also ran cargo clippy fix

failing  `watch_events` test fixed in anvil: https://github.com/foundry-rs/foundry/pull/1861
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
