### PR TITLE
fix(abigen): only derive default of no arrays len > 32

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/util.rs
+++ b/ethers-contract/ethers-contract-abigen/src/util.rs
@@ -1,11 +1,12 @@
-use ethers_core::types::Address;
-use std::path::PathBuf;
-
+use ethers_core::{
+    abi::{Param, ParamType},
+    types::Address,
+};
 use eyre::Result;
 use inflector::Inflector;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::quote;
-
+use std::path::PathBuf;
 use syn::{Ident as SynIdent, Path};
 
 /// Expands a identifier string into a token.
@@ -185,9 +186,41 @@ pub fn json_files(root: impl AsRef<std::path::Path>) -> Vec<PathBuf> {
         .collect()
 }
 
+/// rust-std derives `Default` automatically only for arrays len <= 32
+///
+/// Returns whether the corresponding struct can derive `Default`
+pub fn can_derive_defaults(params: &[Param]) -> bool {
+    params.iter().map(|param| &param.kind).all(can_derive_default)
+}
+
+pub fn can_derive_default(param: &ParamType) -> bool {
+    const MAX_SUPPORTED_LEN: usize = 32;
+    match param {
+        ParamType::FixedBytes(len) => *len <= MAX_SUPPORTED_LEN,
+        ParamType::FixedArray(ty, len) => {
+            if *len > MAX_SUPPORTED_LEN {
+                false
+            } else {
+                can_derive_default(&*ty)
+            }
+        }
+        ParamType::Tuple(params) => params.iter().all(can_derive_default),
+        _ => true,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn can_detect_non_default() {
+        let param = ParamType::FixedArray(Box::new(ParamType::Uint(64)), 128);
+        assert!(!can_derive_default(&param));
+
+        let param = ParamType::FixedArray(Box::new(ParamType::Uint(64)), 32);
+        assert!(can_derive_default(&param));
+    }
 
     #[test]
     fn can_resolve_path() {

--- a/ethers-contract/ethers-contract-abigen/src/util.rs
+++ b/ethers-contract/ethers-contract-abigen/src/util.rs
@@ -201,7 +201,7 @@ pub fn can_derive_default(param: &ParamType) -> bool {
             if *len > MAX_SUPPORTED_LEN {
                 false
             } else {
-                can_derive_default(&*ty)
+                can_derive_default(ty)
             }
         }
         ParamType::Tuple(params) => params.iter().all(can_derive_default),

--- a/ethers-contract/tests/it/abigen.rs
+++ b/ethers-contract/tests/it/abigen.rs
@@ -15,6 +15,7 @@ use std::{convert::TryFrom, sync::Arc};
 
 fn assert_codec<T: AbiDecode + AbiEncode>() {}
 fn assert_tokenizeable<T: Tokenizable>() {}
+fn assert_call<T: AbiEncode + AbiDecode + Default + Tokenizable>() {}
 
 #[test]
 fn can_gen_human_readable() {
@@ -237,6 +238,9 @@ fn can_gen_human_readable_with_structs() {
     assert_eq!(contract_call, decoded_enum);
     assert_eq!(contract_call, call.into());
     assert_eq!(encoded_call, contract_call.encode());
+
+    assert_call::<BarCall>();
+    assert_call::<YeetCall>();
 }
 
 #[test]
@@ -301,6 +305,10 @@ fn can_handle_overloaded_functions() {
     let _contract_call = SimpleContractCalls::SetValue0(call);
     let call = SetValue1Call("message".to_string(), "message".to_string());
     let _contract_call = SimpleContractCalls::SetValue1(call);
+
+    assert_call::<SetValue0Call>();
+    assert_call::<SetValue1Call>();
+    assert_call::<GetValueWithOtherValueAndAddrCall>();
 }
 
 #[test]
@@ -694,4 +702,9 @@ fn gen_complex_function() {
 #[test]
 fn can_gen_large_tuple_types() {
     abigen!(LargeTuple, "./tests/solidity-contracts/large_tuple.json");
+}
+
+#[test]
+fn can_gen_large_tuple_array() {
+    abigen!(LargeTuple, "./tests/solidity-contracts/large-array.json");
 }

--- a/ethers-contract/tests/it/abigen.rs
+++ b/ethers-contract/tests/it/abigen.rs
@@ -11,7 +11,10 @@ use ethers_middleware::SignerMiddleware;
 use ethers_providers::{MockProvider, Provider};
 use ethers_signers::{LocalWallet, Signer};
 use ethers_solc::Solc;
-use std::{convert::TryFrom, sync::Arc};
+use std::{
+    convert::{TryFrom, TryInto},
+    sync::Arc,
+};
 
 fn assert_codec<T: AbiDecode + AbiEncode>() {}
 fn assert_tokenizeable<T: Tokenizable>() {}
@@ -707,4 +710,13 @@ fn can_gen_large_tuple_types() {
 #[test]
 fn can_gen_large_tuple_array() {
     abigen!(LargeTuple, "./tests/solidity-contracts/large-array.json");
+
+    impl Default for CallWithLongArrayCall {
+        fn default() -> Self {
+            Self { long_array: [0; 128] }
+        }
+    }
+
+    let _call = CallWithLongArrayCall::default();
+    assert_call::<CallWithLongArrayCall>();
 }

--- a/ethers-contract/tests/solidity-contracts/large-array.json
+++ b/ethers-contract/tests/solidity-contracts/large-array.json
@@ -1,0 +1,15 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint64[128]",
+        "name": "longArray",
+        "type": "uint64[128]"
+      }
+    ],
+    "name": "callWithLongArray",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes #1640

this adds a check whether default can be derived for a call/output struct
rust-std auto derives default only for arrays len <=32

I think it's fine to skip the derive if not possible, since this generates code, the user still can implement it manually
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
skip `derive(Default)` of a type contains a fixed array with more than 32 elements
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
