### PR TITLE
fix(abigen): remove redundant index adjustment for many overloads

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -414,20 +414,10 @@ impl Context {
             let mut functions = functions.iter().enumerate().collect::<Vec<_>>();
             functions.sort_by(|(_, f1), (_, f2)| f1.inputs.len().cmp(&f2.inputs.len()));
 
-            // the `functions` are now mapped with their index according as defined in the ABI, but
-            // we always want the zero arg function (`log()`) to be `log0`, even if it defined after
-            // an overloaded function like `log(address)`
-            if num_functions > NAME_ALIASING_OVERLOADED_FUNCTIONS_CAP {
-                // lots of overloads, so we set `log()` to index 0, and shift all fun
-                for (idx, _) in &mut functions[1..] {
-                    *idx += 1;
-                }
-                functions[0].0 = 0;
-            } else {
-                // for few overloads we stick entirely to the input len order
-                for (idx, (f_idx, _)) in functions.iter_mut().enumerate() {
-                    *f_idx = idx;
-                }
+            // the `functions` are now mapped with their index as defined in the ABI, but
+            // we always want the zero arg function (`log()`) to be `log0`
+            for (idx, (f_idx, _)) in functions.iter_mut().enumerate() {
+                *f_idx = idx;
             }
 
             // the first function will be the function with the least amount of inputs, like log()

--- a/ethers-contract/tests/abigen.rs
+++ b/ethers-contract/tests/abigen.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "abigen")]
+#![allow(unused)]
 //! Test cases to validate the `abigen!` macro
 use ethers_contract::{abigen, EthCall, EthEvent};
 use ethers_core::{
@@ -600,4 +601,28 @@ fn can_gen_seaport() {
         "fulfillAdvancedOrder(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),uint120,uint120,bytes,bytes),(uint256,uint8,uint256,uint256,bytes32[])[],bytes32,address)"
     );
     assert_eq!(hex::encode(FulfillAdvancedOrderCall::selector()), "e7acab24");
+}
+
+#[test]
+fn can_generate_to_string_overload() {
+    abigen!(
+        ToString,
+        r#"[
+                toString(bytes)
+                toString(address)
+                toString(uint256)
+                toString(int256)
+                toString(bytes32)
+                toString(bool)
+    ]"#
+    );
+
+    match ToStringCalls::ToString0(ToString0Call(Default::default())) {
+        ToStringCalls::ToString0(_) => {}
+        ToStringCalls::ToString1(_) => {}
+        ToStringCalls::ToString2(_) => {}
+        ToStringCalls::ToString3(_) => {}
+        ToStringCalls::ToString4(_) => {}
+        ToStringCalls::ToString5(_) => {}
+    };
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
removes a redundant index increase when deriving aliases for overloaded functions

prior to this, many overloaded function would be expanded to 

```rust
        HEVMCalls::ToString0(inner) =>,
        HEVMCalls::ToString2(inner) => ,
        HEVMCalls::ToString3(inner) => ,
        HEVMCalls::ToString4(inner) => ,
```

as seen here https://github.com/foundry-rs/foundry/pull/2127/files



<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
removes the index increase that turned out to be redundant.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
