### PR TITLE
chore: inherit stderr for anvil

### DIFF
--- a/ethers-core/src/utils/anvil.rs
+++ b/ethers-core/src/utils/anvil.rs
@@ -214,7 +214,7 @@ impl Anvil {
         } else {
             Command::new("anvil")
         };
-        cmd.stdout(std::process::Stdio::piped());
+        cmd.stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::inherit());
         let port = if let Some(port) = self.port { port } else { unused_port() };
         cmd.arg("-p").arg(port.to_string());
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
reading from stderr and stdout continuously is surprisingly hard because both are blocking operations.
this will inherit stderr to at least show the panic message if it panics, alternatively we could spawn an stderr reader to another thread and read the stderr output there, but this will also block and hang if anvil never prints to stderr, so unsure if worth it to have a background thread that may live for the entire program just for monitoring the anvil launch...
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
