### PR TITLE
chore(ethers-signers): bump coins-ledger to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "coins-ledger"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498841803f751d49bb08fe4a88b514087c52e5df885575ed4757f14ab151e239"
+checksum = "bbfa8a730d02735d8d53888a95d8f33aaa9dda9979862de113202421db939b2a"
 dependencies = [
  "async-trait",
  "blake2b_simd",

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -18,7 +18,7 @@ ethers-core = { version = "^0.13.0", path = "../ethers-core", features = ["eip71
 thiserror = { version = "1.0.31", default-features = false }
 coins-bip32 = "0.6.0"
 coins-bip39 = "0.6.0"
-coins-ledger = { version = "0.6.0", default-features = false, optional = true }
+coins-ledger = { version = "0.6.1", default-features = false, optional = true }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 async-trait = { version = "0.1.50", default-features = false }
 elliptic-curve = { version = "0.11.12", default-features = false }


### PR DESCRIPTION
Bump coins-ledger to using hidapi-rusb docs fixes