### PR TITLE
fix(providers): validate address resolver

### DIFF
--- a/ethers-providers/src/ens.rs
+++ b/ethers-providers/src/ens.rs
@@ -28,6 +28,9 @@ pub const NAME_SELECTOR: Selector = [105, 31, 52, 49];
 /// text(bytes32, string)
 pub const FIELD_SELECTOR: Selector = [89, 209, 212, 60];
 
+/// supportsInterface(bytes4 interfaceID)
+pub const INTERFACE_SELECTOR: Selector = [1, 255, 201, 167];
+
 /// Returns a transaction request for calling the `resolver` method on the ENS server
 pub fn get_resolver<T: Into<Address>>(ens_address: T, name: &str) -> TransactionRequest {
     // keccak256('resolver(bytes32)')
@@ -35,6 +38,19 @@ pub fn get_resolver<T: Into<Address>>(ens_address: T, name: &str) -> Transaction
     TransactionRequest {
         data: Some(data.into()),
         to: Some(NameOrAddress::Address(ens_address.into())),
+        ..Default::default()
+    }
+}
+
+/// Returns a transaction request for checking interface support
+pub fn supports_interface<T: Into<Address>>(
+    resolver_address: T,
+    selector: Selector,
+) -> TransactionRequest {
+    let data = [&INTERFACE_SELECTOR[..], &selector[..]].concat();
+    TransactionRequest {
+        data: Some(data.into()),
+        to: Some(NameOrAddress::Address(resolver_address.into())),
         ..Default::default()
     }
 }

--- a/ethers-providers/src/ens.rs
+++ b/ethers-providers/src/ens.rs
@@ -47,7 +47,7 @@ pub fn supports_interface<T: Into<Address>>(
     resolver_address: T,
     selector: Selector,
 ) -> TransactionRequest {
-    let data = [&INTERFACE_SELECTOR[..], &selector[..]].concat();
+    let data = [&INTERFACE_SELECTOR[..], &selector[..], &[0; 28]].concat();
     TransactionRequest {
         data: Some(data.into()),
         to: Some(NameOrAddress::Address(resolver_address.into())),

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1250,7 +1250,7 @@ impl<P: JsonRpcClient> Provider<P> {
         }
 
         if let ParamType::Address = param {
-            // Reverse resolver reverts when calling `supportInterface(bytes4)`
+            // Reverse resolver reverts when calling `supportsInterface(bytes4)`
             self.validate_resolver(resolver_address, selector, ens_name).await?;
         }
 
@@ -1266,7 +1266,7 @@ impl<P: JsonRpcClient> Provider<P> {
     async fn validate_resolver(
         &self,
         resolver_address: Address,
-        selector: [u8; 4],
+        selector: Selector,
         ens_name: &str,
     ) -> Result<(), ProviderError> {
         let data =

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1285,7 +1285,8 @@ impl<P: JsonRpcClient> Provider<P> {
 
         if !supports_selector {
             return Err(ProviderError::EnsError(format!(
-                "Resolver ({:?}) does not support selector {}.",
+                "`{}` resolver ({:?}) does not support selector {}.",
+                ens_name,
                 resolver_address,
                 hex::encode(&selector)
             )))

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1249,12 +1249,49 @@ impl<P: JsonRpcClient> Provider<P> {
             return Err(ProviderError::EnsError(ens_name.to_owned()))
         }
 
+        if let ParamType::Address = param {
+            // Reverse resolver reverts when calling `supportInterface(bytes4)`
+            self.validate_resolver(resolver_address, selector, ens_name).await?;
+        }
+
         // resolve
         let data = self
             .call(&ens::resolve(resolver_address, selector, ens_name, parameters).into(), None)
             .await?;
 
         Ok(decode_bytes(param, data))
+    }
+
+    /// Validates that the resolver supports `selector`.
+    async fn validate_resolver(
+        &self,
+        resolver_address: Address,
+        selector: [u8; 4],
+        ens_name: &str,
+    ) -> Result<(), ProviderError> {
+        let data =
+            self.call(&ens::supports_interface(resolver_address, selector).into(), None).await?;
+
+        if data.is_empty() {
+            return Err(ProviderError::EnsError(format!(
+                "`{}` resolver ({:?}) is invalid.",
+                ens_name, resolver_address
+            )))
+        }
+
+        let supports_selector = abi::decode(&[ParamType::Bool], data.as_ref())
+            .map(|token| token[0].clone().into_bool().unwrap_or_default())
+            .unwrap_or_default();
+
+        if !supports_selector {
+            return Err(ProviderError::EnsError(format!(
+                "Resolver ({:?}) does not support selector {}.",
+                resolver_address,
+                hex::encode(&selector)
+            )))
+        }
+
+        Ok(())
     }
 
     #[cfg(test)]
@@ -1985,5 +2022,20 @@ mod tests {
         assert_eq!(tx.gas(), Some(&gas));
         assert_eq!(tx.gas_price(), Some(gas_price));
         assert!(tx.access_list().is_none());
+    }
+
+    #[tokio::test]
+    async fn mainnet_lookup_address_invalid_resolver() {
+        let provider = crate::MAINNET.provider();
+
+        let err = provider
+            .lookup_address("0x30c9223d9e3d23e0af1073a38e0834b055bf68ed".parse().unwrap())
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            &err.to_string(),
+            "ens name not found: `ox63616e.eth` resolver (0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) is invalid."
+        );
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
ref https://github.com/foundry-rs/foundry/issues/2764

> seems like the domain ox63616e.eth has its resolver set to the WETH contract, ultimately leading to decoding a '0x' address



<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Make sure that the resolver set is a valid one that supports `name(bytes32)` or any other selector that might be passed.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
