### PR TITLE
nit: Explicitly handle all chains on match

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -93,7 +93,22 @@ impl Chain {
             Chain::Oasis => 5_500,
             Chain::Emerald => 6_000,
             Chain::Dev | Chain::AnvilHardhat => 200,
-            _ => return None,
+            // Explictly handle all network to make it easier not to forget this match when new
+            // networks are added.
+            Chain::Morden |
+            Chain::Ropsten |
+            Chain::Rinkeby |
+            Chain::Goerli |
+            Chain::Kovan |
+            Chain::XDai |
+            Chain::Sepolia |
+            Chain::Moonbase |
+            Chain::MoonbeamDev |
+            Chain::OptimismKovan |
+            Chain::Poa |
+            Chain::Sokol |
+            Chain::Rsk |
+            Chain::EmeraldTestnet => return None,
         };
 
         Some(Duration::from_millis(ms))


### PR DESCRIPTION
## Motivation

Whenever `Chain` enum is matched, all its variant should be handled explicitly. This will help developers get assistance from the compiler to figure out all places that they need to take care if a new chain is added.

## Solution

Avoid wildcard pattern (`_`) while matching chain.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
