### PR TITLE
fix: use fully qualified path for Result

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract/events.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/events.rs
@@ -77,7 +77,7 @@ impl Context {
             }
 
              impl #ethers_contract::EthLogDecode for #enum_name {
-                fn decode_log(log: &#ethers_core::abi::RawLog) -> Result<Self, #ethers_core::abi::Error>
+                fn decode_log(log: &#ethers_core::abi::RawLog) -> ::std::result::Result<Self, #ethers_core::abi::Error>
                 where
                     Self: Sized,
                 {

--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -91,7 +91,7 @@ impl Context {
             ///    let msg = greeter_contract.greet().call().await.unwrap();
             /// # }
             /// ```
-            pub fn deploy<T: #ethers_core::abi::Tokenize >(client: ::std::sync::Arc<M>, constructor_args: T) -> Result<#ethers_contract::builders::ContractDeployer<M, Self>, #ethers_contract::ContractError<M>> {
+            pub fn deploy<T: #ethers_core::abi::Tokenize >(client: ::std::sync::Arc<M>, constructor_args: T) -> ::std::result::Result<#ethers_contract::builders::ContractDeployer<M, Self>, #ethers_contract::ContractError<M>> {
                let factory = #ethers_contract::ContractFactory::new(#get_abi, #get_bytecode, client);
                let deployer = factory.deploy(constructor_args)?;
                let deployer = #ethers_contract::ContractDeployer::new(deployer);
@@ -219,7 +219,7 @@ impl Context {
             }
 
         impl  #ethers_core::abi::AbiDecode for #enum_name {
-            fn decode(data: impl AsRef<[u8]>) -> Result<Self, #ethers_core::abi::AbiError> {
+            fn decode(data: impl AsRef<[u8]>) -> ::std::result::Result<Self, #ethers_core::abi::AbiError> {
                  #(
                     if let Ok(decoded) = <#struct_names as #ethers_core::abi::AbiDecode>::decode(data.as_ref()) {
                         return Ok(#enum_name::#variant_names(decoded))

--- a/ethers-contract/ethers-contract-derive/src/abi_ty.rs
+++ b/ethers-contract/ethers-contract-derive/src/abi_ty.rs
@@ -152,7 +152,7 @@ pub fn derive_tokenizeable_impl(input: &DeriveInput) -> proc_macro2::TokenStream
              #tokenize_predicates
          {
 
-             fn from_token(token: #core_crate::abi::Token) -> Result<Self, #core_crate::abi::InvalidOutputType> where
+             fn from_token(token: #core_crate::abi::Token) -> ::std::result::Result<Self, #core_crate::abi::InvalidOutputType> where
                  Self: Sized {
                 #from_token_impl
              }
@@ -174,7 +174,7 @@ fn tokenize_unit_type(name: &Ident) -> TokenStream {
     let ethers_core = ethers_core_crate();
     quote! {
          impl #ethers_core::abi::Tokenizable for #name {
-             fn from_token(token: #ethers_core::abi::Token) -> Result<Self, #ethers_core::abi::InvalidOutputType> where
+             fn from_token(token: #ethers_core::abi::Token) -> ::std::result::Result<Self, #ethers_core::abi::InvalidOutputType> where
                  Self: Sized {
                 if let #ethers_core::abi::Token::Tuple(tokens) = token {
                     if !tokens.is_empty() {
@@ -210,7 +210,7 @@ fn tokenize_unit_type(name: &Ident) -> TokenStream {
 fn tokenize_enum<'a>(
     enum_name: &Ident,
     variants: impl Iterator<Item = &'a Variant> + 'a,
-) -> Result<TokenStream, Error> {
+) -> ::std::result::Result<TokenStream, Error> {
     let ethers_core = ethers_core_crate();
 
     let mut into_tokens = TokenStream::new();
@@ -252,7 +252,7 @@ fn tokenize_enum<'a>(
     Ok(quote! {
          impl #ethers_core::abi::Tokenizable for #enum_name {
 
-             fn from_token(token: #ethers_core::abi::Token) -> Result<Self, #ethers_core::abi::InvalidOutputType> where
+             fn from_token(token: #ethers_core::abi::Token) -> ::std::result::Result<Self, #ethers_core::abi::InvalidOutputType> where
                  Self: Sized {
                 #from_tokens
                 Err(#ethers_core::abi::InvalidOutputType("Failed to decode all type variants".to_string()))

--- a/ethers-contract/ethers-contract-derive/src/abigen.rs
+++ b/ethers-contract/ethers-contract-derive/src/abigen.rs
@@ -27,7 +27,7 @@ pub(crate) struct Contracts {
 }
 
 impl Contracts {
-    pub(crate) fn expand(self) -> Result<TokenStream2, syn::Error> {
+    pub(crate) fn expand(self) -> ::std::result::Result<TokenStream2, syn::Error> {
         let mut expansions = Vec::with_capacity(self.inner.len());
 
         // expand all contracts

--- a/ethers-contract/ethers-contract-derive/src/call.rs
+++ b/ethers-contract/ethers-contract-derive/src/call.rs
@@ -95,7 +95,7 @@ pub fn derive_trait_impls(
         }
 
         impl  #core_crate::abi::AbiDecode for #struct_name {
-            fn decode(bytes: impl AsRef<[u8]>) -> Result<Self, #core_crate::abi::AbiError> {
+            fn decode(bytes: impl AsRef<[u8]>) -> ::std::result::Result<Self, #core_crate::abi::AbiError> {
                 #decode_impl
             }
         }

--- a/ethers-contract/ethers-contract-derive/src/codec.rs
+++ b/ethers-contract/ethers-contract-derive/src/codec.rs
@@ -12,7 +12,7 @@ pub fn derive_codec_impl(input: &DeriveInput) -> proc_macro2::TokenStream {
 
     quote! {
         impl  #core_crate::abi::AbiDecode for #name {
-            fn decode(bytes: impl AsRef<[u8]>) -> Result<Self, #core_crate::abi::AbiError> {
+            fn decode(bytes: impl AsRef<[u8]>) -> ::std::result::Result<Self, #core_crate::abi::AbiError> {
                 if let #core_crate::abi::ParamType::Tuple(params) = <Self as #core_crate::abi::AbiType>::param_type() {
                   let tokens = #core_crate::abi::decode(&params, bytes.as_ref())?;
                   Ok(<Self as #core_crate::abi::Tokenizable>::from_token(#core_crate::abi::Token::Tuple(tokens))?)

--- a/ethers-contract/ethers-contract-derive/src/event.rs
+++ b/ethers-contract/ethers-contract-derive/src/event.rs
@@ -95,7 +95,7 @@ pub(crate) fn derive_eth_event_impl(input: DeriveInput) -> TokenStream {
                 #abi.into()
             }
 
-            fn decode_log(log: &#core_crate::abi::RawLog) -> Result<Self, #core_crate::abi::Error> where Self: Sized {
+            fn decode_log(log: &#core_crate::abi::RawLog) -> ::std::result::Result<Self, #core_crate::abi::Error> where Self: Sized {
                 #decode_log_impl
             }
 

--- a/ethers-contract/tests/it/common/derive.rs
+++ b/ethers-contract/tests/it/common/derive.rs
@@ -605,3 +605,16 @@ fn eth_display_works_on_ethers_bytes() {
     let s = format!("{}", call);
     assert_eq!(s, "0xaaaaaa");
 }
+
+#[test]
+fn can_use_result_name() {
+    abigen!(
+        ResultContract,
+        r#"[
+           struct Result {uint256 result;}
+           result(Result result) (uint256)
+        ]"#,
+    );
+
+    let _call = ResultCall { result: Result { result: U256::zero() } };
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes #1526


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use fully qualified path for Result to prevent clash if a struct is named `Result`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
