### PR TITLE
fix: dont skip null to field

### DIFF
--- a/ethers-core/src/types/transaction/response.rs
+++ b/ethers-core/src/types/transaction/response.rs
@@ -40,7 +40,7 @@ pub struct Transaction {
     pub from: Address,
 
     /// Recipient (None when contract creation)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub to: Option<Address>,
 
     /// Transferred value


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/2888

apparently the `to` field should be `null` or an address

geth also does not omit it if empty 

https://github.com/ethereum/go-ethereum/blob/81bd998353789980a6ef3e493b3562750b416d96/core/types/transaction_marshalling.go#L43
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
