### PR TITLE
Add test reproducing panic when requesting unmined block from alchemy

### DIFF
--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1999,4 +1999,32 @@ mod tests {
         assert_eq!(tx.gas_price(), Some(gas_price));
         assert!(tx.access_list().is_none());
     }
+
+
+    const ALCHEMY_ENDPOINT: &str = "https://eth-mainnet.g.alchemy.com/v2/22nxXxb2M_6Ec7SDb7pK8OzM4qQmKxEC"; 
+    #[tokio::test]
+    async fn get_block_alchemy() {
+        let provider = Provider::<Http>::try_from(ALCHEMY_ENDPOINT)
+            .unwrap()
+            .interval(Duration::from_millis(1000));
+
+        let max_num = BlockId::from(U64::from(i64::MAX));
+        println!("max_num {:?}", max_num);
+        provider.get_block(max_num).await.unwrap();
+
+    }
+
+    #[tokio::test]
+    async fn get_block_geth() {
+        let geth = Anvil::new().block_time(2u64).spawn();
+        let provider = Provider::<Http>::try_from(geth.endpoint())
+            .unwrap()
+            .interval(Duration::from_millis(1000));
+
+        let max_num = BlockId::from(U64::from(i64::MAX));
+        println!("max_num {:?}", max_num);
+        provider.get_block(max_num).await.unwrap();
+
+    }
+
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Currently the provider panics when trying to get a non-existant block number from alchemy.
This is due to alchemy responding with a payload:

```
{
  "jsonrpc": "2.0",
  "id": 5
}
```

Which results in a panic.

## Solution

WIP: No solution yet

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
