### PR TITLE
feat(TraceType+Deserialize): added Deserialize to TraceType

### DIFF
--- a/ethers-core/src/types/trace/mod.rs
+++ b/ethers-core/src/types/trace/mod.rs
@@ -11,7 +11,7 @@ pub use filter::*;
 mod geth;
 pub use geth::*;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 /// Description of the type of trace to make
 pub enum TraceType {
     /// Transaction Trace


### PR DESCRIPTION
## Motivation

Would be cleaner if foundry used the same type for ```trace_replayTransaction``` but it doesn't implement Deserialize.

## Solution

Implement Deserialize.
