### PR TITLE
fix(providers): QuorumProvider zero-parameter json Value handling

### DIFF
--- a/ethers-providers/src/transports/mock.rs
+++ b/ethers-providers/src/transports/mock.rs
@@ -53,7 +53,14 @@ impl MockProvider {
     ) -> Result<(), MockError> {
         let (m, inp) = self.requests.lock().unwrap().pop_front().ok_or(MockError::EmptyRequests)?;
         assert_eq!(m, method);
-        assert_eq!(serde_json::to_value(data).expect("could not serialize data"), inp);
+        assert!(!matches!(inp, serde_json::Value::Null));
+        if std::mem::size_of::<T>() == 0 {
+            assert!(inp.is_array());
+            assert_eq!(inp.as_array().unwrap().len(), 0);
+        } else {
+            assert_eq!(serde_json::to_value(data).expect("could not serialize data"), inp);
+        }
+
         Ok(())
     }
 

--- a/ethers-providers/src/transports/mock.rs
+++ b/ethers-providers/src/transports/mock.rs
@@ -10,10 +10,19 @@ use std::{
 };
 use thiserror::Error;
 
+/// Helper type that can be used to pass through the `params` value.
+/// This is necessary because the wrapper provider is supposed to skip the `params` if it's of
+/// size 0, see `crate::transports::common::Request`
+#[derive(Debug)]
+enum MockParams {
+    Value(Value),
+    Zst
+}
+
 #[derive(Clone, Debug)]
 /// Mock transport used in test environments.
 pub struct MockProvider {
-    requests: Arc<Mutex<VecDeque<(String, Value)>>>,
+    requests: Arc<Mutex<VecDeque<(String, MockParams)>>>,
     responses: Arc<Mutex<VecDeque<Value>>>,
 }
 
