### PR TITLE
fix(providers): Quorum provider resilience to out-of-sync and failing nodes

### DIFF
--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -181,10 +181,9 @@ impl<T: JsonRpcClientWrapper> QuorumProvider<T> {
         while !queries.is_empty() {
             let (response, _index, remaining) = future::select_all(queries).await;
             queries = remaining;
-            if response.is_ok() {
-                numbers.push(response.unwrap())
-            } else {
-                errors.push(response.unwrap_err())
+            match response {
+                Ok(v) => numbers.push(v),
+                Err(e) => errors.push(e),
             }
         }
 

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -160,23 +160,41 @@ impl<T> QuorumProviderBuilder<T> {
 }
 
 impl<T: JsonRpcClientWrapper> QuorumProvider<T> {
-    /// Returns the block height that _all_ providers have surpassed.
-    ///
-    /// This is the minimum of all provider's block numbers
-    async fn get_minimum_block_number(&self) -> Result<U64, ProviderError> {
-        let mut numbers = join_all(self.providers.iter().map(|provider| async move {
+    /// Returns the block height that a _quorum_ of providers have reached.
+    async fn get_quorum_block_number(&self) -> Result<U64, QuorumError> {
+        let (oks, errs) = join_all(self.providers.iter().map(|provider| async move {
             let block = provider.inner.request("eth_blockNumber", QuorumParams::Zst).await?;
-            serde_json::from_value::<U64>(block).map_err(ProviderError::from)
+            serde_json::from_value::<U64>(block).map(|b| (provider, b)).map_err(ProviderError::from)
         }))
         .await
         .into_iter()
-        .collect::<Result<Vec<_>, _>>()?;
-        numbers.sort();
+        .partition::<Vec<Result<(&WeightedProvider<T>, U64), ProviderError>>, _>(|res| res.is_ok());
 
-        numbers
-            .into_iter()
-            .next()
-            .ok_or_else(|| ProviderError::CustomError("No Providers".to_string()))
+        let mut numbers = oks.into_iter().map(Result::unwrap).collect::<Vec<_>>();
+
+        numbers.sort_by(|(_, block_a), (_, block_b)| {
+            // order by descending block number
+            block_a.cmp(block_b).reverse()
+        });
+
+        // find the highest possible block number a quorum agrees on
+        let mut weight_set = vec![];
+        let mut block = U64::from(0);
+        for (provider, n) in numbers.iter().copied() {
+            weight_set.push(provider);
+            debug_assert!(block == U64::from(0) || block >= n);
+            block = n;
+            if self.quorum.weight(weight_set.iter().copied()) >= self.quorum_weight {
+                return Ok(block)
+            }
+        }
+        Err(QuorumError::NoQuorumReached {
+            values: numbers
+                .into_iter()
+                .map(|(_, block)| serde_json::to_value(block).expect("Failed to serialize U64"))
+                .collect(),
+            errors: errs.into_iter().map(Result::unwrap_err).collect(),
+        })
     }
 
     /// Normalizes the request payload depending on the call
@@ -198,13 +216,9 @@ impl<T: JsonRpcClientWrapper> QuorumProvider<T> {
                 // calls that include the block number in the params at the last index of json array
                 if let Some(block) = params.as_array_mut().and_then(|arr| arr.last_mut()) {
                     if Some("latest") == block.as_str() {
-                        // replace `latest` with the minimum block height of all providers
-                        if let Ok(minimum) = self
-                            .get_minimum_block_number()
-                            .await
-                            .and_then(|num| Ok(serde_json::to_value(num)?))
-                        {
-                            *block = minimum
+                        // replace `latest` with block height of a quorum of providers
+                        if let Ok(minimum) = self.get_quorum_block_number().await {
+                            *block = serde_json::to_value(minimum).expect("Failed to serialize U64")
                         }
                     }
                 }
@@ -236,20 +250,23 @@ pub enum Quorum {
 }
 
 impl Quorum {
-    fn weight<T>(self, providers: &[WeightedProvider<T>]) -> u64 {
+    fn weight<'a, T: 'a>(
+        self,
+        providers: impl IntoIterator<Item = &'a WeightedProvider<T>>,
+    ) -> u64 {
         match self {
-            Quorum::All => providers.iter().map(|p| p.weight).sum::<u64>(),
+            Quorum::All => providers.into_iter().map(|p| p.weight).sum::<u64>(),
             Quorum::Majority => {
-                let total = providers.iter().map(|p| p.weight).sum::<u64>();
+                let total = providers.into_iter().map(|p| p.weight).sum::<u64>();
                 let rem = total % 2;
                 total / 2 + rem
             }
             Quorum::Percentage(p) => {
-                providers.iter().map(|p| p.weight).sum::<u64>() * (p as u64) / 100
+                providers.into_iter().map(|p| p.weight).sum::<u64>() * (p as u64) / 100
             }
             Quorum::ProviderCount(num) => {
                 // take the lowest `num` weights
-                let mut weights = providers.iter().map(|p| p.weight).collect::<Vec<_>>();
+                let mut weights = providers.into_iter().map(|p| p.weight).collect::<Vec<_>>();
                 weights.sort_unstable();
                 weights.into_iter().take(num).sum()
             }
@@ -456,19 +473,30 @@ where
         };
         self.normalize_request(method, &mut params).await;
 
-        let requests = self
-            .providers
-            .iter()
-            .enumerate()
-            .map(|(idx, provider)| {
-                let params = params.clone();
-                let fut = provider.inner.request(method, params).map(move |res| (res, idx));
-                Box::pin(fut) as PendingRequest
-            })
-            .collect::<Vec<_>>();
+        match method {
+            "eth_blockNumber" => {
+                let block = self.get_quorum_block_number().await?;
+                // a little janky to convert to a string and back but we don't know for sure what
+                // type R is and adding constraints for just this case feels wrong.
+                let value = serde_json::to_value(block).expect("Failed to serialize U64");
+                Ok(serde_json::from_value(value)?)
+            }
+            _ => {
+                let requests = self
+                    .providers
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, provider)| {
+                        let params = params.clone();
+                        let fut = provider.inner.request(method, params).map(move |res| (res, idx));
+                        Box::pin(fut) as PendingRequest
+                    })
+                    .collect::<Vec<_>>();
 
-        let value = QuorumRequest::new(self, requests).await?;
-        Ok(serde_json::from_value(value)?)
+                let value = QuorumRequest::new(self, requests).await?;
+                Ok(serde_json::from_value(value)?)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

Wanted some thoughts on this before I go through and fix up tests and the like. Currently tests are not passing; as this PR does change the behavior, I do not think the failing tests indicate an issue at this time, but I have not really dug into it.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
This PR addresses a couple of main issues:
1) Currently `get_minimum_block_number`, which is used for a number of request pathways to replace `latest` block parameters, is not resistent to
1a) any provider failing, even if a quorum of providers successfully return their block numbers
1b) a provider falling out-of-sync and returning a (very?) low block number (technically a possible attack vector as well)
2) eth_getBlockByNumber still passes through `"latest"` instead of replacing with a specific block number

The spirit of the changes made is to bring the resilience of a quorum to (1) and patch (2) since it was probably just forgotten.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

A few different options were considered to address (1), namely to either wait for any quorum's worth of responses and then use the minimum of that response (which does not protect against (1b)) or to wait for all responses, separate out errors, and take the minimum block number of the maximum quorum. The latter was chosen.

The algorithm for this is to simply
1) request block numbers from all providers
2) wait for all responses (using a timeout on providers is a must for this to be resilient to providers dropping requests)
3) split responses into Ok/Err lists (returns the errors if a quorum is not reached)
4) sort Ok responses by descending block order
5) find the minimum number of providers required from the head of the list to reach a quorum
6) take the minimum block number of this list of providers

By doing this, we should be resilient to both (1a) and (1b).

## PR Checklist

- [ ] Added Tests
- [x] Added Documentation
- [ ] Updated the changelog
