### PR TITLE
fix(provider): use provider interval on PendingTransaction

### DIFF
--- a/ethers-providers/src/pending_transaction.rs
+++ b/ethers-providers/src/pending_transaction.rs
@@ -1,7 +1,4 @@
-use crate::{
-    stream::{interval, DEFAULT_POLL_INTERVAL},
-    JsonRpcClient, Middleware, PinBoxFut, Provider, ProviderError,
-};
+use crate::{stream::interval, JsonRpcClient, Middleware, PinBoxFut, Provider, ProviderError};
 use ethers_core::types::{Transaction, TransactionReceipt, TxHash, U64};
 use futures_core::stream::Stream;
 use futures_util::stream::StreamExt;
@@ -70,13 +67,14 @@ const DEFAULT_RETRIES: usize = 3;
 impl<'a, P: JsonRpcClient> PendingTransaction<'a, P> {
     /// Creates a new pending transaction poller from a hash and a provider
     pub fn new(tx_hash: TxHash, provider: &'a Provider<P>) -> Self {
-        let delay = Box::pin(Delay::new(DEFAULT_POLL_INTERVAL));
+        let delay = Box::pin(Delay::new(provider.get_interval()));
+
         Self {
             tx_hash,
             confirmations: 1,
             provider,
             state: PendingTxState::InitialDelay(delay),
-            interval: Box::new(interval(DEFAULT_POLL_INTERVAL)),
+            interval: Box::new(interval(provider.get_interval())),
             retries_remaining: DEFAULT_RETRIES,
         }
     }

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -635,7 +635,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.fill_transaction(&mut tx, block).await?;
         let tx_hash = self.request("eth_sendTransaction", [tx]).await?;
 
-        Ok(PendingTransaction::new(tx_hash, self).interval(self.get_interval()))
+        Ok(PendingTransaction::new(tx_hash, self))
     }
 
     /// Send the raw RLP encoded transaction to the entire Ethereum network and returns the
@@ -646,7 +646,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
     ) -> Result<PendingTransaction<'a, P>, ProviderError> {
         let rlp = utils::serialize(&tx);
         let tx_hash = self.request("eth_sendRawTransaction", [rlp]).await?;
-        Ok(PendingTransaction::new(tx_hash, self).interval(self.get_interval()))
+        Ok(PendingTransaction::new(tx_hash, self))
     }
 
     /// The JSON-RPC provider is at the bottom-most position in the middleware stack. Here we check


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
ref https://github.com/foundry-rs/foundry/pull/2579

Pending transaction was not respecting the provider interval duration. 
