### PR TITLE
chore(solc): always use sync sources reading

### DIFF
--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -65,6 +65,7 @@ harness = false
 
 [[bench]]
 name = "read_all"
+required-features = ["project-util"]
 harness = false
 
 [[test]]

--- a/ethers-solc/benches/read_all.rs
+++ b/ethers-solc/benches/read_all.rs
@@ -4,7 +4,7 @@ extern crate criterion;
 
 use criterion::Criterion;
 use ethers_core::rand;
-use ethers_solc::artifacts::Source;
+use ethers_solc::{artifacts::Source, project_util::TempProject};
 use rand::{distributions::Alphanumeric, Rng};
 use std::{
     fs::File,
@@ -14,10 +14,26 @@ use std::{
 
 fn read_all_benchmark(c: &mut Criterion) {
     let root = tempfile::tempdir().unwrap();
-    let inputs = prepare_contracts(root.path(), 8);
+    let inputs = prepare_contracts(root.path(), 35);
 
     let mut group = c.benchmark_group("read many");
-    group.sample_size(10);
+    group.bench_function("sequential", |b| {
+        b.iter(|| {
+            Source::read_all(&inputs).unwrap();
+        });
+    });
+    group.bench_function("parallel", |b| {
+        b.iter(|| {
+            Source::par_read_all(&inputs).unwrap();
+        });
+    });
+}
+
+fn read_solmate(c: &mut Criterion) {
+    let prj = TempProject::checkout("transmissions11/solmate").unwrap();
+    let inputs = ethers_solc::utils::source_files(prj.sources_path());
+
+    let mut group = c.benchmark_group("read solmate");
     group.bench_function("sequential", |b| {
         b.iter(|| {
             Source::read_all(&inputs).unwrap();
@@ -40,7 +56,7 @@ fn prepare_contracts(root: &Path, num: usize) -> Vec<PathBuf> {
         let mut rng = rand::thread_rng();
 
         // let's assume a solidity file is between 2kb and 16kb
-        let n: usize = rng.gen_range(2..17);
+        let n: usize = rng.gen_range(4..17);
         let s: String = rng.sample_iter(&Alphanumeric).take(n * 1024).map(char::from).collect();
         writer.write_all(s.as_bytes()).unwrap();
         writer.flush().unwrap();
@@ -49,5 +65,5 @@ fn prepare_contracts(root: &Path, num: usize) -> Vec<PathBuf> {
     files
 }
 
-criterion_group!(benches, read_all_benchmark);
+criterion_group!(benches, read_all_benchmark, read_solmate);
 criterion_main!(benches);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
also tested the sync vs. par file reading on solmate which has 50 source files in range of >4kb and par is only marginally faster:

```console
read solmate/sequential time:   [707.99 µs 713.80 µs 719.63 µs]                                    
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
read solmate/parallel   time:   [489.61 µs 515.83 µs 537.40 µs]                                 
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

```

this is still µs, so I think we can disable this par threshold altogether

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
