### PR TITLE
fix(core): GethTrace shouldn't have 0x prefix for return_value

### DIFF
--- a/ethers-core/src/types/trace/geth.rs
+++ b/ethers-core/src/types/trace/geth.rs
@@ -1,5 +1,5 @@
 use crate::types::{Bytes, H256, U256};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use std::collections::BTreeMap;
 
 // https://github.com/ethereum/go-ethereum/blob/a9ef135e2dd53682d106c6a2aede9187026cc1de/eth/tracers/logger/logger.go#L406-L411
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 pub struct GethTrace {
     pub failed: bool,
     pub gas: u64,
-    #[serde(rename = "returnValue")]
+    #[serde(serialize_with = "serialize_bytes", rename = "returnValue")]
     pub return_value: Bytes,
     #[serde(rename = "structLogs")]
     pub struct_logs: Vec<StructLog>,
@@ -53,4 +53,12 @@ pub struct GethDebugTracingOptions {
     pub tracer: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout: Option<String>,
+}
+
+fn serialize_bytes<S, T>(x: T, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: AsRef<[u8]>,
+{
+    s.serialize_str(&hex::encode(x.as_ref()))
 }


### PR DESCRIPTION
## Motivation

https://github.com/foundry-rs/foundry/issues/3206

Left – ours, right – geth

<img width="622" alt="image" src="https://user-images.githubusercontent.com/5773434/190515398-0d4f1dd0-9f93-4c16-892b-85758cb5cfe8.png">


## Solution

Left – ours, right – geth

<img width="616" alt="image" src="https://user-images.githubusercontent.com/5773434/190515470-aefe0815-12cc-4abf-b79f-896898c19c40.png">

