### PR TITLE
ethers-etherscan: derive debug, clone and copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - Add Arithmetic Shift Right operation for I256 [#1323](https://github.com/gakonst/ethers-rs/issues/1323)
 - [#1535](https://github.com/gakonst/ethers-rs/pull/1535) Add support to Aurora and Aurora testnet networks.
 - [#1632](https://github.com/gakonst/ethers-rs/pull/1632) Re-export `H32` from `ethabi`.
+- [#1634](https://github.com/gakonst/ethers-rs/pull/1634) Derive missing `Clone`, `Copy` and `Debug` impls in ethers-etherscan.
 
 ## ethers-contract-abigen
 

--- a/ethers-etherscan/src/account.rs
+++ b/ethers-etherscan/src/account.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 /// The raw response from the balance-related API endpoints
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AccountBalance {
     pub account: Address,
     pub balance: String,
@@ -139,7 +139,7 @@ mod hex_string {
 ///
 /// Transactions from the Genesis block may contain fields that do not conform to the expected
 /// types.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum GenesisOption<T> {
     None,
     Genesis,
@@ -169,7 +169,7 @@ impl<T> GenesisOption<T> {
 }
 
 /// The raw response from the transaction list API endpoint
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NormalTransaction {
     pub is_error: String,
@@ -211,7 +211,7 @@ pub struct NormalTransaction {
 }
 
 /// The raw response from the internal transaction list API endpoint
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InternalTransaction {
     #[serde(deserialize_with = "deserialize_stringified_block_number")]
@@ -239,7 +239,7 @@ pub struct InternalTransaction {
 }
 
 /// The raw response from the ERC20 transfer list API endpoint
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ERC20TokenTransferEvent {
     #[serde(deserialize_with = "deserialize_stringified_block_number")]
@@ -274,7 +274,7 @@ pub struct ERC20TokenTransferEvent {
 }
 
 /// The raw response from the ERC721 transfer list API endpoint
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ERC721TokenTransferEvent {
     #[serde(deserialize_with = "deserialize_stringified_block_number")]
@@ -309,7 +309,7 @@ pub struct ERC721TokenTransferEvent {
 }
 
 /// The raw response from the ERC1155 transfer list API endpoint
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ERC1155TokenTransferEvent {
     #[serde(deserialize_with = "deserialize_stringified_block_number")]
@@ -344,7 +344,7 @@ pub struct ERC1155TokenTransferEvent {
 }
 
 /// The raw response from the mined blocks API endpoint
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MinedBlock {
     #[serde(deserialize_with = "deserialize_stringified_block_number")]
@@ -354,6 +354,7 @@ pub struct MinedBlock {
 }
 
 /// The pre-defined block parameter for balance API endpoints
+#[derive(Clone, Copy, Debug)]
 pub enum Tag {
     Earliest,
     Pending,
@@ -377,6 +378,7 @@ impl Default for Tag {
 }
 
 /// The list sorting preference
+#[derive(Clone, Copy, Debug)]
 pub enum Sort {
     Asc,
     Desc,
@@ -392,6 +394,7 @@ impl Display for Sort {
 }
 
 /// Common optional arguments for the transaction or event list API endpoints
+#[derive(Clone, Copy, Debug)]
 pub struct TxListParams {
     start_block: u64,
     end_block: u64,
@@ -425,6 +428,7 @@ impl From<TxListParams> for HashMap<&'static str, String> {
 }
 
 /// Options for querying internal transactions
+#[derive(Clone, Debug)]
 pub enum InternalTxQueryOption {
     ByAddress(Address),
     ByTransactionHash(H256),
@@ -432,6 +436,7 @@ pub enum InternalTxQueryOption {
 }
 
 /// Options for querying ERC20 or ERC721 token transfers
+#[derive(Clone, Debug)]
 pub enum TokenQueryOption {
     ByAddress(Address),
     ByContract(Address),
@@ -460,6 +465,7 @@ impl TokenQueryOption {
 }
 
 /// The pre-defined block type for retrieving mined blocks
+#[derive(Copy, Clone, Debug)]
 pub enum BlockType {
     CanonicalBlocks,
     Uncles,

--- a/ethers-etherscan/src/contract.rs
+++ b/ethers-etherscan/src/contract.rs
@@ -139,7 +139,7 @@ impl Default for CodeFormat {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct ContractMetadata {
     pub items: Vec<Metadata>,
@@ -154,12 +154,12 @@ impl IntoIterator for ContractMetadata {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone, Debug)]
 struct EtherscanSourceEntry {
     content: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone, Debug)]
 struct EtherscanSourceJsonMetadata {
     sources: HashMap<String, EtherscanSourceEntry>,
 }
@@ -217,7 +217,7 @@ impl ContractMetadata {
 }
 
 /// Etherscan contract metadata
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Metadata {
     #[serde(rename = "SourceCode")]
     pub source_code: String,

--- a/ethers-etherscan/src/gas.rs
+++ b/ethers-etherscan/src/gas.rs
@@ -7,7 +7,7 @@ use ethers_core::types::U256;
 
 use crate::{Client, EtherscanError, Response, Result};
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct GasOracle {
     #[serde(deserialize_with = "deserialize_number_from_string")]

--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -399,7 +399,7 @@ pub enum ResponseData<T> {
 }
 
 /// The type that gets serialized as query
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 struct Query<'a, T: Serialize> {
     apikey: Cow<'a, str>,
     module: Cow<'a, str>,

--- a/ethers-etherscan/src/source_tree.rs
+++ b/ethers-etherscan/src/source_tree.rs
@@ -4,13 +4,13 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SourceTreeEntry {
     pub path: PathBuf,
     pub contents: String,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SourceTree {
     pub entries: Vec<SourceTreeEntry>,
 }

--- a/ethers-etherscan/src/transaction.rs
+++ b/ethers-etherscan/src/transaction.rs
@@ -4,14 +4,14 @@ use serde::Deserialize;
 
 use crate::{Client, EtherscanError, Response, Result};
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 struct ContractExecutionStatus {
     is_error: String,
     err_description: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone, Debug)]
 struct TransactionReceiptStatus {
     status: String,
 }


### PR DESCRIPTION
Derive Debug, Clone and Copy on all appropriate Structs and Enums.

## Motivation

I needed to be able to clone `TxListParams` and noticed that a lot of the structs and enums in ethers-etherscan do not implement Debug, Clone and Copy.

## Solution

Derive the above traits as appropriate.

## PR Checklist

- [x] Added Tests (unnecessary)
- [x] Added Documentation (unnecessary)
- [x] Updated the changelog
