### PR TITLE
Implement fastrlp traits for Bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,6 +1279,7 @@ dependencies = [
  "convert_case",
  "elliptic-curve",
  "ethabi",
+ "fastrlp",
  "generic-array 0.14.5",
  "hex",
  "hex-literal",
@@ -1510,6 +1511,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.1.1"
+source = "git+https://github.com/vorot93/fastrlp#4ad1aace9948380790d7f922585899e65e44b58f"
+dependencies = [
+ "arrayvec 0.7.2",
+ "auto_impl",
+ "bytes",
+ "ethereum-types",
+ "fastrlp-derive",
+]
+
+[[package]]
+name = "fastrlp-derive"
+version = "0.1.1"
+source = "git+https://github.com/vorot93/fastrlp#4ad1aace9948380790d7f922585899e65e44b58f"
+dependencies = [
+ "bytes",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,8 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "fastrlp"
-version = "0.1.1"
-source = "git+https://github.com/vorot93/fastrlp#4ad1aace9948380790d7f922585899e65e44b58f"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6c60b758dc5bf92743e1b863ac88b84a4750bd096b19c2f524359659dc1f1ac"
 dependencies = [
  "arrayvec 0.7.2",
  "auto_impl",
@@ -1528,7 +1529,8 @@ dependencies = [
 [[package]]
 name = "fastrlp-derive"
 version = "0.1.1"
-source = "git+https://github.com/vorot93/fastrlp#4ad1aace9948380790d7f922585899e65e44b58f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9499f20a2fa1a744422de24d1b4d1ec58f240147de1d0a3ceacadf2e240b4fc2"
 dependencies = [
  "bytes",
  "proc-macro2",

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/gakonst/ethers-rs"
 keywords = ["ethereum", "web3", "celo", "ethers"]
 
 [dependencies]
-fastrlp = { git = "https://github.com/vorot93/fastrlp", features = ["std", "derive", "ethereum-types"] }
+fastrlp = { version = "0.1.2", features = ["std", "derive", "ethereum-types"] }
 rlp = { version = "0.5.0", default-features = false, features = ["std"] }
 ethabi = { version = "17.1.0", default-features = false, features = ["full-serde", "rlp"] }
 arrayvec = { version = "0.7.2", default-features = false }

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/gakonst/ethers-rs"
 keywords = ["ethereum", "web3", "celo", "ethers"]
 
 [dependencies]
+fastrlp = { git = "https://github.com/vorot93/fastrlp", features = ["std", "derive", "ethereum-types"] }
 rlp = { version = "0.5.0", default-features = false, features = ["std"] }
 ethabi = { version = "17.1.0", default-features = false, features = ["full-serde", "rlp"] }
 arrayvec = { version = "0.7.2", default-features = false }

--- a/ethers-core/src/types/bytes.rs
+++ b/ethers-core/src/types/bytes.rs
@@ -1,6 +1,5 @@
 use fastrlp::{Decodable, Encodable};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use thiserror::Error;
 use std::{
     borrow::Borrow,
     clone::Clone,
@@ -8,6 +7,7 @@ use std::{
     ops::Deref,
     str::FromStr,
 };
+use thiserror::Error;
 
 /// Wrapper type around Bytes to deserialize/serialize "0x" prefixed ethereum hex strings
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize, Ord, PartialOrd)]

--- a/ethers-core/src/types/bytes.rs
+++ b/ethers-core/src/types/bytes.rs
@@ -1,6 +1,6 @@
+use fastrlp::{Decodable, Encodable};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
-
 use std::{
     borrow::Borrow,
     clone::Clone,
@@ -128,6 +128,21 @@ impl PartialEq<Bytes> for Vec<u8> {
 impl PartialEq<bytes::Bytes> for Bytes {
     fn eq(&self, other: &bytes::Bytes) -> bool {
         other == self.as_ref()
+    }
+}
+
+impl Encodable for Bytes {
+    fn length(&self) -> usize {
+        self.0.length()
+    }
+    fn encode(&self, out: &mut dyn bytes::BufMut) {
+        self.0.encode(out)
+    }
+}
+
+impl Decodable for Bytes {
+    fn decode(buf: &mut &[u8]) -> Result<Self, fastrlp::DecodeError> {
+        Ok(Self(bytes::Bytes::decode(buf)?))
     }
 }
 


### PR DESCRIPTION
## Motivation

Many types in ethers and foundry contain the `Bytes` type, implementing fastrlp traits on any of them would be more convenient if `Bytes` implemented fastrlp traits.

## Solution

`Encodable` and `Decodable` are already implemented for `bytes::Bytes`, we can just defer to those implementations.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
