### PR TITLE
feat(provider): expose url for http

### DIFF
--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1338,6 +1338,18 @@ impl Provider<crate::Ipc> {
     }
 }
 
+impl Provider<HttpProvider> {
+    /// The Url to which requests are made
+    pub fn url(&self) -> &Url {
+        self.inner.url()
+    }
+
+    /// Mutable access to the Url to which requests are made
+    pub fn url_mut(&mut self) -> &mut Url {
+        self.inner.url_mut()
+    }
+}
+
 impl<Read, Write> Provider<RwClient<Read, Write>>
 where
     Read: JsonRpcClient + 'static,

--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -115,6 +115,16 @@ impl Provider {
         Self::new_with_client(url, Client::new())
     }
 
+    /// The Url to which requests are made
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Mutable access to the Url to which requests are made
+    pub fn url_mut(&mut self) -> &mut Url {
+        &mut self.url
+    }
+
     /// Initializes a new HTTP Client with authentication
     ///
     /// # Example


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
expose the `Url` for HTTP provider, this way we can get and adjust the URL the Http connects to

ideally this should be included in the general abstraction, ref #1267 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
