### PR TITLE
fix(solc): ensure base-path is not include-path

### DIFF
--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -188,6 +188,10 @@ impl<T: ArtifactOutput> Project<T> {
                     solc = solc.with_base_path(self.root());
                     if SUPPORTS_INCLUDE_PATH.matches(&version) {
                         include_paths.extend(self.include_paths.paths().cloned());
+                        // `--base-path` and `--include-path` conflict if set to the same path, so
+                        // as a precaution, we ensure here that the `--base-path` is not also used
+                        // for `--include-path`
+                        include_paths.remove(self.root());
                         solc = solc.args(include_paths.args());
                     }
                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
ensure that the `--base-path` is not also used for `--include-path`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
