### PR TITLE
chore: export quorum's JsonRpcClientWrapper

### DIFF
--- a/ethers-providers/src/transports/mod.rs
+++ b/ethers-providers/src/transports/mod.rs
@@ -33,8 +33,7 @@ mod ws;
 pub use ws::{ClientError as WsClientError, Ws};
 
 mod quorum;
-pub(crate) use quorum::JsonRpcClientWrapper;
-pub use quorum::{Quorum, QuorumError, QuorumProvider, WeightedProvider};
+pub use quorum::{JsonRpcClientWrapper, Quorum, QuorumError, QuorumProvider, WeightedProvider};
 
 mod rw;
 pub use rw::{RwClient, RwClientError};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
exports trait and also make default generic type ` Box<dyn JsonRpcClientWrapper>`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
