### PR TITLE
feat: add EthError trait and derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 
 ### Unreleased
 
+- generate error bindings for custom errors [#1549](https://github.com/gakonst/ethers-rs/pull/1549)
 - Support overloaded events
   [#1233](https://github.com/gakonst/ethers-rs/pull/1233)
 - Relax Clone requirements when Arc<Middleware> is used

--- a/ethers-contract/ethers-contract-abigen/src/contract/errors.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/errors.rs
@@ -1,0 +1,169 @@
+//! derive error bindings
+
+use super::{util, Context};
+use crate::contract::common::{expand_data_struct, expand_data_tuple, expand_params};
+use ethers_core::{
+    abi::{ethabi::AbiError, ErrorExt},
+    macros::{ethers_contract_crate, ethers_core_crate},
+};
+use eyre::Result;
+use inflector::Inflector;
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+
+impl Context {
+    /// Returns all error declarations
+    pub(crate) fn errors(&self) -> Result<TokenStream> {
+        let data_types = self
+            .abi
+            .errors
+            .values()
+            .flatten()
+            .map(|event| self.expand_error(event))
+            .collect::<Result<Vec<_>>>()?;
+
+        // only expand an enum when multiple errors are present
+        let errors_enum_decl = if self.abi.errors.values().flatten().count() > 1 {
+            self.expand_errors_enum()
+        } else {
+            quote! {}
+        };
+
+        Ok(quote! {
+            // HERE
+            #( #data_types )*
+
+            #errors_enum_decl
+
+            // HERE end
+        })
+    }
+
+    /// Expands an ABI error into a single error data type. This can expand either
+    /// into a structure or a tuple in the case where all error parameters are anonymous.
+    fn expand_error(&self, error: &AbiError) -> Result<TokenStream> {
+        let sig = self.error_aliases.get(&error.abi_signature()).cloned();
+        let abi_signature = error.abi_signature();
+
+        let error_name = error_struct_name(&error.name, sig);
+
+        let fields = self.expand_error_params(error)?;
+
+        // expand as a tuple if all fields are anonymous
+        let all_anonymous_fields = error.inputs.iter().all(|input| input.name.is_empty());
+        let data_type_definition = if all_anonymous_fields {
+            // expand to a tuple struct
+            expand_data_tuple(&error_name, &fields)
+        } else {
+            // expand to a struct
+            expand_data_struct(&error_name, &fields)
+        };
+
+        let doc = format!(
+            "Custom Error type `{}` with signature `{}` and selector `{:?}`",
+            error.name,
+            abi_signature,
+            error.selector()
+        );
+        let abi_signature_doc = util::expand_doc(&doc);
+        let ethers_contract = ethers_contract_crate();
+        // use the same derives as for events
+        let derives = util::expand_derives(&self.event_derives);
+
+        let error_name = &error.name;
+
+        Ok(quote! {
+             #abi_signature_doc
+            #[derive(Clone, Debug, Default, Eq, PartialEq, #ethers_contract::EthError, #ethers_contract::EthDisplay, #derives)]
+            #[etherror( name = #error_name, abi = #abi_signature )]
+            pub #data_type_definition
+        })
+    }
+
+    /// Expands to the `name : type` pairs of the function's outputs
+    fn expand_error_params(&self, error: &AbiError) -> Result<Vec<(TokenStream, TokenStream)>> {
+        expand_params(&error.inputs, |s| self.internal_structs.get_struct_type(s))
+    }
+
+    /// The name ident of the errors enum
+    fn expand_error_enum_name(&self) -> Ident {
+        util::ident(&format!("{}Errors", self.contract_ident))
+    }
+
+    /// Generate an enum with a variant for each event
+    fn expand_errors_enum(&self) -> TokenStream {
+        let variants = self
+            .abi
+            .errors
+            .values()
+            .flatten()
+            .map(|err| {
+                error_struct_name(&err.name, self.error_aliases.get(&err.abi_signature()).cloned())
+            })
+            .collect::<Vec<_>>();
+
+        let ethers_core = ethers_core_crate();
+        let ethers_contract = ethers_contract_crate();
+
+        // use the same derives as for events
+        let derives = util::expand_derives(&self.event_derives);
+        let enum_name = self.expand_error_enum_name();
+
+        quote! {
+           #[derive(Debug, Clone, PartialEq, Eq, #ethers_contract::EthAbiType, #derives)]
+            pub enum #enum_name {
+                #(#variants(#variants)),*
+            }
+
+        impl  #ethers_core::abi::AbiDecode for #enum_name {
+            fn decode(data: impl AsRef<[u8]>) -> ::std::result::Result<Self, #ethers_core::abi::AbiError> {
+                 #(
+                    if let Ok(decoded) = <#variants as #ethers_core::abi::AbiDecode>::decode(data.as_ref()) {
+                        return Ok(#enum_name::#variants(decoded))
+                    }
+                )*
+                Err(#ethers_core::abi::Error::InvalidData.into())
+            }
+        }
+
+         impl  #ethers_core::abi::AbiEncode for #enum_name {
+            fn encode(self) -> Vec<u8> {
+                match self {
+                    #(
+                        #enum_name::#variants(element) => element.encode()
+                    ),*
+                }
+            }
+        }
+
+        impl ::std::fmt::Display for #enum_name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                match self {
+                    #(
+                        #enum_name::#variants(element) => element.fmt(f)
+                    ),*
+                }
+            }
+        }
+
+        #(
+            impl ::std::convert::From<#variants> for #enum_name {
+                fn from(var: #variants) -> Self {
+                    #enum_name::#variants(var)
+                }
+            }
+        )*
+
+        }
+    }
+}
+
+/// Expands an ABI error into an identifier for its event data type.
+fn error_struct_name(error_name: &str, alias: Option<Ident>) -> Ident {
+    alias.unwrap_or_else(|| util::ident(error_name))
+}
+
+/// Returns the alias name for an error
+pub(crate) fn error_struct_alias(name: &str) -> Ident {
+    util::ident(&name.to_pascal_case())
+}

