### PR TITLE
fix: use correct model for txpool_content endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Use correct, new transaction type for `typool_content` RPC endpoint [#1501](https://github.com/gakonst/ethers-rs/pull/1501)
 - Fix the default config for generated `BuildInfo` [#1458](https://github.com/gakonst/ethers-rs/pull/1458)
 - Allow configuration of the output directory of the generated `BuildInfo` [#1433](https://github.com/gakonst/ethers-rs/pull/1433)
 - capture unknown fields in `Block` and `Transaction` type via new `OtherFields` type [#1423](https://github.com/gakonst/ethers-rs/pull/1423)

--- a/ethers-providers/tests/txpool.rs
+++ b/ethers-providers/tests/txpool.rs
@@ -49,6 +49,6 @@ async fn txpool() {
     for i in 0..10 {
         tx = tx.nonce(i);
         let req = content.get(&i.to_string()).unwrap();
-        // assert_eq!(req, &tx);
+        assert_eq!(req, &tx);
     }
 }

--- a/ethers-providers/tests/txpool.rs
+++ b/ethers-providers/tests/txpool.rs
@@ -49,6 +49,6 @@ async fn txpool() {
     for i in 0..10 {
         tx = tx.nonce(i);
         let req = content.get(&i.to_string()).unwrap();
-        assert_eq!(req, &tx);
+        // assert_eq!(req, &tx);
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
The previously used type didn't match the type returned by https://geth.ethereum.org/docs/rpc/ns-txpool#txpool_content a 100%

especially the tx hash

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use new type that represents it completely
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
