### PR TITLE
feature: allow event builder to stream with meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@
 
 - Make `ethers-solc` optional dependency of `ethers`, needs `ethers-solc` feature to activate
   [#1463](https://github.com/gakonst/ethers-rs/pull/1463)
-- Add `rawMetadata:String` field to configurable contract output 
+- Add `rawMetadata:String` field to configurable contract output
   [#1365](https://github.com/gakonst/ethers-rs/pull/1365)
 - Use relative source paths and `solc --base-path`
   [#1317](https://github.com/gakonst/ethers-rs/pull/1317)
@@ -237,6 +237,8 @@
 
 ### Unreleased
 
+- Add `Event::stream_with_meta` and `Event::subscribe_with_meta`
+  [#1483](https://github.com/gakonst/ethers-rs/pull/1483)
 - Added tx builder methods to `ContractFactory`
   [#1289](https://github.com/gakonst/ethers-rs/pull/1289)
 - Relax Clone requirements when Arc<Middleware> is used

--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -165,7 +165,7 @@ where
         Ok(EventStream::new(filter.id, filter, Box::new(move |log| self.parse_log(log))))
     }
 
-    /// As [`stream`], but does not discard Log metadata.
+    /// As [`Self::stream`], but does not discard [`Log`] metadata.
     pub async fn stream_with_meta(
         &'a self,
     ) -> Result<

--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -175,10 +175,14 @@ where
     > {
         let filter =
             self.provider.watch(&self.filter).await.map_err(ContractError::MiddlewareError)?;
-        Ok(EventStream::new(filter.id, filter, Box::new(move |log| {
-            let meta = LogMeta::from(&log);
-            Ok((self.parse_log(log)?, meta))
-        })))
+        Ok(EventStream::new(
+            filter.id,
+            filter,
+            Box::new(move |log| {
+                let meta = LogMeta::from(&log);
+                Ok((self.parse_log(log)?, meta))
+            }),
+        ))
     }
 }
 
@@ -218,10 +222,14 @@ where
             .subscribe_logs(&self.filter)
             .await
             .map_err(ContractError::MiddlewareError)?;
-            Ok(EventStream::new(filter.id, filter, Box::new(move |log| {
+        Ok(EventStream::new(
+            filter.id,
+            filter,
+            Box::new(move |log| {
                 let meta = LogMeta::from(&log);
                 Ok((self.parse_log(log)?, meta))
-            })))
+            }),
+        ))
     }
 }
 


### PR DESCRIPTION
## Motivation

Event builder stream & subscribe always discards metadata. This sucks :)

## Solution

Add a near-identical functions that retain metadata

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
