### PR TITLE
fix unused warning

### DIFF
--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -8,7 +8,9 @@ use crate::{
 };
 
 #[cfg(not(target_arch = "wasm32"))]
-use crate::transports::{Authorization, HttpRateLimitRetryPolicy, RetryClient};
+use crate::transports::{HttpRateLimitRetryPolicy, RetryClient};
+#[cfg(all(not(target_arch = "wasm32"), feature = "ws"))]
+use crate::transports::Authorization;
 
 #[cfg(feature = "celo")]
 use crate::CeloMiddleware;

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -7,10 +7,10 @@ use crate::{
     PendingTransaction, QuorumProvider, RwClient, SyncingStatus,
 };
 
-#[cfg(not(target_arch = "wasm32"))]
-use crate::transports::{HttpRateLimitRetryPolicy, RetryClient};
 #[cfg(all(not(target_arch = "wasm32"), feature = "ws"))]
 use crate::transports::Authorization;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::transports::{HttpRateLimitRetryPolicy, RetryClient};
 
 #[cfg(feature = "celo")]
 use crate::CeloMiddleware;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Authorization is current always `use`d when the target is not `wasm32`, but it's only actually used in the code when the `ws` feature is also enabled.  This causes an annoying error when i `cargo clippy`.

```rs
warning: unused import: `Authorization`
  --> <redacted>/ethers-rs/ethers-providers/src/provider.rs:11:25
   |
11 | use crate::transports::{Authorization, HttpRateLimitRetryPolicy, RetryClient};
   |                         ^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
See the code, make it only import when needed


Have not used `#[cfg(...)]` a lot, might've done it a bit more verbose than necessary?
