### PR TITLE
chore: bump ethabi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "17.1.0"
+version = "17.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f186de076b3e77b8e6d73c99d1b52edc2a229e604f4b5eb6992c06c11d79d537"
+checksum = "e4966fba78396ff92db3b817ee71143eccd98acf0f876b8d600e585a670c5d1b"
 dependencies = [
  "ethereum-types",
  "hex",

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["ethereum", "web3", "celo", "ethers"]
 [dependencies]
 fastrlp = { version = "0.1.3", features = ["std", "derive", "ethereum-types"] }
 rlp = { version = "0.5.0", default-features = false, features = ["std"] }
-ethabi = { version = "17.1.0", default-features = false, features = ["full-serde", "rlp"] }
+ethabi = { version = "17.2.0", default-features = false, features = ["full-serde", "rlp"] }
 arrayvec = { version = "0.7.2", default-features = false }
 rlp-derive = { version = "0.1.0", default-features = false }
 


### PR DESCRIPTION
## Motivation

https://github.com/rust-ethereum/ethabi/pull/276 landed in `17.2.0`
