### PR TITLE
Fix 'get_transactions' response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - Fix handling of Websocket connection errors [#1287](https://github.com/gakonst/ethers-rs/pull/1287)
 - Add Arithmetic Shift Right operation for I256 [#1323](https://github.com/gakonst/ethers-rs/issues/1323)
 - [#1535](https://github.com/gakonst/ethers-rs/pull/1535) Add support to Aurora and Aurora testnet networks.
+- [#1632](https://github.com/gakonst/ethers-rs/pull/1632) Re-export `H32` from `ethabi`.
 
 ## ethers-contract-abigen
 

--- a/ethers-core/src/types/mod.rs
+++ b/ethers-core/src/types/mod.rs
@@ -5,7 +5,7 @@ pub type Selector = [u8; 4];
 /// A transaction Hash
 pub use ethabi::ethereum_types::H256 as TxHash;
 
-pub use ethabi::ethereum_types::{Address, Bloom, H160, H256, H512, H64, U128, U256, U64};
+pub use ethabi::ethereum_types::{Address, Bloom, H160, H256, H32, H512, H64, U128, U256, U64};
 
 pub mod transaction;
 pub use transaction::{

--- a/ethers-etherscan/src/account.rs
+++ b/ethers-etherscan/src/account.rs
@@ -52,9 +52,9 @@ mod genesis_string {
     {
         let json = Cow::<'de, str>::deserialize(deserializer)?;
         if !json.is_empty() && !json.starts_with("GENESIS") {
-            let value =
-                serde_json::from_str(&format!("\"{}\"", &json)).map_err(D::Error::custom)?;
-            Ok(GenesisOption::Some(value))
+            serde_json::from_str(&format!("\"{}\"", &json))
+                .map(GenesisOption::Some)
+                .map_err(D::Error::custom)
         } else if json.starts_with("GENESIS") {
             Ok(GenesisOption::Genesis)
         } else {
@@ -92,9 +92,9 @@ mod json_string {
         if json.is_empty() {
             Ok(Option::None)
         } else {
-            let value =
-                serde_json::from_str(&format!("\"{}\"", &json)).map_err(D::Error::custom)?;
-            Ok(Option::Some(value))
+            serde_json::from_str(&format!("\"{}\"", &json))
+                .map(Option::Some)
+                .map_err(D::Error::custom)
         }
     }
 }
@@ -128,9 +128,9 @@ mod hex_string {
         if json.is_empty() || json == "0x" {
             Ok(Option::None)
         } else {
-            let value =
-                serde_json::from_str(&format!("\"{}\"", &json)).map_err(D::Error::custom)?;
-            Ok(Option::Some(value))
+            serde_json::from_str(&format!("\"{}\"", &json))
+                .map(Option::Some)
+                .map_err(D::Error::custom)
         }
     }
 }

--- a/ethers-etherscan/src/account.rs
+++ b/ethers-etherscan/src/account.rs
@@ -135,7 +135,10 @@ mod hex_string {
     }
 }
 
-/// Possible values for some field responses
+/// Possible values for some field responses.
+///
+/// Transactions from the Genesis block may contain fields that do not conform to the expected
+/// types.
 #[derive(Debug)]
 pub enum GenesisOption<T> {
     None,


### PR DESCRIPTION
## Motivation

The response to the `get_transactions` method on the etherscan client has a number of issues:
1. `methodId` and `functionName` fields are missing.
2. A number of fields are of the type `GenesisOption`, but from my investigations only `hash` and `from` can have this format.
3. `input` does not need to be wrapped in an option. From my investigation, the response from etherscan is always `"0x"` for empty input, and the serde implementation for the `Bytes` type will process this as an empty byte array.

## Solution

1. Add the missing fields.
2. Replace `GenesisOption` with `Option` on fields that cannot start with `GENESIS`.
3. Remove the option wrapper for the `bytes` field.

## PR Checklist

- [x] Added Tests (no tests needed as the existing tests are sufficient)
- [x] Added Documentation
- [x] Updated the changelog
