### PR TITLE
fix: geth trace types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Fix geth trace types for debug_traceTransaction rpc
 - Fix RLP decoding of legacy `Transaction`
 - Fix RLP encoding of `TransactionReceipt` [#1661](https://github.com/gakonst/ethers-rs/pull/1661)
 - Add `Unit8` helper type [#1639](https://github.com/gakonst/ethers-rs/pull/1639)

--- a/ethers-core/src/types/trace/geth.rs
+++ b/ethers-core/src/types/trace/geth.rs
@@ -23,15 +23,15 @@ pub struct StructLog {
     #[serde(rename = "gasCost")]
     pub gas_cost: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub memory: Option<Vec<u8>>,
+    pub memory: Option<Vec<H256>>,
     pub op: String,
-    pub pc: U256,
+    pub pc: u64,
     #[serde(rename = "refund", skip_serializing_if = "Option::is_none")]
     pub refund_counter: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stack: Option<Vec<U256>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub storage: Option<BTreeMap<H160, BTreeMap<H256, H256>>>,
+    pub storage: Option<BTreeMap<H256, H256>>,
 }
 
 /// Bindings for additional `debug_traceTransaction` options


### PR DESCRIPTION
## Motivation
Geth debug_traceTransaction was originally implemented in the following [commit](https://github.com/gakonst/ethers-rs/commit/cb7e58664576c220ed656bfa191ac4065a052cce). Types implemented for ```memory``` and ```stack``` where both ```strings``` when they should have been ```H256``` and ```U256``` respectively. This wasn't a breaking issue at the time as everything technically worked perfectly fine with ```strings```.  There is currently no unit tests for this tracing as per the original pull [request](https://github.com/gakonst/ethers-rs/pull/1469) this would require an rpc connection that supports the ```debug_traceTransaction``` method. About a month later the following [commit](https://github.com/gakonst/ethers-rs/commit/7c265500646c301b12a6a1fe00eec032b1908396) was pushed which added a missing value ```refund``` and made some of the types ```optional```, however the commit also changed the types of ```storage```, ```memory``` to incorrect types that are breaking changes when executing a geth trace.

## Solution
```storage```, ```memory``` and ```pc``` have had their types corrected.
Below is a snippet of a structLog of what a Geth trace looks like directly from the [example](https://github.com/gakonst/ethers-rs/blob/master/examples/geth_trace_transaction.rs) transaction so that it is clear what the geth trace types should be.
```json
      {
        "pc": 11112,
        "op": "SLOAD",
        "gas": 68979,
        "gasCost": 2100,
        "depth": 2,
        "stack": [
          "0xa9059cbb",
          "0x3f1",
          "0x88885af5baecd911e613529391706e17159d0a75",
          "0x3eea8174",
          "0x1"
        ],
        "memory": [
          "0000000000000000000000000000000000000000000000000000000000000000",
          "0000000000000000000000000000000000000000000000000000000000000000",
          "0000000000000000000000000000000000000000000000000000000000000080"
        ],
        "storage": {
          "0000000000000000000000000000000000000000000000000000000000000001": "000000000000000000000000f0d160dec1749afaf5a831668093b1431f7c8527",
          "10d6a54a4754c8869d6886b5f5d7fbfa5b4522237ea5c60d11bc4e7a1ff9390b": "000000000000000000000000807a96288a1a408dbc13de2b1d087d10356395d2",
          "7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3": "000000000000000000000000a2327a938febf5fec13bacfb16ae10ecbc4cbdcf"
        }
      },
```
executed directly with geth node
```
curl -H "Content-Type: application/json" -X POST --data '{"id": 1, "method": "debug_traceTransaction", "params": ["0x97a02abf405d36939e5b232a5d4ef5206980c5a6661845436058f30600c52df7", {"disableStack": false, "disableStorage": false, "enableMemory": true}]}' localhost:8550 > temp.json
```

## PR Checklist

- [ no] Added Tests
- [ X] Added Documentation
- [ X] Updated the changelog
