### PR TITLE
feat(provider): add option to create ws provider with auth

### DIFF
--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 #[cfg(not(target_arch = "wasm32"))]
-use crate::transports::{HttpRateLimitRetryPolicy, RetryClient};
+use crate::transports::{Authorization, HttpRateLimitRetryPolicy, RetryClient};
 
 #[cfg(feature = "celo")]
 use crate::CeloMiddleware;
@@ -1283,6 +1283,15 @@ impl Provider<crate::Ws> {
         url: impl tokio_tungstenite::tungstenite::client::IntoClientRequest + Unpin,
     ) -> Result<Self, ProviderError> {
         let ws = crate::Ws::connect(url).await?;
+        Ok(Self::new(ws))
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn connect_with_auth(
+        url: impl tokio_tungstenite::tungstenite::client::IntoClientRequest + Unpin,
+        auth: Authorization,
+    ) -> Result<Self, ProviderError> {
+        let ws = crate::Ws::connect_with_auth(url, auth).await?;
         Ok(Self::new(ws))
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Currently `Provider::<Ws>` only exposes `connect` from `Ws` module.

## Solution

This pull request exposes the `connect_with_auth` function added on #829 .

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
