### PR TITLE
fix: emit null transaction fields

### DIFF
--- a/ethers-core/src/types/transaction/response.rs
+++ b/ethers-core/src/types/transaction/response.rs
@@ -21,18 +21,15 @@ pub struct Transaction {
     pub nonce: U256,
 
     /// Block hash. None when pending.
-    #[serde(rename = "blockHash")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, rename = "blockHash")]
     pub block_hash: Option<H256>,
 
     /// Block number. None when pending.
-    #[serde(rename = "blockNumber")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, rename = "blockNumber")]
     pub block_number: Option<U64>,
 
     /// Transaction Index. None when pending.
-    #[serde(rename = "transactionIndex")]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, rename = "transactionIndex")]
     pub transaction_index: Option<U64>,
 
     /// Sender


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/3045

continues https://github.com/gakonst/ethers-rs/pull/1631

> While testing with brownie I came across this issue when using anvil. Basically it's the same as [in this ethereum.stackexchange question](https://ethereum.stackexchange.com/questions/127948/deploy-smartcontract-to-local-hyperledger-besu-network-using-brownie).
As described in the link, anvil isn't following the [standard JSON-RPC API](https://eth.wiki/json-rpc/API#eth_gettransactionbyhash). Pending transactions should return the fields blockNumber, blockHash and transactionIndex with a value of null, but they are not present. The to field correctly exists in my tests with a value of null though.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use `serde(default)` and remove the skip
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
