### PR TITLE
chore: seal extension traits

### DIFF
--- a/ethers-core/src/abi/mod.rs
+++ b/ethers-core/src/abi/mod.rs
@@ -26,8 +26,19 @@ pub use human_readable::{
 
 use crate::types::{H256, H512, I256, U128, U256, U64};
 
+
+mod sealed {
+    use ethabi::{Event, Function};
+
+    /// private trait to ensure extension traits are used as intended
+    pub trait Sealed {}
+    impl Sealed for Function {}
+    impl Sealed for Event {}
+    impl Sealed for ethabi::AbiError {}
+}
+
 /// Extension trait for `ethabi::Function`.
-pub trait FunctionExt {
+pub trait FunctionExt: sealed::Sealed {
     /// Compute the method signature in the standard ABI format. This does not
     /// include the output types.
     fn abi_signature(&self) -> String;
@@ -52,7 +63,7 @@ impl FunctionExt for Function {
 }
 
 /// Extension trait for `ethabi::Event`.
-pub trait EventExt {
+pub trait EventExt: sealed::Sealed {
     /// Compute the event signature in human-readable format. The `keccak256`
     /// hash of this value is the actual event signature that is used as topic0
     /// in the transaction logs.
@@ -71,7 +82,7 @@ impl EventExt for Event {
 }
 
 /// Extension trait for `ethabi::AbiError`.
-pub trait ErrorExt {
+pub trait ErrorExt: sealed::Sealed {
     /// Compute the method signature in the standard ABI format.
     fn abi_signature(&self) -> String;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
seal extension traits so they can't be implemented since these are only intended for `ethabi`.

this prevents accidental misuse where `EthCall` or `EthEvent` traits should actually be used

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
