### PR TITLE
chore: update svm and svm-builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3767,9 +3767,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svm-rs"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb821e69d2c2131d7b4c776865afd16515baccaf9ce478e5c7d89e2b22584566"
+checksum = "0d3173bcc4e5c210a147bd6d61becd3cc053517bf38253bd93c376ae7d818172"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3798,9 +3798,9 @@ dependencies = [
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40d9e313af1ab9fa5c7bfc75b797dfc177dab9168ff9e0e9be762bcae74f990"
+checksum = "9667365ef795e87d08cb456815d028ce96bfdcfd7b9aaa2bb461766e2e4a738b"
 dependencies = [
  "build_const",
  "hex",

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -43,8 +43,8 @@ cfg-if = "1.0.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 home = "0.5.3"
-svm = { package = "svm-rs", version = "0.2.14", default-features = false, optional = true, features = ["blocking"] }
-svm-builds = { package = "svm-rs-builds", version = "0.1.6", optional = true}
+svm = { package = "svm-rs", version = "0.2.15", default-features = false, optional = true, features = ["blocking"] }
+svm-builds = { package = "svm-rs-builds", version = "0.1.7", optional = true}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # NOTE: this enables wasm compatibility for getrandom indirectly


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

svm 0.2.15 and svm-builds 0.1.7 were published after having update the solc binaries for 0.8.15 and 0.8.16 to support Z3 SMT solver but with statically linked Z3. This will resolve issues experienced by Foundry users who do not have Z3 installed, due to Z3 previously being dynamically linked for the solc builds.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