@@ -28,14 +37,19 @@ impl Default for MockProvider {
 impl JsonRpcClient for MockProvider {
     type Error = MockError;
 
-    /// Pushes the `(method, input)` to the back of the `requests` queue,
+    /// Pushes the `(method, params)` to the back of the `requests` queue,
     /// pops the responses from the back of the `responses` queue
     async fn request<T: Serialize + Send + Sync, R: DeserializeOwned>(
         &self,
         method: &str,
-        input: T,
+        params: T,
     ) -> Result<R, MockError> {
-        self.requests.lock().unwrap().push_back((method.to_owned(), serde_json::to_value(input)?));
+        let params = if std::mem::size_of::<T>() == 0 {
+            MockParams::Zst
+        } else {
+            MockParams::Value(serde_json::to_value(params)?)
+        };
+        self.requests.lock().unwrap().push_back((method.to_owned(), params));
         let mut data = self.responses.lock().unwrap();
         let element = data.pop_back().ok_or(MockError::EmptyResponses)?;
         let res: R = serde_json::from_value(element)?;
@@ -53,12 +67,13 @@ impl MockProvider {
     ) -> Result<(), MockError> {
         let (m, inp) = self.requests.lock().unwrap().pop_front().ok_or(MockError::EmptyRequests)?;
         assert_eq!(m, method);
-        assert!(!matches!(inp, serde_json::Value::Null));
+        assert!(!matches!(inp, MockParams::Value(serde_json::Value::Null)));
         if std::mem::size_of::<T>() == 0 {
-            assert!(inp.is_array());
-            assert_eq!(inp.as_array().unwrap().len(), 0);
-        } else {
+            assert!(matches!(inp, MockParams::Zst));
+        } else if let MockParams::Value(inp) = inp {
             assert_eq!(serde_json::to_value(data).expect("could not serialize data"), inp);
+        } else {
+            unreachable!("Zero sized types must be denoted with MockParams::Zst")
         }
 
         Ok(())

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -1,5 +1,4 @@
 use std::{
-    fmt,
     fmt::Debug,
     future::Future,
     pin::Pin,
@@ -166,7 +165,7 @@ impl<T: JsonRpcClientWrapper> QuorumProvider<T> {
     /// This is the minimum of all provider's block numbers
     async fn get_minimum_block_number(&self) -> Result<U64, ProviderError> {
         let mut numbers = join_all(self.providers.iter().map(|provider| async move {
-            let block = provider.inner.request("eth_blockNumber", serde_json::json!([])).await?;
+            let block = provider.inner.request("eth_blockNumber", QuorumParams::Zst).await?;
             serde_json::from_value::<U64>(block).map_err(ProviderError::from)
         }))
         .await
@@ -181,7 +180,13 @@ impl<T: JsonRpcClientWrapper> QuorumProvider<T> {
     }
 
     /// Normalizes the request payload depending on the call
-    async fn normalize_request(&self, method: &str, params: &mut Value) {
+    async fn normalize_request(&self, method: &str, q_params: &mut QuorumParams) {
+        let params = if let QuorumParams::Value(v) = q_params {
+            v
+        } else {
+            // at this time no normalization is required for calls with zero parameters.
+            return
+        };
         match method {
             "eth_call" |
             "eth_createAccessList" |
@@ -364,8 +369,8 @@ impl From<QuorumError> for ProviderError {
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-pub trait JsonRpcClientWrapper: Send + Sync + fmt::Debug {
-    async fn request(&self, method: &str, params: Value) -> Result<Value, ProviderError>;
+pub trait JsonRpcClientWrapper: Send + Sync + Debug {
+    async fn request(&self, method: &str, params: QuorumParams) -> Result<Value, ProviderError>;
 }
 type NotificationStream =
     Box<dyn futures_core::Stream<Item = Box<RawValue>> + Send + Unpin + 'static>;
@@ -381,14 +386,20 @@ pub trait PubsubClientWrapper: JsonRpcClientWrapper {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl<C: JsonRpcClient> JsonRpcClientWrapper for C {
-    async fn request(&self, method: &str, params: Value) -> Result<Value, ProviderError> {
-        Ok(JsonRpcClient::request(self, method, params).await.map_err(C::Error::into)?)
+    async fn request(&self, method: &str, params: QuorumParams) -> Result<Value, ProviderError> {
+        let fut = if let QuorumParams::Value(params) = params {
+            JsonRpcClient::request(self, method, params)
+        } else {
+            JsonRpcClient::request(self, method, ())
+        };
+
+        Ok(fut.await.map_err(C::Error::into)?)
     }
 }
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl JsonRpcClientWrapper for Box<dyn JsonRpcClientWrapper> {
-    async fn request(&self, method: &str, params: Value) -> Result<Value, ProviderError> {
+    async fn request(&self, method: &str, params: QuorumParams) -> Result<Value, ProviderError> {
         self.as_ref().request(method, params).await
     }
 }
@@ -396,7 +407,7 @@ impl JsonRpcClientWrapper for Box<dyn JsonRpcClientWrapper> {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl JsonRpcClientWrapper for Box<dyn PubsubClientWrapper> {
-    async fn request(&self, method: &str, params: Value) -> Result<Value, ProviderError> {
+    async fn request(&self, method: &str, params: QuorumParams) -> Result<Value, ProviderError> {
         self.as_ref().request(method, params).await
     }
 }
@@ -439,9 +450,9 @@ where
     ) -> Result<R, Self::Error> {
         let mut params = if std::mem::size_of::<T>() == 0 {
             // we don't want `()` to become `"null"`.
-            serde_json::json!([])
+            QuorumParams::Zst
         } else {
-            serde_json::to_value(params)?
+            QuorumParams::Value(serde_json::to_value(params)?)
         };
         self.normalize_request(method, &mut params).await;
 
@@ -559,6 +570,15 @@ where
         }
         Ok(())
     }
+}
+
+/// Helper type that can be used to pass through the `params` value.
+/// This is necessary because the wrapper provider is supposed to skip the `params` if it's of
+/// size 0, see `crate::transports::common::Request`
+#[derive(Clone)]
+pub enum QuorumParams {
+    Value(Value),
+    Zst
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Currently the `QuorumProvider` fails for the very simple case of `provider.request("eth_blockNumber", ())`.

Example code which fails:
```rs
use ethers::prelude::{Http, JsonRpcClient, Quorum, QuorumProvider, WeightedProvider, U64};

#[tokio::main(flavor = "current_thread")]
async fn main() {
    let provider1 = "http://127.0.0.1:8545".parse::<Http>().unwrap();
    let provider2 = "http://127.0.0.1:8545".parse::<Http>().unwrap();
    let provider3 = "http://127.0.0.1:8545".parse::<Http>().unwrap();
    let quorum_provider = QuorumProvider::builder()
        .add_providers(
            [&provider1, &provider2, &provider3]
                .into_iter()
                .cloned()
                .map(WeightedProvider::new),
        )
        .quorum(Quorum::Majority)
        .build();

    let block_number: U64 = quorum_provider
        .request("eth_blockNumber", ())
        .await
        .expect("Failed to get block number");
    println!("Quorum block number {block_number}");
}
```

Ran against the hardhat node.
```
$ yarn hardhat node
```

Bit about my env:
```
$ yarn hardhat --version
2.9.9
```

The error message observed from the above code is:
```
thread 'main' panicked at 'Failed to get block number: JsonRpcClientError(NoQuorumReached { values: [], errors: [JsonRpcClientError(SerdeJson { err: Error("invalid type: null, expected u64", line: 1, column: 26), text: "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32600,\"message\":\"Invalid request\",\"data\":{\"message\":\"Invalid request\"}}}" }), JsonRpcClientError(SerdeJson { err: Error("invalid type: null, expected u64", line: 1, column: 26), text: "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32600,\"message\":\"Invalid request\",\"data\":{\"message\":\"Invalid request\"}}}" }), JsonRpcClientError(SerdeJson { err: Error("invalid type: null, expected u64", line: 1, column: 26), text: "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32600,\"message\":\"Invalid request\",\"data\":{\"message\":\"Invalid request\"}}}" })] })'
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

After much digging into why this was an issue with `QuorumProvider` and not also with `Http`, I noticed that the http provider is using the following to serialize the body.
```rust
fn is_zst<T>(_t: &T) -> bool {
    std::mem::size_of::<T>() == 0
}

#[derive(Serialize, Deserialize, Debug)]
/// A JSON-RPC request
pub struct Request<'a, T> {
    id: u64,
    jsonrpc: &'a str,
    method: &'a str,
    #[serde(skip_serializing_if = "is_zst")]
    params: T,
}
```

What happens instead with `QuorumProvider` is it is using `serde_json::Value` types to support multiple different backends through the `JsonRpcClientWrapper` which defines something like:
```rust
impl<C: JsonRpcClient> JsonRpcClientWrapper for C {
    async fn request(&self, method: &str, params: Value) -> Result<Value, ProviderError> {
        Ok(JsonRpcClient::request(self, method, params).await.map_err(C::Error::into)?)
    }
}
```

the consequence is that when `params` is `()` it will be serialized as `serde_json::Value::Null` instead of being excluded from the body. Some providers may accept this as valid, but since it is not working with the hardhat node we need it changed at a minimum for our local code tests. The two solutions I saw for this are to:

1) Make it an Option<Value> which can be excluded from the body
2) Use an empty array

~~This PR opts for option (2) as it seems to be the minimal change.~~
See discussion below.

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
