### PR TITLE
fix(solc): remove default include paths

### DIFF
--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -88,9 +88,8 @@ impl ProjectPathsConfig {
     ///
     /// See [IncludePaths]
     pub fn include_paths(&self) -> Vec<PathBuf> {
-        // Note: root must not be included, since it will be used as base-path, which would be a
-        // conflict
-        vec![self.sources.clone(), self.tests.clone(), self.scripts.clone()]
+        // Note: sources, tests and scripts are covered by the base-path
+        Default::default()
     }
 
     /// Creates all configured dirs and files
@@ -261,15 +260,6 @@ impl ProjectPathsConfig {
                 // also try to resolve absolute imports from the project paths
                 for path in [&self.root, &self.sources, &self.tests, &self.scripts] {
                     if cwd.starts_with(path) {
-                        if let Ok(import) = utils::canonicalize(path.join(import)) {
-                            return Ok(import)
-                        }
-                    }
-                }
-                // if still unable to resolve, attempt to find the absolute import
-                // inside the project paths that's possible due to `--include-dir`
-                for path in [&self.sources, &self.tests, &self.scripts] {
-                    if path.join(import).exists() {
                         if let Ok(import) = utils::canonicalize(path.join(import)) {
                             return Ok(import)
                         }

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -84,14 +84,6 @@ impl ProjectPathsConfig {
         paths
     }
 
-    /// Returns all `--include-path` paths that should be used for this project
-    ///
-    /// See [IncludePaths]
-    pub fn include_paths(&self) -> Vec<PathBuf> {
-        // Note: sources, tests and scripts are covered by the base-path
-        Default::default()
-    }
-
     /// Creates all configured dirs and files
     pub fn create_all(&self) -> std::result::Result<(), SolcIoError> {
         if let Some(parent) = self.cache.parent() {

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -269,15 +269,9 @@ impl ProjectPathsConfig {
                 // if still unable to resolve, attempt to find the absolute import
                 // inside the project paths that's possible due to `--include-dir`
                 for path in [&self.sources, &self.tests, &self.scripts] {
-                    if let Ok(entries) = std::fs::read_dir(path) {
-                        for entry in entries {
-                            if let Ok(entry) = entry {
-                                if import.starts_with(entry.file_name()) {
-                                    if let Ok(import) = utils::canonicalize(path.join(import)) {
-                                        return Ok(import)
-                                    }
-                                }
-                            }
+                    if path.join(import).exists() {
+                        if let Ok(import) = utils::canonicalize(path.join(import)) {
+                            return Ok(import)
                         }
                     }
                 }

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -266,6 +266,21 @@ impl ProjectPathsConfig {
                         }
                     }
                 }
+                // if still unable to resolve, attempt to find the absolute import
+                // inside the project paths that's possible due to `--include-dir`
+                for path in [&self.sources, &self.tests, &self.scripts] {
+                    if let Ok(entries) = std::fs::read_dir(path) {
+                        for entry in entries {
+                            if let Ok(entry) = entry {
+                                if import.starts_with(entry.file_name()) {
+                                    if let Ok(import) = utils::canonicalize(path.join(import)) {
+                                        return Ok(import)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             resolved.ok_or_else(|| {

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -804,7 +804,7 @@ impl<T: ArtifactOutput> ProjectBuilder<T> {
             artifacts,
             ignored_error_codes,
             mut allowed_paths,
-            mut include_paths,
+            include_paths,
             solc_jobs,
             offline,
             build_info,
@@ -823,8 +823,6 @@ impl<T: ArtifactOutput> ProjectBuilder<T> {
 
         // allow every contract under root by default
         allowed_paths.insert(paths.root.clone());
-        // allow paths where contracts are stored by default
-        include_paths.extend(paths.include_paths());
 
         Ok(Project {
             paths,


### PR DESCRIPTION
## Motivation

currently, the default `include_path`s contain the sources, test & script dirs, which lead to the possibility of ambiguous imports like `import 'interface/IContract.sol';` given the project tree
```text
- src
-- Contract.sol
-- interface
--- IContract.sol
```

while it is possible to make the `Graph` resolve such import paths properly, it leads to ambiguity while trying to reconstruct sources for standard json input, since the same node can be imported as `interface/IContract.sol` and `src/interface/IContract.sol`

more info [here](https://docs.soliditylang.org/en/v0.8.13/path-resolution.html#initial-content-of-the-virtual-filesystem)

## Solution

remove default include paths since they are all covered by the base path

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
