### PR TITLE
Add Arithmetic Shift Left operation for I256. Minor update to the ASR…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 - Add `From<H160>` and From<Vec<H160>> traits to `ValueOrArray<H160>` [#1199](https://github.com/gakonst/ethers-rs/pull/1200)
 - Fix handling of Websocket connection errors [#1287](https://github.com/gakonst/ethers-rs/pull/1287)
 - Add Arithmetic Shift Right operation for I256 [#1323](https://github.com/gakonst/ethers-rs/issues/1323)
+- Add Arithemtic Shift Left operation for I256 [#1451](https://github.com/gakonst/ethers-rs/issues/1451)
 
 ## ethers-contract-abigen
 

--- a/ethers-core/src/types/i256.rs
+++ b/ethers-core/src/types/i256.rs
@@ -949,7 +949,7 @@ impl I256 {
                 // It's always going to be zero (i.e. 00000000...00000000)
                 Sign::Positive => Self::zero(),
                 // It's always going to be -1 (i.e. 11111111...11111111)
-                Sign::Negative => Self::from(-1i8),
+                Sign::Negative => Self::minus_one(),
             }
         } else {
             // Perform the shift.
@@ -963,6 +963,24 @@ impl I256 {
                         Self::from_raw(!U256::from(2u8).pow(U256::from(255u32 - shift)).sub(1u8));
                     (self >> shift) | bitwise_or
                 }
+            }
+        }
+    }
+
+    /// Arithmetic Shift Left operation. Shifts `shift` number of times to the left, checking for
+    /// overflow on the final result.
+    ///
+    /// Returns `None` if the operation overflowed (most significant bit changes).
+    pub fn asl(self, shift: u32) -> Option<Self> {
+        if shift == 0 {
+            Some(self)
+        } else {
+            let result = self << shift;
+            if result.sign() != self.sign() {
+                // Overflow occured
+                None
+            } else {
+                Some(result)
             }
         }
     }
@@ -1559,16 +1577,16 @@ mod tests {
         let expected_result = I256::from_raw(U256::MAX.sub(1u8));
         assert_eq!(value.asr(253u32), expected_result, "1011...1111 >> 253 was not 1111...1110");
 
-        let value = I256::from(-1i8);
-        let expected_result = I256::from(-1i8);
+        let value = I256::minus_one();
+        let expected_result = I256::minus_one();
         assert_eq!(value.asr(250u32), expected_result, "-1 >> any_amount was not -1");
 
         let value = I256::from_raw(U256::from(2u8).pow(U256::from(254u8))).neg();
-        let expected_result = I256::from(-1i8);
+        let expected_result = I256::minus_one();
         assert_eq!(value.asr(255u32), expected_result, "1011...1111 >> 255 was not -1");
 
         let value = I256::from_raw(U256::from(2u8).pow(U256::from(254u8))).neg();
-        let expected_result = I256::from(-1i8);
+        let expected_result = I256::minus_one();
         assert_eq!(value.asr(1024u32), expected_result, "1011...1111 >> 1024 was not -1");
 
         let value = I256::from(1024i32);
@@ -1578,6 +1596,49 @@ mod tests {
         let value = I256::MAX;
         let expected_result = I256::zero();
         assert_eq!(value.asr(255u32), expected_result, "I256::MAX >> 255 was not 0");
+
+        let value = I256::from_raw(U256::from(2u8).pow(U256::from(254u8))).neg();
+        let expected_result = value;
+        assert_eq!(value.asr(0u32), expected_result, "1011...1111 >> 0 was not 1011...111");
+    }
+
+    #[test]
+    fn arithmetic_shift_left() {
+        let value = I256::minus_one();
+        let expected_result = Some(value);
+        assert_eq!(value.asl(0u32), expected_result, "-1 << 0 was not -1");
+
+        let value = I256::minus_one();
+        let expected_result = None;
+        assert_eq!(
+            value.asl(256u32),
+            expected_result,
+            "-1 << 256 did not overflow (result should be 0000...0000)"
+        );
+
+        let value = I256::minus_one();
+        let expected_result = Some(I256::from_raw(U256::from(2u8).pow(U256::from(255u8))));
+        assert_eq!(value.asl(255u32), expected_result, "-1 << 255 was not 1000...0000");
+
+        let value = I256::from(-1024i32);
+        let expected_result = Some(I256::from(-32768i32));
+        assert_eq!(value.asl(5u32), expected_result, "-1024 << 5 was not -32768");
+
+        let value = I256::from(1024i32);
+        let expected_result = Some(I256::from(32768i32));
+        assert_eq!(value.asl(5u32), expected_result, "1024 << 5 was not 32768");
+
+        let value = I256::from(1024i32);
+        let expected_result = None;
+        assert_eq!(
+            value.asl(245u32),
+            expected_result,
+            "1024 << 245 did not overflow (result should be 1000...0000)"
+        );
+
+        let value = I256::zero();
+        let expected_result = Some(value);
+        assert_eq!(value.asl(1024u32), expected_result, "0 << anything was not 0");
     }
 
     #[test]


### PR DESCRIPTION
… tests to include coverage for a shift of 0, and move to 'I256::minus_one' over 'I256::from(-1i8)' syntax

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Issue #1451 

## Solution
The option to shortcut for ASL wasn't implemented due to readability concerns, as the code would have multiple `else if` statements due to the shift having different thresholds.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
