### PR TITLE
feat(ethers-solc): configurable build-info output dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Allow configuration of the output directory of the generated `BuildInfo` [#1433](https://github.com/gakonst/ethers-rs/pull/1433)
 - capture unknown fields in `Block` and `Transaction` type via new `OtherFields` type [#1423](https://github.com/gakonst/ethers-rs/pull/1423)
 - Methods like `set_to()` from `TypedTransaction` can be chained
 - Use H64 for Block Nonce [#1396](https://github.com/gakonst/ethers-rs/pull/1396)

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -125,8 +125,8 @@ impl<T: ArtifactOutput> Project<T> {
     }
 
     /// Returns the path to the `build-info` directory nested in the artifacts dir
-    pub fn build_info_path(&self) -> PathBuf {
-        self.paths.artifacts.join("build-info")
+    pub fn build_info_path(&self) -> &PathBuf {
+        &self.paths.build_infos
     }
 
     /// Returns the root directory of the project


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
I would like to be able to configure the output directory of the hh style bulidinfo files so that tooling that expects the build info files to be in a specific directory can just work.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Allows for the build info output directory to be configured. It should be backwards compatible by using the same directory that it currently uses by default. Will require a follow up PR in foundry to pass through the config value

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
