### PR TITLE
docs: add comment about safety of u8 -> u64 cast in signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Add comment about safety of u8 -> u64 cast in `ethers_core::types::Signature`
 - Fix geth trace types for debug_traceTransaction rpc
 - Fix RLP decoding of legacy `Transaction`
 - Fix RLP encoding of `TransactionReceipt` [#1661](https://github.com/gakonst/ethers-rs/pull/1661)

--- a/ethers-core/src/types/signature.rs
+++ b/ethers-core/src/types/signature.rs
@@ -215,6 +215,11 @@ impl From<&Signature> for [u8; 65] {
         sig[32..64].copy_from_slice(&s_bytes);
         // TODO: What if we try to serialize a signature where
         // the `v` is not normalized?
+
+        // The u64 to u8 cast is safe because `sig.v` can only ever be 27 or 28 
+        // here. Regarding EIP-155, the modification to `v` happens during tx 
+        // creation only _after_ the transaction is signed using 
+        // `ethers_signers::to_eip155_v`.
         sig[64] = src.v as u8;
         sig
     }

--- a/ethers-core/src/types/signature.rs
+++ b/ethers-core/src/types/signature.rs
@@ -216,9 +216,9 @@ impl From<&Signature> for [u8; 65] {
         // TODO: What if we try to serialize a signature where
         // the `v` is not normalized?
 
-        // The u64 to u8 cast is safe because `sig.v` can only ever be 27 or 28 
-        // here. Regarding EIP-155, the modification to `v` happens during tx 
-        // creation only _after_ the transaction is signed using 
+        // The u64 to u8 cast is safe because `sig.v` can only ever be 27 or 28
+        // here. Regarding EIP-155, the modification to `v` happens during tx
+        // creation only _after_ the transaction is signed using
         // `ethers_signers::to_eip155_v`.
         sig[64] = src.v as u8;
         sig


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Lack of clarity around safety of casting `sig.v` from `u64` to `u8`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add comment explaining why it's safe :)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests (N/A)
- [ ] Added Documentation (N/A)
- [x] Updated the changelog
