### PR TITLE
fix: handle provider error correctly

### DIFF
--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -52,7 +52,10 @@ pub enum ClientError {
 
 impl From<ClientError> for ProviderError {
     fn from(src: ClientError) -> Self {
-        ProviderError::JsonRpcClientError(Box::new(src))
+        match src {
+            ClientError::ReqwestError(err) => ProviderError::HTTPError(err),
+            _ => ProviderError::JsonRpcClientError(Box::new(src)),
+        }
     }
 }
 

--- a/ethers-providers/src/transports/retry.rs
+++ b/ethers-providers/src/transports/retry.rs
@@ -245,8 +245,7 @@ where
         let params = if std::mem::size_of::<A>() == 0 {
             RetryParams::Zst(())
         } else {
-            let params =
-                serde_json::to_value(params).map_err(RetryClientError::SerdeJson)?;
+            let params = serde_json::to_value(params).map_err(RetryClientError::SerdeJson)?;
             RetryParams::Value(params)
         };
 

--- a/ethers-providers/src/transports/retry.rs
+++ b/ethers-providers/src/transports/retry.rs
@@ -246,7 +246,7 @@ where
             RetryParams::Zst(())
         } else {
             let params =
-                serde_json::to_value(params).map_err(|err| RetryClientError::SerdeJson(err))?;
+                serde_json::to_value(params).map_err(RetryClientError::SerdeJson)?;
             RetryParams::Value(params)
         };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
the `JsonRpcClient::Error` is already `Into<ProviderError>`, which we can use to simplify retry error handling, no need for downcasting which might not return the right result if wrapped in another enum

this also converts the `HttpErr(reqwest)` into the corresponding `ProviderError::Http(reqwest)` variant
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
