### PR TITLE
fix: remove 0x bytecode object prefix for CompilerOutput

### DIFF
--- a/ethers-solc/src/artifacts/bytecode.rs
+++ b/ethers-solc/src/artifacts/bytecode.rs
@@ -6,7 +6,7 @@ use crate::{
     utils,
 };
 use ethers_core::{abi::Address, types::Bytes};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
@@ -16,6 +16,7 @@ pub struct Bytecode {
     #[serde(default, skip_serializing_if = "::std::collections::BTreeMap::is_empty")]
     pub function_debug_data: BTreeMap<String, FunctionDebugData>,
     /// The bytecode as a hex string.
+    #[serde(serialize_with = "serialize_bytecode_without_prefix")]
     pub object: BytecodeObject,
     /// Opcodes list (string)
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -364,6 +365,34 @@ impl AsRef<[u8]> for BytecodeObject {
             BytecodeObject::Bytecode(code) => code.as_ref(),
             BytecodeObject::Unlinked(code) => code.as_bytes(),
         }
+    }
+}
+
+/// This will serialize the bytecode data without a `0x` prefix, which the `ethers::types::Bytes` adds by default.
+///
+/// This ensures that we serialize bytecode data in the same way as solc does, See also <https://github.com/gakonst/ethers-rs/issues/1422>
+pub fn serialize_bytecode_without_prefix<S>(bytecode: &BytecodeObject, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+{
+    match bytecode {
+        BytecodeObject::Bytecode(code) => {
+            s.serialize_str(&hex::encode(code))
+        },
+        BytecodeObject::Unlinked(code) => {
+            s.serialize_str(code.strip_prefix("0x").unwrap_or_else(||code.as_str()))
+        },
+    }
+}
+
+pub fn serialize_bytecode_without_prefix_opt<S>(bytecode: &Option<BytecodeObject>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+{
+    if let Some(bytecode) = bytecode {
+        serialize_bytecode_without_prefix(bytecode, s)
+    } else {
+        s.serialize_none()
     }
 }
 

--- a/ethers-solc/src/artifacts/bytecode.rs
+++ b/ethers-solc/src/artifacts/bytecode.rs
@@ -368,31 +368,22 @@ impl AsRef<[u8]> for BytecodeObject {
     }
 }
 
-/// This will serialize the bytecode data without a `0x` prefix, which the `ethers::types::Bytes` adds by default.
+/// This will serialize the bytecode data without a `0x` prefix, which the `ethers::types::Bytes`
+/// adds by default.
 ///
 /// This ensures that we serialize bytecode data in the same way as solc does, See also <https://github.com/gakonst/ethers-rs/issues/1422>
-pub fn serialize_bytecode_without_prefix<S>(bytecode: &BytecodeObject, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
+pub fn serialize_bytecode_without_prefix<S>(
+    bytecode: &BytecodeObject,
+    s: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
 {
     match bytecode {
-        BytecodeObject::Bytecode(code) => {
-            s.serialize_str(&hex::encode(code))
-        },
+        BytecodeObject::Bytecode(code) => s.serialize_str(&hex::encode(code)),
         BytecodeObject::Unlinked(code) => {
-            s.serialize_str(code.strip_prefix("0x").unwrap_or_else(||code.as_str()))
-        },
-    }
-}
-
-pub fn serialize_bytecode_without_prefix_opt<S>(bytecode: &Option<BytecodeObject>, s: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-{
-    if let Some(bytecode) = bytecode {
-        serialize_bytecode_without_prefix(bytecode, s)
-    } else {
-        s.serialize_none()
+            s.serialize_str(code.strip_prefix("0x").unwrap_or_else(|| code.as_str()))
+        }
     }
 }
 

--- a/ethers-solc/src/artifacts/bytecode.rs
+++ b/ethers-solc/src/artifacts/bytecode.rs
@@ -382,7 +382,7 @@ where
     match bytecode {
         BytecodeObject::Bytecode(code) => s.serialize_str(&hex::encode(code)),
         BytecodeObject::Unlinked(code) => {
-            s.serialize_str(code.strip_prefix("0x").unwrap_or_else(|| code.as_str()))
+            s.serialize_str(code.strip_prefix("0x").unwrap_or(code.as_str()))
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes #1422
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
adds custom serialization for `Bytecode` objects that omits the `0x` prefix. This way the artifact types used by Forge (ConfigurableArtifact) are not affected and will still be output with 0x prefix

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
