### PR TITLE
feat(ethers-core): double anvil startup time

### DIFF
--- a/ethers-core/src/utils/anvil.rs
+++ b/ethers-core/src/utils/anvil.rs
@@ -93,6 +93,7 @@ pub struct Anvil {
     fork: Option<String>,
     fork_block_number: Option<u64>,
     args: Vec<String>,
+    timeout: Option<u64>,
 }
 
 impl Anvil {
@@ -206,6 +207,13 @@ impl Anvil {
         self
     }
 
+    /// Sets the timeout which will be used when the `anvil` instance is launched.
+    #[must_use]
+    pub fn timeout<T: Into<u64>>(mut self, timeout: T) -> Self {
+        self.timeout = Some(timeout.into());
+        self
+    }
+
     /// Consumes the builder and spawns `anvil` with stdout redirected
     /// to /dev/null.
     pub fn spawn(self) -> AnvilInstance {
@@ -251,7 +259,7 @@ impl Anvil {
         let mut addresses = Vec::new();
         let mut is_private_key = false;
         loop {
-            if start + Duration::from_millis(ANVIL_STARTUP_TIMEOUT_MILLIS) <= Instant::now() {
+            if start + Duration::from_millis(self.timeout.unwrap_or(ANVIL_STARTUP_TIMEOUT_MILLIS)) <= Instant::now() {
                 panic!("Timed out waiting for anvil to start. Is anvil installed?")
             }
 

--- a/ethers-core/src/utils/anvil.rs
+++ b/ethers-core/src/utils/anvil.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 /// How long we will wait for anvil to indicate that it is ready.
-const ANVIL_STARTUP_TIMEOUT_MILLIS: u64 = 5_000;
+const ANVIL_STARTUP_TIMEOUT_MILLIS: u64 = 10_000;
 
 /// An anvil CLI instance. Will close the instance when dropped.
 ///

--- a/ethers-core/src/utils/anvil.rs
+++ b/ethers-core/src/utils/anvil.rs
@@ -259,7 +259,9 @@ impl Anvil {
         let mut addresses = Vec::new();
         let mut is_private_key = false;
         loop {
-            if start + Duration::from_millis(self.timeout.unwrap_or(ANVIL_STARTUP_TIMEOUT_MILLIS)) <= Instant::now() {
+            if start + Duration::from_millis(self.timeout.unwrap_or(ANVIL_STARTUP_TIMEOUT_MILLIS)) <=
+                Instant::now()
+            {
                 panic!("Timed out waiting for anvil to start. Is anvil installed?")
             }
 


### PR DESCRIPTION
## Motivation

To close #1660. Anvil's startup time may exceed 5000 millisecond and cause timeout because of additional task to setup a fork.

## Solution

Double the startup time as the same as geth. If still cause panic, it should be other problem.

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
