### PR TITLE
ethers-solc: add immutableReferences output selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Add `evm.deployedBytecode.immutableReferences` output selector [#1523](https://github.com/gakonst/ethers-rs/pull/1523) 
 - Added `get_erc1155_token_transfer_events` function for etherscan client [#1503](https://github.com/gakonst/ethers-rs/pull/1503)
 - Add support for Geth `debug_traceTransaction` [#1469](https://github.com/gakonst/ethers-rs/pull/1469)
 - Use correct, new transaction type for `typool_content` RPC endpoint [#1501](https://github.com/gakonst/ethers-rs/pull/1501)

--- a/ethers-solc/src/artifacts/output_selection.rs
+++ b/ethers-solc/src/artifacts/output_selection.rs
@@ -427,6 +427,7 @@ pub enum DeployedBytecodeOutputSelection {
     SourceMap,
     LinkReferences,
     GeneratedSources,
+    ImmutableReferences,
 }
 
 impl Serialize for DeployedBytecodeOutputSelection {
@@ -465,6 +466,9 @@ impl fmt::Display for DeployedBytecodeOutputSelection {
             DeployedBytecodeOutputSelection::GeneratedSources => {
                 f.write_str("evm.deployedBytecode.generatedSources")
             }
+            DeployedBytecodeOutputSelection::ImmutableReferences => {
+                f.write_str("evm.deployedBytecode.immutableReferences")
+            }
         }
     }
 }
@@ -486,6 +490,9 @@ impl FromStr for DeployedBytecodeOutputSelection {
             }
             "evm.deployedBytecode.generatedSources" => {
                 Ok(DeployedBytecodeOutputSelection::GeneratedSources)
+            }
+            "evm.deployedBytecode.immutableReferences" => {
+                Ok(DeployedBytecodeOutputSelection::ImmutableReferences)
             }
             s => Err(format!("Invalid deployedBytecode selection: {}", s)),
         }
@@ -572,5 +579,14 @@ mod tests {
         empty.0.insert("contract.sol".to_string(), OutputSelection::empty_file_output_select());
         let s = serde_json::to_string(&empty).unwrap();
         assert_eq!(s, r#"{"contract.sol":{"*":[]}}"#);
+    }
+
+    #[test]
+    fn deployed_bytecode_from_str() {
+        assert_eq!(
+            DeployedBytecodeOutputSelection::from_str("evm.deployedBytecode.immutableReferences")
+                .unwrap(),
+            DeployedBytecodeOutputSelection::ImmutableReferences
+        )
     }
 }


### PR DESCRIPTION
## Motivation

It is a property on the deployed bytecode object
on the compiler output. This is the precursor for
`forge inspect <contract-name> immutableReferences`.

See https://docs.soliditylang.org/en/v0.8.15/using-the-compiler.html?highlight=immutable#output-description

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.


Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->



## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
