### PR TITLE
fix(solc): consider case sensitive conflicting artifact paths

### DIFF
--- a/ethers-solc/src/artifact_output/files.rs
+++ b/ethers-solc/src/artifact_output/files.rs
@@ -1,0 +1,60 @@
+use crate::contracts::VersionedContract;
+use std::{
+    collections::HashMap,
+    hash::{Hash},
+    ops::{Deref, DerefMut},
+    path::{Path, PathBuf},
+};
+
+/// Container type for all contracts mapped to their output file
+pub struct MappedArtifactFiles<'a> {
+    /// Represents the determined output artifact file and the contract(s) that target it
+    ///
+    /// This is guaranteed to be `len >= 1`
+    ///
+    /// If there is more than 1 contract in the map, this means we have a naming conflict where
+    /// different contracts target the same output file. This happens if the solidity file and
+    /// contract name match, but they are in different folders.
+    pub files: HashMap<MappedArtifactFile, Vec<MappedContract<'a>>>,
+}
+
+impl<'a> MappedArtifactFiles<'a> {
+    pub fn with_capacity(len: usize) -> Self {
+        Self { files: HashMap::with_capacity(len) }
+    }
+}
+
+impl<'a> Deref for MappedArtifactFiles<'a> {
+    type Target = HashMap<MappedArtifactFile, Vec<MappedContract<'a>>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.files
+    }
+}
+
+impl<'a> DerefMut for MappedArtifactFiles<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.files
+    }
+}
+
+/// Represents the targeted path of a contract or multiple contracts
+///
+/// To account for case-sensitivity we identify it via lowercase path
+#[derive(Debug, Hash, PartialEq, Eq)]
+pub struct MappedArtifactFile {
+    lower_case_path: String,
+}
+
+impl MappedArtifactFile {
+    pub fn new(path: &Path) -> Self {
+        Self { lower_case_path: path.to_string_lossy().to_lowercase() }
+    }
+}
+
+pub struct MappedContract<'a> {
+    pub file: &'a str,
+    pub name: &'a str,
+    pub contract: &'a VersionedContract,
+    pub artifact_path: PathBuf,
+}

--- a/ethers-solc/src/artifact_output/files.rs
+++ b/ethers-solc/src/artifact_output/files.rs
@@ -1,7 +1,7 @@
 use crate::contracts::VersionedContract;
 use std::{
     collections::HashMap,
-    hash::{Hash},
+    hash::Hash,
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
 };

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -2226,6 +2226,103 @@ fn can_handle_conflicting_files_recompile() {
     assert!(inner_recompiled.get_abi().unwrap().functions.contains_key("baz"));
 }
 
+// <https://github.com/foundry-rs/foundry/issues/2843>
+#[test]
+fn can_handle_conflicting_files_case_sensitive_recompile() {
+    let project = TempProject::<ConfigurableArtifacts>::dapptools().unwrap();
+
+    project
+        .add_source(
+            "a",
+            r#"
+    pragma solidity ^0.8.10;
+
+    contract A {
+            function foo() public{}
+    }
+   "#,
+        )
+        .unwrap();
+
+    project
+        .add_source(
+            "inner/A",
+            r#"
+    pragma solidity ^0.8.10;
+
+    contract A {
+            function bar() public{}
+    }
+   "#,
+        )
+        .unwrap();
+
+    let compiled = project.compile().unwrap();
+    assert!(!compiled.has_compiler_errors());
+
+    let artifacts = compiled.artifacts().count();
+    assert_eq!(artifacts, 2);
+
+    // nothing to compile
+    let compiled = project.compile().unwrap();
+    assert!(compiled.is_unchanged());
+    let artifacts = compiled.artifacts().count();
+    assert_eq!(artifacts, 2);
+
+    let cache = SolFilesCache::read(project.cache_path()).unwrap();
+
+    let mut source_files = cache.files.keys().cloned().collect::<Vec<_>>();
+    source_files.sort_unstable();
+
+    assert_eq!(source_files, vec![PathBuf::from("src/a.sol"), PathBuf::from("src/inner/A.sol"),]);
+
+    let mut artifacts =
+        project.artifacts_snapshot().unwrap().artifacts.into_stripped_file_prefixes(project.root());
+    artifacts.strip_prefix_all(&project.paths().artifacts);
+
+    assert_eq!(artifacts.len(), 2);
+    let mut artifact_files = artifacts.artifact_files().map(|f| f.file.clone()).collect::<Vec<_>>();
+    artifact_files.sort_unstable();
+
+    let expected_files = vec![PathBuf::from("a.sol/A.json"), PathBuf::from("inner/A.sol/A.json")];
+    assert_eq!(artifact_files, expected_files);
+
+    // overwrite conflicting nested file, effectively changing it
+    project
+        .add_source(
+            "inner/A",
+            r#"
+    pragma solidity ^0.8.10;
+    contract A {
+    function bar() public{}
+    function baz() public{}
+    }
+   "#,
+        )
+        .unwrap();
+
+    let compiled = project.compile().unwrap();
+    assert!(!compiled.has_compiler_errors());
+
+    let mut recompiled_artifacts =
+        project.artifacts_snapshot().unwrap().artifacts.into_stripped_file_prefixes(project.root());
+    recompiled_artifacts.strip_prefix_all(&project.paths().artifacts);
+
+    assert_eq!(recompiled_artifacts.len(), 2);
+    let mut artifact_files =
+        recompiled_artifacts.artifact_files().map(|f| f.file.clone()).collect::<Vec<_>>();
+    artifact_files.sort_unstable();
+    assert_eq!(artifact_files, expected_files);
+
+    // ensure that `a.sol/A.json` is unchanged
+    let outer = artifacts.find("src/a.sol", "A").unwrap();
+    let outer_recompiled = recompiled_artifacts.find("src/a.sol", "A").unwrap();
+    assert_eq!(outer, outer_recompiled);
+
+    let inner_recompiled = recompiled_artifacts.find("src/inner/A.sol", "A").unwrap();
+    assert!(inner_recompiled.get_abi().unwrap().functions.contains_key("baz"));
+}
+
 #[test]
 fn can_checkout_repo() {
     let project = TempProject::checkout("transmissions11/solmate").unwrap();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Followup to https://github.com/gakonst/ethers-rs/pull/1621

As reported here https://github.com/foundry-rs/foundry/issues/2843#issuecomment-1221326854

there still can be conflicts for cases like `a.sol` and `inner/A.sol`, this was because we used  `PathBuf` as the key which is case sensitive.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* add new helper type `MappedArtifactFiles` that now uses lowercase(PathBuf.to_string()) as the key type so that we treat the output candidate `a.sol/A.json` and `A.sol/A.json` as the same file. (`a.sol/a.json`)
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