--- a/ethers-contract/ethers-contract-abigen/src/contract/structs.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/structs.rs
@@ -334,6 +334,11 @@ impl InternalStructs {
             .map(String::as_str)
     }
 
+    /// Returns the name of the rust type for the type
+    pub fn get_struct_type(&self, internal_type: &str) -> Option<&str> {
+        self.rust_type_names.get(struct_type_identifier(internal_type)).map(String::as_str)
+    }
+
     /// Returns the mapping table of abi `internal type identifier -> rust type`
     pub fn rust_type_names(&self) -> &HashMap<String, String> {
         &self.rust_type_names

--- a/ethers-contract/ethers-contract-abigen/src/lib.rs
+++ b/ethers-contract/ethers-contract-abigen/src/lib.rs
@@ -72,6 +72,9 @@ pub struct Abigen {
 
     /// Manually specified event name aliases.
     event_aliases: HashMap<String, String>,
+
+    /// Manually specified error name aliases.
+    error_aliases: HashMap<String, String>,
 }
 
 impl Abigen {
@@ -85,6 +88,7 @@ impl Abigen {
             event_derives: Vec::new(),
             event_aliases: HashMap::new(),
             rustfmt: true,
+            error_aliases: Default::default(),
         })
     }
 
@@ -123,6 +127,17 @@ impl Abigen {
         S2: Into<String>,
     {
         self.method_aliases.insert(signature.into(), alias.into());
+        self
+    }
+
+    /// Manually adds a solidity error alias to specify what the error struct will be in Rust.
+    #[must_use]
+    pub fn add_error_alias<S1, S2>(mut self, signature: S1, alias: S2) -> Self
+    where
+        S1: Into<String>,
+        S2: Into<String>,
+    {
+        self.error_aliases.insert(signature.into(), alias.into());
         self
     }
 

--- a/ethers-contract/ethers-contract-derive/src/calllike.rs
+++ b/ethers-contract/ethers-contract-derive/src/calllike.rs
@@ -1,0 +1,174 @@
+//! Code used by both `call` and `error`
+
+use crate::{abi_ty, utils};
+use ethers_core::{
+    abi::Param,
+    macros::{ethers_contract_crate, ethers_core_crate},
+};
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use syn::{parse::Error, spanned::Spanned as _, AttrStyle, DeriveInput, Lit, Meta, NestedMeta};
+
+/// All the attributes the `EthCall`/`EthError` macro supports
+#[derive(Default)]
+pub struct EthCalllikeAttributes {
+    pub name: Option<(String, Span)>,
+    pub abi: Option<(String, Span)>,
+}
+
+/// extracts the attributes from the struct annotated with the given attribute
+pub fn parse_calllike_attributes(
+    input: &DeriveInput,
+    attr_name: &str,
+) -> Result<EthCalllikeAttributes, TokenStream> {
+    let mut result = EthCalllikeAttributes::default();
+    for a in input.attrs.iter() {
+        if let AttrStyle::Outer = a.style {
+            if let Ok(Meta::List(meta)) = a.parse_meta() {
+                if meta.path.is_ident(attr_name) {
+                    for n in meta.nested.iter() {
+                        if let NestedMeta::Meta(meta) = n {
+                            match meta {
+                                Meta::Path(path) => {
+                                    return Err(Error::new(
+                                        path.span(),
+                                        format!("unrecognized {} parameter", attr_name),
+                                    )
+                                    .to_compile_error())
+                                }
+                                Meta::List(meta) => {
+                                    return Err(Error::new(
+                                        meta.path.span(),
+                                        format!("unrecognized {} parameter", attr_name),
+                                    )
+                                    .to_compile_error())
+                                }
+                                Meta::NameValue(meta) => {
+                                    if meta.path.is_ident("name") {
+                                        if let Lit::Str(ref lit_str) = meta.lit {
+                                            if result.name.is_none() {
+                                                result.name =
+                                                    Some((lit_str.value(), lit_str.span()));
+                                            } else {
+                                                return Err(Error::new(
+                                                    meta.span(),
+                                                    "name already specified",
+                                                )
+                                                .to_compile_error())
+                                            }
+                                        } else {
+                                            return Err(Error::new(
+                                                meta.span(),
+                                                "name must be a string",
+                                            )
+                                            .to_compile_error())
+                                        }
+                                    } else if meta.path.is_ident("abi") {
+                                        if let Lit::Str(ref lit_str) = meta.lit {
+                                            if result.abi.is_none() {
+                                                result.abi =
+                                                    Some((lit_str.value(), lit_str.span()));
+                                            } else {
+                                                return Err(Error::new(
+                                                    meta.span(),
+                                                    "abi already specified",
+                                                )
+                                                .to_compile_error())
+                                            }
+                                        } else {
+                                            return Err(Error::new(
+                                                meta.span(),
+                                                "abi must be a string",
+                                            )
+                                            .to_compile_error())
+                                        }
+                                    } else {
+                                        return Err(Error::new(
+                                            meta.span(),
+                                            format!("unrecognized {} parameter", attr_name),
+                                        )
+                                        .to_compile_error())
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(result)
+}
+
+/// Generates the decode implementation based on the type's runtime `AbiType` impl
+pub fn derive_decode_impl_with_abi_type(
+    input: &DeriveInput,
+    trait_ident: Ident,
+) -> Result<TokenStream, Error> {
+    let datatypes_array = utils::derive_abi_parameters_array(input, &trait_ident.to_string())?;
+    Ok(derive_decode_impl(datatypes_array, trait_ident))
+}
+
+/// Generates the decode implementation based on the params
+pub fn derive_decode_impl_from_params(params: &[Param], trait_ident: Ident) -> TokenStream {
+    let datatypes = params.iter().map(|input| utils::param_type_quote(&input.kind));
+    let datatypes_array = quote! {[#( #datatypes ),*]};
+    derive_decode_impl(datatypes_array, trait_ident)
+}
+
+pub fn derive_decode_impl(datatypes_array: TokenStream, trait_ident: Ident) -> TokenStream {
+    let core_crate = ethers_core_crate();
+    let contract_crate = ethers_contract_crate();
+    let data_types_init = quote! {let data_types = #datatypes_array;};
+
+    quote! {
+        let bytes = bytes.as_ref();
+        if bytes.len() < 4 || bytes[..4] != <Self as #contract_crate::#trait_ident>::selector() {
+            return Err(#contract_crate::AbiError::WrongSelector);
+        }
+        #data_types_init
+        let data_tokens = #core_crate::abi::decode(&data_types, &bytes[4..])?;
+        Ok(<Self as #core_crate::abi::Tokenizable>::from_token( #core_crate::abi::Token::Tuple(data_tokens))?)
+    }
+}
+
+/// Generates the Codec implementation
+pub fn derive_codec_impls(
+    input: &DeriveInput,
+    decode_impl: TokenStream,
+    trait_ident: Ident,
+) -> TokenStream {
+    // the ethers crates to use
+    let core_crate = ethers_core_crate();
+    let contract_crate = ethers_contract_crate();
+    let struct_name = &input.ident;
+
+    let codec_impl = quote! {
+
+        impl #core_crate::abi::AbiDecode for #struct_name {
+            fn decode(bytes: impl AsRef<[u8]>) -> ::std::result::Result<Self, #core_crate::abi::AbiError> {
+                #decode_impl
+            }
+        }
+
+        impl #core_crate::abi::AbiEncode for #struct_name {
+            fn encode(self) -> ::std::vec::Vec<u8> {
+                let tokens =  #core_crate::abi::Tokenize::into_tokens(self);
+                let selector = <Self as #contract_crate::#trait_ident>::selector();
+                let encoded = #core_crate::abi::encode(&tokens);
+                selector
+                    .iter()
+                    .copied()
+                    .chain(encoded.into_iter())
+                    .collect()
+            }
+        }
+
+    };
+    let tokenize_impl = abi_ty::derive_tokenizeable_impl(input);
+
+    quote! {
+        #tokenize_impl
+        #codec_impl
+    }
+}

--- a/ethers-contract/ethers-contract-derive/src/lib.rs
+++ b/ethers-contract/ethers-contract-derive/src/lib.rs
@@ -11,8 +11,10 @@ use abigen::Contracts;
 pub(crate) mod abi_ty;
 mod abigen;
 mod call;
+pub(crate) mod calllike;
 mod codec;
 mod display;
+mod error;
 mod event;
 mod spanned;
 pub(crate) mod utils;
@@ -280,4 +282,41 @@ pub fn derive_abi_event(input: TokenStream) -> TokenStream {
 pub fn derive_abi_call(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     TokenStream::from(call::derive_eth_call_impl(input))
+}
+
+/// Derives the `EthError` and `Tokenizeable` trait for the labeled type.
+///
+/// Additional arguments can be specified using the `#[etherror(...)]`
+/// attribute:
+///
+/// For the struct:
+///
+/// - `name`, `name = "..."`: Overrides the generated `EthCall` function name, default is the
+///  struct's name.
+/// - `abi`, `abi = "..."`: The ABI signature for the function this call's data corresponds to.
+///
+///  NOTE: in order to successfully parse the `abi` (`<name>(<args>,...)`) the `<name`>
+///   must match either the struct name or the name attribute: `#[ethcall(name ="<name>"]`
+///
+/// # Example
+///
+/// ```ignore
+/// use ethers_contract::EthError;
+///
+/// #[derive(Debug, Clone, EthError)]
+/// #[etherror(name ="my_error")]
+/// struct MyError {
+///     addr: Address,
+///     old_value: String,
+///     new_value: String,
+/// }
+/// assert_eq!(
+///     MyCall::abi_signature().as_ref(),
+///     "my_error(address,string,string)"
+/// );
+/// ```
+#[proc_macro_derive(EthError, attributes(etherror))]
+pub fn derive_abi_error(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(error::derive_eth_error_impl(input))
 }

--- a/ethers-contract/ethers-contract-derive/src/utils.rs
+++ b/ethers-contract/ethers-contract-derive/src/utils.rs
@@ -1,10 +1,14 @@
 use ethers_core::{abi::ParamType, macros::ethers_core_crate, types::Selector};
-use proc_macro2::Literal;
+use proc_macro2::{Ident, Literal, Span};
 use quote::{quote, quote_spanned};
 use syn::{
     parse::Error, spanned::Spanned as _, Data, DeriveInput, Expr, Fields, GenericArgument, Lit,
     PathArguments, Type,
 };
+
+pub fn ident(name: &str) -> Ident {
+    Ident::new(name, Span::call_site())
+}
 
 pub fn signature(hash: &[u8]) -> proc_macro2::TokenStream {
     let core_crate = ethers_core_crate();

--- a/ethers-contract/src/error.rs
+++ b/ethers-contract/src/error.rs
@@ -1,0 +1,20 @@
+use ethers_core::{
+    abi::{AbiDecode, AbiEncode, Tokenizable},
+    types::Selector,
+    utils::id,
+};
+use std::borrow::Cow;
+
+/// A helper trait for types that represents a custom error type
+pub trait EthError: Tokenizable + AbiDecode + AbiEncode + Send + Sync {
+    /// The name of the error
+    fn error_name() -> Cow<'static, str>;
+
+    /// Retrieves the ABI signature for the error
+    fn abi_signature() -> Cow<'static, str>;
+
+    /// The selector of the error
+    fn selector() -> Selector {
+        id(Self::abi_signature())
+    }
+}

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -11,6 +11,9 @@ pub use base::{decode_function_data, encode_function_data, AbiError, BaseContrac
 mod call;
 pub use call::{ContractError, EthCall};
 
+mod error;
+pub use error::EthError;
+
 mod factory;
 pub use factory::{ContractDeployer, ContractFactory};
 
@@ -42,7 +45,9 @@ pub use ethers_contract_abigen::{Abigen, MultiAbigen};
 
 #[cfg(any(test, feature = "abigen"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "abigen")))]
-pub use ethers_contract_derive::{abigen, EthAbiCodec, EthAbiType, EthCall, EthDisplay, EthEvent};
+pub use ethers_contract_derive::{
+    abigen, EthAbiCodec, EthAbiType, EthCall, EthDisplay, EthError, EthEvent,
+};
 
 // Hide the Lazy re-export, it's just for convenience
 #[doc(hidden)]

--- a/ethers-contract/tests/it/abigen.rs
+++ b/ethers-contract/tests/it/abigen.rs
@@ -629,6 +629,18 @@ fn can_gen_seaport() {
         "fulfillAdvancedOrder(((address,address,(uint8,address,uint256,uint256,uint256)[],(uint8,address,uint256,uint256,uint256,address)[],uint8,uint256,uint256,bytes32,uint256,bytes32,uint256),uint120,uint120,bytes,bytes),(uint256,uint8,uint256,uint256,bytes32[])[],bytes32,address)"
     );
     assert_eq!(hex::encode(FulfillAdvancedOrderCall::selector()), "e7acab24");
+
+    assert_codec::<SeaportErrors>();
+    let err = SeaportErrors::BadContractSignature(BadContractSignature::default());
+
+    let encoded = err.clone().encode();
+    assert_eq!(err, SeaportErrors::decode(encoded).unwrap());
+
+    let err = SeaportErrors::ConsiderationNotMet(ConsiderationNotMet {
+        order_index: U256::zero(),
+        consideration_index: U256::zero(),
+        shortfall_amount: U256::zero(),
+    });
 }
 
 #[test]

--- a/ethers-core/src/abi/mod.rs
+++ b/ethers-core/src/abi/mod.rs
@@ -70,6 +70,29 @@ impl EventExt for Event {
     }
 }
 
+/// Extension trait for `ethabi::AbiError`.
+pub trait ErrorExt {
+    /// Compute the method signature in the standard ABI format.
+    fn abi_signature(&self) -> String;
+
+    /// Compute the Keccak256 error selector used by contract ABIs.
+    fn selector(&self) -> Selector;
+}
+
+impl ErrorExt for ethabi::AbiError {
+    fn abi_signature(&self) -> String {
+        if self.inputs.is_empty() {
+            return format!("{}()", self.name)
+        }
+        let inputs = self.inputs.iter().map(|p| p.kind.to_string()).collect::<Vec<_>>().join(",");
+        format!("{}({})", self.name, inputs)
+    }
+
+    fn selector(&self) -> Selector {
+        id(self.abi_signature())
+    }
+}
+
 /// A trait for types that can be represented in the ethereum ABI.
 pub trait AbiType {
     /// The native ABI type this type represents.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Add support for custom errors
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* introduce new `EthError` trait, basically same as `EthCall` with derive impl
  * unify some derive code for `EthCall` and `EthError` in `calllike` 
* support human readable error parsing
* generate bindings for custom solidity errors, if there are more than 1 error in the abi, we generate an error enum `enum <name>Errors {..` see Seaport test

 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
