### PR TITLE
fix: geth structlog memory

### DIFF
--- a/ethers-core/src/types/trace/geth.rs
+++ b/ethers-core/src/types/trace/geth.rs
@@ -22,8 +22,9 @@ pub struct StructLog {
     pub gas: u64,
     #[serde(rename = "gasCost")]
     pub gas_cost: u64,
+    /// ref <https://github.com/ethereum/go-ethereum/blob/366d2169fbc0e0f803b68c042b77b6b480836dbc/eth/tracers/logger/logger.go#L450-L452>
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub memory: Option<Vec<H256>>,
+    pub memory: Option<Vec<String>>,
     pub op: String,
     pub pc: u64,
     #[serde(rename = "refund", skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
we went from `Vec<u8>` to `Vec<H256>` here https://github.com/gakonst/ethers-rs/pull/1682 but the actual data is a 32byte string containing memory chunks of 32byte:

https://github.com/ethereum/go-ethereum/blob/366d2169fbc0e0f803b68c042b77b6b480836dbc/eth/tracers/logger/logger.go#L450-L452

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
