### PR TITLE
fix: serialize slot as h256 66 byte string

### DIFF
--- a/ethers-providers/tests/provider.rs
+++ b/ethers-providers/tests/provider.rs
@@ -6,7 +6,7 @@ use std::{convert::TryFrom, time::Duration};
 mod eth_tests {
     use super::*;
     use ethers_core::{
-        types::{Address, BlockId, TransactionRequest, H256},
+        types::{Address, BlockId, TransactionRequest, H256, U256},
         utils::Anvil,
     };
     use ethers_providers::RINKEBY;
@@ -112,6 +112,18 @@ mod eth_tests {
             Provider::<RetryClient<Http>>::new_client("http://localhost:8545", 10, 200).unwrap();
 
         send_zst_requests(provider).await;
+    }
+
+    // compatibility test for `eth_getStorageAt`
+    #[tokio::test]
+    #[ignore]
+    async fn eth_get_storage_at_compat() {
+        use ethers_core::abi::ethereum_types::BigEndianHash;
+        let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
+        let acc: Address = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266".parse().unwrap();
+
+        let _value =
+            provider.get_storage_at(acc, H256::from_uint(&U256::from(6u64)), None).await.unwrap();
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Ref https://github.com/foundry-rs/foundry/issues/2687

hardhat recently enforced 66byte slot argument for `eth_getStorageAt` https://github.com/NomicFoundation/hardhat/pull/2581 because:

> According to [the spec](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/ethereum/execution-apis/assembled-spec/openrpc.json&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false), the storage slot in eth_getStorageAt should have a length of 66 (0x + 32 bytes).

this is a bit confusing to me because this spec https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat says it's a [QUANTITY](https://ethereum.org/en/developers/docs/apis/json-rpc/#quantities-encoding)...

~~this is not very clear to me~~

resolved here https://github.com/NomicFoundation/hardhat/pull/2581#issuecomment-1242956716

we should merge this to be on par with hardhat

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
