### PR TITLE
Add a simple constructor for Wallet

### DIFF
--- a/ethers-signers/src/wallet/mod.rs
+++ b/ethers-signers/src/wallet/mod.rs
@@ -70,7 +70,7 @@ pub struct Wallet<D: DigestSigner<Sha256Proxy, RecoverableSignature>> {
 impl<D: DigestSigner<Sha256Proxy, RecoverableSignature>> Wallet<D> {
 
     /// Construct a new wallet with an external Signer
-    pub fn new_plain(signer: D, address: Address, chain_id: u64) -> Self {
+    pub fn new_with_signer(signer: D, address: Address, chain_id: u64) -> Self {
         Wallet { signer, address, chain_id }
     }
 }

--- a/ethers-signers/src/wallet/mod.rs
+++ b/ethers-signers/src/wallet/mod.rs
@@ -67,6 +67,14 @@ pub struct Wallet<D: DigestSigner<Sha256Proxy, RecoverableSignature>> {
     pub(crate) chain_id: u64,
 }
 
+impl<D: DigestSigner<Sha256Proxy, RecoverableSignature>> Wallet<D> {
+
+    /// Construct a new wallet with an external Signer
+    pub fn new_plain(signer: D, address: Address, chain_id: u64) -> Self {
+        Wallet { signer, address, chain_id }
+    }
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl<D: Sync + Send + DigestSigner<Sha256Proxy, RecoverableSignature>> Signer for Wallet<D> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
I implemented `Signer`, but realized that I had to copy a large amount of code (Wallet and more) just to get a working implementation.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
A plain constructor for `Wallet` allows other implementation of `Signer` to use this code.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests: correctness is by inspection of the one liner
- [x] Added Documentation: yes
- [ ] Updated the changelog: I don't understand the changelog. It's from a long time ago?
