### PR TITLE
Use H64 for Block Nonce

### DIFF
--- a/ethers-core/src/types/block.rs
+++ b/ethers-core/src/types/block.rs
@@ -1,5 +1,5 @@
 // Taken from <https://github.com/tomusdrw/rust-web3/blob/master/src/types/block.rs>
-use crate::types::{Address, Bloom, Bytes, Transaction, TxHash, H256, U256, U64};
+use crate::types::{Address, Bloom, Bytes, Transaction, TxHash, H256, H64, U256, U64};
 use chrono::{DateTime, TimeZone, Utc};
 #[cfg(not(feature = "celo"))]
 use core::cmp::Ordering;
@@ -81,7 +81,7 @@ pub struct Block<TX> {
     pub mix_hash: Option<H256>,
     /// Nonce
     #[cfg(not(feature = "celo"))]
-    pub nonce: Option<U64>,
+    pub nonce: Option<H64>,
     /// Base fee per unit of gas (if past London)
     #[serde(rename = "baseFeePerGas")]
     pub base_fee_per_gas: Option<U256>,

--- a/ethers-core/src/types/mod.rs
+++ b/ethers-core/src/types/mod.rs
@@ -5,7 +5,7 @@ pub type Selector = [u8; 4];
 /// A transaction Hash
 pub use ethabi::ethereum_types::H256 as TxHash;
 
-pub use ethabi::ethereum_types::{Address, Bloom, H160, H256, H512, U128, U256, U64};
+pub use ethabi::ethereum_types::{Address, Bloom, H160, H256, H512, H64, U128, U256, U64};
 
 pub mod transaction;
 pub use transaction::{


### PR DESCRIPTION
## Motivation

`geth` and other libraries represent the block nonce as a 8 byte fixed array. `ethers-rs` uses an unsigned 64 bit integer to represent the nonce. This causes the nonce to be serialized without leading 0's as specified by the JSON-RPC spec, which therefore may cause deserialization problems with other libraries that expect a fixed byte array. This is the case with `web3` for example which fails to deserialize the nonce [because it uses `H64`](https://docs.rs/web3/0.18.0/web3/types/struct.Block.html#structfield.nonce)

## Solution

Use `H64` instead of `U64` for nonce

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
