### PR TITLE
fix(providers): don't default to "latest" block ID for `eth_estimateGas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Stop defaulting to the `"latest"` block in `eth_estimateGas` params [#1657](https://github.com/gakonst/ethers-rs/pull/1657)
 - Fix geth trace types for debug_traceTransaction rpc
 - Fix RLP decoding of legacy `Transaction`
 - Fix RLP encoding of `TransactionReceipt` [#1661](https://github.com/gakonst/ethers-rs/pull/1661)

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -574,7 +574,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         block: Option<BlockId>,
     ) -> Result<U256, ProviderError> {
         let tx = utils::serialize(tx);
-        // Some chains (e.g. Optimism) don't support a block ID being passed as a param,
+        // Some nodes (e.g. old Optimism clients) don't support a block ID being passed as a param,
         // so refrain from defaulting to BlockNumber::Latest.
         let params = if let Some(block_id) = block {
             vec![tx, utils::serialize(&block_id)]


### PR DESCRIPTION
## Motivation

Upon testing using a newer version of `ethers-rs`, I ran into issues estimating gas for Optimism chains (i.e. mainnet & optimism kovan). After some digging, it seem like this PR https://github.com/gakonst/ethers-rs/pull/1619 made a change to the way `eth_estimateGas` RPCs are constructed that breaks gas estimation for Optimism chains.

Previously, no block ID was provided when estimating gas, and this resulted params length of 1, where the element at index 0 was the tx to estimate. E.g. this works as expected against Optimism / OptimismKovan (this is just estimating a DAI transfer on mainnet Optimism):
```
$ curl -H "Content-Type: application/json" --data "{\"jsonrpc\":\"2.0\",\"method\":\"eth_estimateGas\",\"params\":[{\"from\":\"0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee\",\"to\":\"0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1\",\"data\":\"0xa9059cbb000000000000000000000000dead00000000000000000000000000000000beef0000000000000000000000000000000000000000000000000000000000000069\"}],\"id\":67}" https://mainnet.optimism.io
{"jsonrpc":"2.0","result":"0xc760","id":67}
```

However, following https://github.com/gakonst/ethers-rs/pull/1619, the `eth_estimateGas` RPC will always specify the block ID, and will default to `"latest"`, resulting in a params length of 2. This works for most chains, but evidently not Optimism / Optimism Kovan :(.

E.g. this doesn't work-- it's the same RPC as above but with the block ID specified:
```
$ curl -H "Content-Type: application/json" --data "{\"jsonrpc\":\"2.0\",\"method\":\"eth_estimateGas\",\"params\":[{\"from\":\"0x82e64f49ed5ec1bc6e43dad4fc8af9bb3a2312ee\",\"to\":\"0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1\",\"data\":\"0xa9059cbb000000000000000000000000dead00000000000000000000000000000000beef0000000000000000000000000000000000000000000000000000000000000069\"},\"latest\"],\"id\":67}" https://mainnet.optimism.io
{"jsonrpc":"2.0","error":{"code":-32602,"message":"too many arguments, want at most 1"},"id":67}
```

From what I can tell, the behavior that https://github.com/gakonst/ethers-rs/pull/1619 introduced is spec compliant and Optimism isn't, but in any case it seems that ethers-rs should work correctly when using Optimism.

## Solution

If the block ID is `None`, instead of defaulting to `"latest"` in the RPC, instead the block ID is omitted.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [x] Updated the changelog
