### PR TITLE
fix(etherscan): support stringified numbers in response

### DIFF
--- a/ethers-core/src/types/serde_helpers.rs
+++ b/ethers-core/src/types/serde_helpers.rs
@@ -3,7 +3,10 @@
 use crate::types::{BlockNumber, U256};
 use ethabi::ethereum_types::FromDecStrErr;
 use serde::{Deserialize, Deserializer};
-use std::convert::{TryFrom, TryInto};
+use std::{
+    convert::{TryFrom, TryInto},
+    str::FromStr,
+};
 
 /// Helper type to parse both `u64` and `U256`
 #[derive(Copy, Clone, Deserialize)]
@@ -18,6 +21,18 @@ impl From<Numeric> for U256 {
         match n {
             Numeric::U256(n) => n,
             Numeric::Num(n) => U256::from(n),
+        }
+    }
+}
+
+impl FromStr for Numeric {
+    type Err = FromDecStrErr;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(val) = s.parse::<u128>() {
+            Ok(Numeric::U256(val.into()))
+        } else {
+            U256::from_dec_str(&s).map(Numeric::U256)
         }
     }
 }

--- a/ethers-core/src/types/serde_helpers.rs
+++ b/ethers-core/src/types/serde_helpers.rs
@@ -30,12 +30,10 @@ impl FromStr for Numeric {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Ok(val) = s.parse::<u128>() {
             Ok(Numeric::U256(val.into()))
+        } else if s.starts_with("0x") {
+            U256::from_str(s).map(Numeric::U256).map_err(|err| err.to_string())
         } else {
-            if s.starts_with("0x") {
-                U256::from_str(&s).map(Numeric::U256).map_err(|err| err.to_string())
-            } else {
-                U256::from_dec_str(&s).map(Numeric::U256).map_err(|err| err.to_string())
-            }
+            U256::from_dec_str(s).map(Numeric::U256).map_err(|err| err.to_string())
         }
     }
 }
@@ -59,12 +57,10 @@ impl TryFrom<StringifiedNumeric> for U256 {
             StringifiedNumeric::String(s) => {
                 if let Ok(val) = s.parse::<u128>() {
                     Ok(val.into())
+                } else if s.starts_with("0x") {
+                    U256::from_str(&s).map_err(|err| err.to_string())
                 } else {
-                    if s.starts_with("0x") {
-                        U256::from_str(&s).map_err(|err| err.to_string())
-                    } else {
-                        U256::from_dec_str(&s).map_err(|err| err.to_string())
-                    }
+                    U256::from_dec_str(&s).map_err(|err| err.to_string())
                 }
             }
         }
