### PR TITLE
fix(abigen): contract names can be reserve words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,9 @@
 - Generate correct bindings of struct's field names that are reserved words
   [#989](https://github.com/gakonst/ethers-rs/pull/989).
 - Generate correct binding module names that are reserved words
-  [#1498](https://github.com/gakonst/ethers-rs/pull/1498)
+  [#1498](https://github.com/gakonst/ethers-rs/pull/1498). Note: this changes
+  generated module names to snake case. For example, `MyContract` is now
+  `my_contract` rather than `mycontract_mod`.
 
 ### 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@
   [#1030](https://github.com/gakonst/ethers-rs/pull/1030).
 - Generate correct bindings of struct's field names that are reserved words
   [#989](https://github.com/gakonst/ethers-rs/pull/989).
+- Generate correct binding module names that are reserved words
+  [#1498](https://github.com/gakonst/ethers-rs/pull/1498)
 
 ### 0.6.0
 

--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -41,4 +41,4 @@ rustls = ["reqwest/rustls-tls"]
 
 [dev-dependencies]
 tempfile = "3.2.0"
-ethers-solc = { version = "^0.13.0", path = "../../ethers-solc", default-features = false, features = ["project-util"] }
+ethers-solc = { version = "^0.13.0", path = "../../ethers-solc", default-features = false, features = ["project-util", "svm-solc"] }

--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -101,8 +101,7 @@ impl Context {
     /// Expands the whole rust contract
     pub fn expand(&self) -> Result<ExpandedContract> {
         let name = &self.contract_ident;
-        let name_mod =
-            util::ident(&format!("{}_mod", self.contract_ident.to_string().to_lowercase()));
+        let name_mod = util::ident(&util::safe_module_name(&self.contract_name));
         let abi_name = self.inline_abi_ident();
 
         // 0. Imports

--- a/ethers-contract/ethers-contract-abigen/src/lib.rs
+++ b/ethers-contract/ethers-contract-abigen/src/lib.rs
@@ -233,7 +233,7 @@ impl ContractBindings {
 
     /// Generate the default module name (snake case of the contract name)
     pub fn module_name(&self) -> String {
-        self.name.to_snake_case()
+        util::safe_module_name(&self.name)
     }
 
     /// Generate the default filename of the module

--- a/ethers-contract/ethers-contract-abigen/src/lib.rs
+++ b/ethers-contract/ethers-contract-abigen/src/lib.rs
@@ -29,7 +29,6 @@ pub use util::parse_address;
 
 use crate::contract::ExpandedContract;
 use eyre::Result;
-use inflector::Inflector;
 use proc_macro2::TokenStream;
 use std::{collections::HashMap, fs::File, io::Write, path::Path};
 

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -1047,11 +1047,6 @@ contract Greeter2 {
         return stuff;
     }
 }
-
-// from a gnosis contract
-contract Enum {
-    enum Operation {Call, DelegateCall}
-}
 "#,
         )
         .unwrap();
@@ -1079,7 +1074,6 @@ contract Enum {
         assert!(multi_file_mod.exists());
         let content = fs::read_to_string(&multi_file_mod).unwrap();
         assert!(content.contains("pub mod shared_types"));
-        assert!(content.contains("pub mod enum_"));
 
         let greeter1 = multi_file_dir.join("greeter_1.rs");
         assert!(greeter1.exists());
@@ -1093,11 +1087,6 @@ contract Enum {
         assert!(!content.contains("pub struct Inner"));
         assert!(!content.contains("pub struct Stuff"));
 
-        let enum_ = multi_file_dir.join("enum_.rs");
-        assert!(enum_.exists());
-        let content = fs::read_to_string(&enum_).unwrap();
-        assert!(!content.contains("pub enum Operation"));
-
         let shared_types = multi_file_dir.join("shared_types.rs");
         assert!(shared_types.exists());
         let content = fs::read_to_string(&shared_types).unwrap();
@@ -1106,11 +1095,11 @@ contract Enum {
     }
 
     #[test]
-    fn can_sanitize_bindings() {
+    fn can_sanitize_reserved_words() {
         let tmp = TempProject::dapptools().unwrap();
 
         tmp.add_source(
-            "Greeter",
+            "ReservedWords",
             r#"
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
@@ -1139,7 +1128,6 @@ contract Enum {
         let single_file_mod = single_file_dir.join("mod.rs");
         assert!(single_file_mod.exists());
         let content = fs::read_to_string(&single_file_mod).unwrap();
-        println!("{}", content);
         assert!(content.contains("pub mod mod_ {"));
         assert!(content.contains("pub mod enum_ {"));
 
@@ -1151,18 +1139,17 @@ contract Enum {
         let multi_file_mod = multi_file_dir.join("mod.rs");
         assert!(multi_file_mod.exists());
         let content = fs::read_to_string(&multi_file_mod).unwrap();
-        assert!(content.contains("pub mod enum_"));
-        assert!(content.contains("pub mod mod_"));
+        assert!(content.contains("pub mod enum_;"));
+        assert!(content.contains("pub mod mod_;"));
 
         let enum_ = multi_file_dir.join("enum_.rs");
         assert!(enum_.exists());
         let content = fs::read_to_string(&enum_).unwrap();
-        assert!(!content.contains("pub enum Operation"));
+        assert!(content.contains("pub mod enum_ {"));
 
         let mod_ = multi_file_dir.join("mod_.rs");
         assert!(mod_.exists());
         let content = fs::read_to_string(&mod_).unwrap();
-        println!("{}", content);
-        assert!(!content.contains("pub enum Operation"));
+        assert!(content.contains("pub mod mod_ {"));
     }
 }

--- a/ethers-contract/ethers-contract-abigen/src/util.rs
+++ b/ethers-contract/ethers-contract-abigen/src/util.rs
@@ -40,6 +40,15 @@ fn safe_identifier_name(name: String) -> String {
     }
 }
 
+/// converts invalid rust module names to valid ones
+pub fn safe_module_name(name: &str) -> String {
+    match safe_snake_case(name).as_ref() {
+        // handle reserve words used in contracts (eg Enum is a gnosis contract)
+        name @ ("enum" | "mod" | "module") => format!("_{}", name),
+        name => name.to_string(),
+    }
+}
+
 /// Expands an identifier as snakecase and preserve any leading or trailing underscores
 pub fn safe_snake_case_ident(name: &str) -> Ident {
     let i = name.to_snake_case();
@@ -227,5 +236,14 @@ mod tests {
         let expected =
             Address::from([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
         assert_eq!(parse_address("0x000102030405060708090a0b0c0d0e0f10111213").unwrap(), expected);
+    }
+
+    #[test]
+    fn test_safe_module_name() {
+        assert_eq!(safe_module_name("Valid"), "valid");
+        assert_eq!(safe_module_name("Enum"), "_enum");
+        assert_eq!(safe_module_name("Mod"), "_mod");
+        assert_eq!(safe_module_name("Module"), "_module");
+        assert_eq!(safe_module_name("2Two"), "_2_two");
     }
 }

--- a/ethers-contract/ethers-contract-abigen/src/util.rs
+++ b/ethers-contract/ethers-contract-abigen/src/util.rs
@@ -42,11 +42,8 @@ fn safe_identifier_name(name: String) -> String {
 
 /// converts invalid rust module names to valid ones
 pub fn safe_module_name(name: &str) -> String {
-    match safe_snake_case(name).as_ref() {
-        // handle reserve words used in contracts (eg Enum is a gnosis contract)
-        name @ ("enum" | "mod" | "module") => format!("_{}", name),
-        name => name.to_string(),
-    }
+    // handle reserve words used in contracts (eg Enum is a gnosis contract)
+    safe_ident(&safe_snake_case(name)).to_string()
 }
 
 /// Expands an identifier as snakecase and preserve any leading or trailing underscores
@@ -241,9 +238,8 @@ mod tests {
     #[test]
     fn test_safe_module_name() {
         assert_eq!(safe_module_name("Valid"), "valid");
-        assert_eq!(safe_module_name("Enum"), "_enum");
-        assert_eq!(safe_module_name("Mod"), "_mod");
-        assert_eq!(safe_module_name("Module"), "_module");
+        assert_eq!(safe_module_name("Enum"), "enum_");
+        assert_eq!(safe_module_name("Mod"), "mod_");
         assert_eq!(safe_module_name("2Two"), "_2_two");
     }
 }

--- a/ethers-contract/tests/abigen.rs
+++ b/ethers-contract/tests/abigen.rs
@@ -366,7 +366,7 @@ async fn can_handle_underscore_functions() {
     // Manual call construction
     use ethers_providers::Middleware;
     // TODO: How do we handle underscores for calls here?
-    let data = simplestorage_mod::HashPuzzleCall.encode();
+    let data = simple_storage::HashPuzzleCall.encode();
     let tx = Eip1559TransactionRequest::new().data(data).to(addr);
     let tx = TypedTransaction::Eip1559(tx);
     let res5 = client.call(&tx, None).await.unwrap();

--- a/ethers-contract/tests/contract.rs
+++ b/ethers-contract/tests/contract.rs
@@ -601,7 +601,7 @@ mod eth_tests {
             out: Address::from([0; 20]),
         };
 
-        let derived_foo_bar = deriveeip712test_mod::FooBar {
+        let derived_foo_bar = derive_eip_712_test::FooBar {
             foo: foo_bar.foo,
             bar: foo_bar.bar,
             fizz: foo_bar.fizz.clone(),


### PR DESCRIPTION
Some contract names [(such as Enum.sol in gnosis)](https://github.com/safe-global/safe-contracts/blob/main/contracts/common/Enum.sol) are rust reserve words that cause invalid bindings to be generated.

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
