### PR TITLE
perf(providers): get response as bytes

### DIFF
--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -72,19 +72,24 @@ impl JsonRpcClient for Provider {
         let payload = Request::new(next_id, method, params);
 
         let res = self.client.post(self.url.as_ref()).json(&payload).send().await?;
-        let text = res.text().await?;
+        let body = res.bytes().await?;
 
-        let raw = match serde_json::from_str(&text) {
+        let raw = match serde_json::from_slice(&body) {
             Ok(Response::Success { result, .. }) => result.to_owned(),
             Ok(Response::Error { error, .. }) => return Err(error.into()),
             Ok(_) => {
                 let err = ClientError::SerdeJson {
                     err: serde::de::Error::custom("unexpected notification over HTTP transport"),
-                    text,
+                    text: String::from_utf8_lossy(&body).to_string(),
                 };
                 return Err(err)
             }
-            Err(err) => return Err(ClientError::SerdeJson { err, text }),
+            Err(err) => {
+                return Err(ClientError::SerdeJson {
+                    err,
+                    text: String::from_utf8_lossy(&body).to_string(),
+                })
+            }
         };
 
         let res = serde_json::from_str(raw.get())


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
uses `resp.bytes()` instead of `resp.text()` 

[text](https://docs.rs/reqwest/latest/reqwest/struct.Response.html#method.text) decodes the body and scans the entire body. this is a bit redundant for json since deserialization is expected to fail if anyway

reqwest's [json](https://docs.rs/reqwest/latest/reqwest/struct.Response.html#method.json) function is also just this:

```rust

pub async fn json<T: DeserializeOwned>(self) -> crate::Result<T> {
        let full = self.bytes().await?;

        serde_json::from_slice(&full).map_err(crate::error::decode)
    }
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
get bytes and deserialize from_slice, and only convert to String in error case
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
