### PR TITLE
fix(contract): relax Middleware trait bound for getters

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract/common.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/common.rs
@@ -95,7 +95,6 @@ pub(crate) fn struct_declaration(cx: &Context) -> TokenStream {
     let abi_name = cx.inline_abi_ident();
 
     let ethers_core = ethers_core_crate();
-    let ethers_providers = ethers_providers_crate();
     let ethers_contract = ethers_contract_crate();
 
     let abi_parse = if !cx.human_readable {
@@ -144,7 +143,7 @@ pub(crate) fn struct_declaration(cx: &Context) -> TokenStream {
             fn deref(&self) -> &Self::Target { &self.0 }
         }
 
-        impl<M: #ethers_providers::Middleware> std::fmt::Debug for #name<M> {
+        impl<M> std::fmt::Debug for #name<M> {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
                 f.debug_tuple(stringify!(#name))
                     .field(&self.address())

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -15,8 +15,6 @@ use ethers_core::types::Eip1559TransactionRequest;
 #[cfg(feature = "legacy")]
 use ethers_core::types::TransactionRequest;
 
-use ethers_providers::Middleware;
-
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
 /// A Contract is an abstraction of an executable program on the Ethereum Blockchain.
@@ -157,6 +155,13 @@ pub struct Contract<M> {
     address: Address,
 }
 
+impl<M> std::ops::Deref for Contract<M> {
+    type Target = BaseContract;
+    fn deref(&self) -> &Self::Target {
+        &self.base_contract
+    }
+}
+
 impl<M> Clone for Contract<M> {
     fn clone(&self) -> Self {
         Contract {
@@ -167,10 +172,14 @@ impl<M> Clone for Contract<M> {
     }
 }
 
-impl<M: Middleware> Contract<M> {
+impl<M> Contract<M> {
     /// Creates a new contract from the provided client, abi and address
-    pub fn new(address: Address, abi: impl Into<BaseContract>, client: impl Into<Arc<M>>) -> Self {
-        Self { base_contract: abi.into(), client: client.into(), address }
+    pub fn new(
+        address: impl Into<Address>,
+        abi: impl Into<BaseContract>,
+        client: impl Into<Arc<M>>,
+    ) -> Self {
+        Self { base_contract: abi.into(), client: client.into(), address: address.into() }
     }
 
     /// Returns an [`Event`](crate::builders::Event) builder for the provided event.
@@ -291,12 +300,5 @@ impl<M: Middleware> Contract<M> {
     /// Returns a reference to the contract's client
     pub fn client(&self) -> &M {
         &self.client
-    }
-}
-
-impl<M: Middleware> std::ops::Deref for Contract<M> {
-    type Target = BaseContract;
-    fn deref(&self) -> &Self::Target {
-        &self.base_contract
     }
 }

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -10,12 +10,12 @@ use ethers_core::{
     types::{Address, Filter, Selector, ValueOrArray},
 };
 
-use ethers_providers::Middleware;
-
 #[cfg(not(feature = "legacy"))]
 use ethers_core::types::Eip1559TransactionRequest;
 #[cfg(feature = "legacy")]
 use ethers_core::types::TransactionRequest;
+
+use ethers_providers::Middleware;
 
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -10,6 +10,8 @@ use ethers_core::{
     types::{Address, Filter, Selector, ValueOrArray},
 };
 
+use ethers_providers::Middleware;
+
 #[cfg(not(feature = "legacy"))]
 use ethers_core::types::Eip1559TransactionRequest;
 #[cfg(feature = "legacy")]
@@ -150,9 +152,9 @@ use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 /// [`method`]: method@crate::Contract::method
 #[derive(Debug)]
 pub struct Contract<M> {
+    address: Address,
     base_contract: BaseContract,
     client: Arc<M>,
-    address: Address,
 }
 
 impl<M> std::ops::Deref for Contract<M> {
@@ -173,6 +175,23 @@ impl<M> Clone for Contract<M> {
 }
 
 impl<M> Contract<M> {
+    /// Returns the contract's address
+    pub fn address(&self) -> Address {
+        self.address
+    }
+
+    /// Returns a reference to the contract's ABI
+    pub fn abi(&self) -> &Abi {
+        &self.base_contract.abi
+    }
+
+    /// Returns a reference to the contract's client
+    pub fn client(&self) -> &M {
+        &self.client
+    }
+}
+
+impl<M: Middleware> Contract<M> {
     /// Creates a new contract from the provided client, abi and address
     pub fn new(
         address: impl Into<Address>,
@@ -285,20 +304,5 @@ impl<M> Contract<M> {
         N: Clone,
     {
         Contract { base_contract: self.base_contract.clone(), client, address: self.address }
-    }
-
-    /// Returns the contract's address
-    pub fn address(&self) -> Address {
-        self.address
-    }
-
-    /// Returns a reference to the contract's ABI
-    pub fn abi(&self) -> &Abi {
-        &self.base_contract.abi
-    }
-
-    /// Returns a reference to the contract's client
-    pub fn client(&self) -> &M {
-        &self.client
     }
 }

--- a/ethers-contract/src/multicall/multicall_contract.rs
+++ b/ethers-contract/src/multicall/multicall_contract.rs
@@ -26,7 +26,7 @@ pub mod multicall_3 {
             &self.0
         }
     }
-    impl<M: ethers_providers::Middleware> std::fmt::Debug for Multicall3<M> {
+    impl<M> std::fmt::Debug for Multicall3<M> {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
             f.debug_tuple(stringify!(Multicall3)).field(&self.address()).finish()
         }

--- a/ethers-core/src/types/i256.rs
+++ b/ethers-core/src/types/i256.rs
@@ -339,13 +339,7 @@ impl I256 {
     /// Returns an `i64` representing the sign of the number.
     fn signum64(self) -> i64 {
         match self.sign() {
-            Sign::Positive => {
-                if self.is_zero() {
-                    0
-                } else {
-                    1
-                }
-            }
+            Sign::Positive => (!self.is_zero()) as i64,
             Sign::Negative => -1,
         }
     }

--- a/ethers-signers/src/ledger/app.rs
+++ b/ethers-signers/src/ledger/app.rs
@@ -141,11 +141,7 @@ impl LedgerEthereum {
 
             signature.v = match tx {
                 TypedTransaction::Eip2930(_) | TypedTransaction::Eip1559(_) => {
-                    if ecc_parity % 2 == 1 {
-                        0
-                    } else {
-                        1
-                    }
+                    (ecc_parity % 2 != 1) as u64
                 }
                 TypedTransaction::Legacy(_) => eip155_chain_id + ecc_parity,
             };


### PR DESCRIPTION
## Motivation

`Contract`'s getters are bound to the `Middleware` trait which blocks `Debug` from being derived automatically for structs that hold abigen'd contracts, eg:

```rust
abigen!(MyContract, "...")
// Clone works fine
// Cannot derive Debug: 'M: Middleware is not satisfied'
#[derive(Clone, Debug)]
struct<M> MyStruct<M> {
  contract: MyContract<M>
}

```

## Solution

Move to new impl block