### PR TITLE
Export LogQueryError

### DIFF
--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -20,7 +20,7 @@ mod pending_escalator;
 pub use pending_escalator::EscalatingPending;
 
 mod log_query;
-pub use log_query::LogQuery;
+pub use log_query::{LogQuery, LogQueryError};
 
 mod stream;
 pub use futures_util::StreamExt;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

It is hard to create a wrapper error type containing errors returned from a `LogQuery`. The `LogQuery` type is public and accessible through `ethers::providers::LogQuery`, but the `LogQueryError` type is not. It can in principle be accesses through the `Stream` trait as such:

```
type LogQueryError<'a> = <LogQuery<'a> as Stream>::Item::Error;
```

but that introduces an unnecessary lifetime parameter and feels pretty hacky.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

```
pub use log_query::{LogQuery, LogQueryError};
``` 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
