### PR TITLE
Fix doc links

### DIFF
--- a/ethers-solc/src/artifact_output/configurable.rs
+++ b/ethers-solc/src/artifact_output/configurable.rs
@@ -5,7 +5,7 @@
 //! `ConfigurableArtifacts` populates a single `Artifact`, the `ConfigurableArtifact`, by default
 //! with essential entries only, such as `abi`, `bytecode`,..., but may include additional values
 //! based on its `ExtraOutputValues` that maps to various objects in the solc contract output, see
-//! also: [`OutputSelection`](crate::artifacts::OutputSelection). In addition to that some output
+//! also: [`OutputSelection`](crate::artifacts::output_selection::OutputSelection). In addition to that some output
 //! values can also be emitted as standalone files.
 
 use crate::{

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -293,6 +293,7 @@ impl<T: ArtifactOutput> Project<T> {
     ///     ).unwrap();
     /// # }
     /// ```
+    #[cfg(all(feature = "svm-solc"))]
     pub fn compile_files<P, I>(&self, files: I) -> Result<ProjectCompileOutput<T>>
     where
         I: IntoIterator<Item = P>,
@@ -300,7 +301,6 @@ impl<T: ArtifactOutput> Project<T> {
     {
         let sources = Source::read_all(files)?;
 
-        #[cfg(all(feature = "svm-solc"))]
         if self.auto_detect {
             return project::ProjectCompiler::with_sources(self, sources)?.compile()
         }
@@ -339,6 +339,7 @@ impl<T: ArtifactOutput> Project<T> {
     ///     ).unwrap();
     /// # }
     /// ```
+    #[cfg(all(feature = "svm-solc"))]
     pub fn compile_sparse<F: FileFilter + 'static>(
         &self,
         filter: F,
@@ -347,7 +348,6 @@ impl<T: ArtifactOutput> Project<T> {
             Source::read_all(self.paths.input_files().into_iter().filter(|p| filter.is_match(p)))?;
         let filter: Box<dyn FileFilter> = Box::new(filter);
 
-        #[cfg(all(feature = "svm-solc"))]
         if self.auto_detect {
             return project::ProjectCompiler::with_sources(self, sources)?
                 .with_sparse_output(filter)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Fixes #1495

## Solution

1. Reference `OutputSelection` with correct module scope.
2. Move `#[cfg(all(feature = "svm-solc"))]` to top of compile_* methods; this enables `Project::svm_compile()` to be in scope within the documentation for the method.

## PR Checklist

- [ ] Added Tests (N/A)
- [ ] Added Documentation (N/A)
- [ ] Updated the changelog
