### PR TITLE
solc: fix bug in basic lib and basic contract generation

### DIFF
--- a/ethers-solc/src/project_util/mod.rs
+++ b/ethers-solc/src/project_util/mod.rs
@@ -191,8 +191,8 @@ impl<T: ArtifactOutput> TempProject<T> {
 pragma solidity {};
 contract {} {{}}
             "#,
+                version.as_ref(),
                 name,
-                version.as_ref()
             ),
         )
     }
@@ -219,8 +219,8 @@ contract {} {{}}
 pragma solidity {};
 contract {} {{}}
             "#,
+                version.as_ref(),
                 name,
-                version.as_ref()
             ),
         )
     }

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -2128,3 +2128,27 @@ fn can_handle_conflicting_files() {
         ]
     );
 }
+
+#[test]
+fn can_add_basic_contract_and_library() {
+    let mut project = TempProject::<ConfigurableArtifacts>::dapptools().unwrap();
+
+    let remapping = project.paths().libraries[0].join("remapping");
+    project
+        .paths_mut()
+        .remappings
+        .push(Remapping::from_str(&format!("remapping/={}/", remapping.display())).unwrap());
+
+    let src = project.add_basic_source("Foo.sol", "^0.8.0").unwrap();
+
+    let lib = project.add_basic_source("Bar.sol", "^0.8.0").unwrap();
+
+    let graph = Graph::resolve(project.paths()).unwrap();
+    assert_eq!(graph.files().len(), 2);
+    assert_eq!(graph.files().clone(), HashMap::from([(src, 0), (lib, 1),]));
+
+    let compiled = project.compile().unwrap();
+    assert!(compiled.find_first("Foo").is_some());
+    assert!(compiled.find_first("Bar").is_some());
+    assert!(!compiled.has_compiler_errors());
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
In `add_basic_lib` and `add_basic_source` functions, the `format!` parameters are written in the wrong order. This creates contracts with "pragma solidity Contract.sol" and declared "contract ^0.8.0 {}".
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Swap the two parameters (after the string literal) passed to the `format!` macro in the mentioned functions.
## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog

This is just a bug fix, so I don't think adding docs and updating changelog is necessary. If they are, please let me know.