@@ -186,7 +182,6 @@ impl TryFrom<StringifiedBlockNumber> for BlockNumber {
         match value {
             StringifiedBlockNumber::Numeric(num) => {
                 let num = U256::try_from(num)
-                    .map_err(|err| err.to_string())
                     .and_then(|num| u64::try_from(num).map_err(str::to_string))?;
                 Ok(BlockNumber::Number(num.into()))
             }

--- a/ethers-etherscan/src/account.rs
+++ b/ethers-etherscan/src/account.rs
@@ -1,16 +1,14 @@
+use crate::{Client, EtherscanError, Query, Response, Result};
+use ethers_core::{
+    abi::Address,
+    types::{serde_helpers::*, BlockNumber, Bytes, H256, U256},
+};
+use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
     collections::HashMap,
     fmt::{Display, Error, Formatter},
 };
-
-use ethers_core::{
-    abi::Address,
-    types::{BlockNumber, Bytes, H256, U256, U64},
-};
-use serde::{Deserialize, Serialize};
-
-use crate::{Client, EtherscanError, Query, Response, Result};
 
 /// The raw response from the balance-related API endpoints
 #[derive(Debug, Serialize, Deserialize)]
@@ -100,6 +98,7 @@ impl<T> GenesisOption<T> {
 #[serde(rename_all = "camelCase")]
 pub struct NormalTransaction {
     pub is_error: String,
+    #[serde(deserialize_with = "deserialize_stringified_block_number")]
     pub block_number: BlockNumber,
     pub time_stamp: String,
     #[serde(with = "jsonstring")]
@@ -108,12 +107,16 @@ pub struct NormalTransaction {
     pub nonce: GenesisOption<U256>,
     #[serde(with = "jsonstring")]
     pub block_hash: GenesisOption<U256>,
-    pub transaction_index: Option<U64>,
+    #[serde(deserialize_with = "deserialize_stringified_u64_opt")]
+    pub transaction_index: Option<u64>,
     #[serde(with = "jsonstring")]
     pub from: GenesisOption<Address>,
     pub to: Option<Address>,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub value: U256,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub gas: U256,
+    #[serde(deserialize_with = "deserialize_stringified_numeric_opt")]
     pub gas_price: Option<U256>,
     #[serde(rename = "txreceipt_status")]
     pub tx_receipt_status: String,
@@ -121,21 +124,26 @@ pub struct NormalTransaction {
     pub input: GenesisOption<Bytes>,
     #[serde(with = "jsonstring")]
     pub contract_address: GenesisOption<Address>,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub gas_used: U256,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub cumulative_gas_used: U256,
-    pub confirmations: U64,
+    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    pub confirmations: u64,
 }
 
 /// The raw response from the internal transaction list API endpoint
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InternalTransaction {
+    #[serde(deserialize_with = "deserialize_stringified_block_number")]
     pub block_number: BlockNumber,
     pub time_stamp: String,
     pub hash: H256,
     pub from: Address,
     #[serde(with = "jsonstring")]
     pub to: GenesisOption<Address>,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub value: U256,
     #[serde(with = "jsonstring")]
     pub contract_address: GenesisOption<Address>,
@@ -143,7 +151,9 @@ pub struct InternalTransaction {
     pub input: GenesisOption<Bytes>,
     #[serde(rename = "type")]
     pub result_type: String,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub gas: U256,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub gas_used: U256,
     pub trace_id: String,
     pub is_error: String,
@@ -154,35 +164,46 @@ pub struct InternalTransaction {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ERC20TokenTransferEvent {
+    #[serde(deserialize_with = "deserialize_stringified_block_number")]
     pub block_number: BlockNumber,
     pub time_stamp: String,
     pub hash: H256,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub nonce: U256,
     pub block_hash: H256,
     pub from: Address,
     pub contract_address: Address,
     pub to: Option<Address>,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub value: U256,
     pub token_name: String,
     pub token_symbol: String,
     pub token_decimal: String,
-    pub transaction_index: U64,
+    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    pub transaction_index: u64,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub gas: U256,
+    #[serde(deserialize_with = "deserialize_stringified_numeric_opt")]
     pub gas_price: Option<U256>,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub gas_used: U256,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub cumulative_gas_used: U256,
     /// deprecated
     pub input: String,
-    pub confirmations: U64,
+    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    pub confirmations: u64,
 }
 
 /// The raw response from the ERC721 transfer list API endpoint
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ERC721TokenTransferEvent {
+    #[serde(deserialize_with = "deserialize_stringified_block_number")]
     pub block_number: BlockNumber,
     pub time_stamp: String,
     pub hash: H256,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub nonce: U256,
     pub block_hash: H256,
     pub from: Address,
@@ -193,23 +214,31 @@ pub struct ERC721TokenTransferEvent {
     pub token_name: String,
     pub token_symbol: String,
     pub token_decimal: String,
-    pub transaction_index: U64,
+    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    pub transaction_index: u64,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub gas: U256,
+    #[serde(deserialize_with = "deserialize_stringified_numeric_opt")]
     pub gas_price: Option<U256>,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub gas_used: U256,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub cumulative_gas_used: U256,
     /// deprecated
     pub input: String,
-    pub confirmations: U64,
+    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    pub confirmations: u64,
 }
 
 /// The raw response from the ERC1155 transfer list API endpoint
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ERC1155TokenTransferEvent {
+    #[serde(deserialize_with = "deserialize_stringified_block_number")]
     pub block_number: BlockNumber,
     pub time_stamp: String,
     pub hash: H256,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub nonce: U256,
     pub block_hash: H256,
     pub from: Address,
@@ -220,20 +249,27 @@ pub struct ERC1155TokenTransferEvent {
     pub token_value: String,
     pub token_name: String,
     pub token_symbol: String,
-    pub transaction_index: U64,
+    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    pub transaction_index: u64,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub gas: U256,
+    #[serde(deserialize_with = "deserialize_stringified_numeric_opt")]
     pub gas_price: Option<U256>,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub gas_used: U256,
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub cumulative_gas_used: U256,
     /// deprecated
     pub input: String,
-    pub confirmations: U64,
+    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    pub confirmations: u64,
 }
 
 /// The raw response from the mined blocks API endpoint
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MinedBlock {
+    #[serde(deserialize_with = "deserialize_stringified_block_number")]
     pub block_number: BlockNumber,
     pub time_stamp: String,
     pub block_reward: String,
@@ -739,8 +775,12 @@ mod tests {
                     ),
                     None,
                 )
-                .await;
-            assert!(txs.is_ok());
+                .await
+                .unwrap();
+            let tx = txs.get(0).unwrap();
+            assert_eq!(tx.gas_used, 93657u64.into());
+            assert_eq!(tx.nonce, 10u64.into());
+            assert_eq!(tx.block_number, 2228258u64.into());
         })
         .await
     }

--- a/ethers-etherscan/src/gas.rs
+++ b/ethers-etherscan/src/gas.rs
@@ -70,15 +70,11 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
-    use serial_test::serial;
-
-    use ethers_core::types::Chain;
-
-    use crate::tests::run_at_least_duration;
-
     use super::*;
+    use crate::tests::run_at_least_duration;
+    use ethers_core::types::Chain;
+    use serial_test::serial;
+    use std::time::Duration;
 
     #[tokio::test]
     #[serial]

--- a/ethers-etherscan/src/transaction.rs
+++ b/ethers-etherscan/src/transaction.rs
@@ -52,13 +52,10 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
-    use serial_test::serial;
-
-    use crate::{tests::run_at_least_duration, Chain};
-
     use super::*;
+    use crate::{tests::run_at_least_duration, Chain};
+    use serial_test::serial;
+    use std::time::Duration;
 
     #[tokio::test]
     #[serial]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes #1507

the etherscan API returns numbers as strings 

```json
    {
      "blockNumber": "2228258",
      "timeStamp": "1473433992",
      "hash": "0x5f2cd76fd3656686e356bc02cc91d8d0726a16936fd08e67ed30467053225a86",
      "nonce": "10",
      "blockHash": "0x466dbced0a98e1b0490f787b51570850c8347960a4e92bd89acf85299e4cb9dc",
      "from": "0x4e83362442b8d1bec281594cea3050c8eb01311c",
      "contractAddress": "0xecf8f87f810ecf450940c9f60066b4a7a501d6a7",
      "to": "0xac75b73394c329376c214663d92156afa864a77f",
      "value": "101000000000000000000",
      "tokenName": "",
      "tokenSymbol": "",
      "tokenDecimal": "1",
      "transactionIndex": "10",
      "gas": "1000000",
      "gasPrice": "20000000000",
      "gasUsed": "93657",
      "cumulativeGasUsed": "684715",
      "input": "deprecated",
      "confirmations": "13002487"
    }
```

wich results in wrong values
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
