### PR TITLE
fix(solc): use empty bytecode as default instead unlinked

### DIFF
--- a/ethers-solc/src/artifacts/bytecode.rs
+++ b/ethers-solc/src/artifacts/bytecode.rs
@@ -458,11 +458,9 @@ impl From<CompactDeployedBytecode> for DeployedBytecode {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use crate::artifacts::{ContractBytecode};
-    use crate::{ConfigurableContractArtifact};
+    use crate::{artifacts::ContractBytecode, ConfigurableContractArtifact};
 
     #[test]
     fn test_empty_bytecode() {
@@ -480,10 +478,10 @@ mod tests {
   }
         "#;
 
-        let artifact : ConfigurableContractArtifact = serde_json::from_str(empty).unwrap();
+        let artifact: ConfigurableContractArtifact = serde_json::from_str(empty).unwrap();
         let contract = artifact.into_contract_bytecode();
         let bytecode: ContractBytecode = contract.into();
         let bytecode = bytecode.unwrap();
-       assert!(!bytecode.bytecode.object.is_unlinked());
+        assert!(!bytecode.bytecode.object.is_unlinked());
     }
 }

--- a/ethers-solc/src/artifacts/bytecode.rs
+++ b/ethers-solc/src/artifacts/bytecode.rs
@@ -352,10 +352,10 @@ impl BytecodeObject {
     }
 }
 
-// Returns a not deployable bytecode by default as empty
+// Returns an empty bytecode object
 impl Default for BytecodeObject {
     fn default() -> Self {
-        BytecodeObject::Unlinked("".to_string())
+        BytecodeObject::Bytecode(Default::default())
     }
 }
 
@@ -455,5 +455,35 @@ impl From<CompactDeployedBytecode> for DeployedBytecode {
             bytecode: bcode.bytecode.map(|d_bcode| d_bcode.into()),
             immutable_references: bcode.immutable_references,
         }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use crate::artifacts::{ContractBytecode};
+    use crate::{ConfigurableContractArtifact};
+
+    #[test]
+    fn test_empty_bytecode() {
+        let empty = r#"
+        {
+  "abi": [],
+  "bytecode": {
+    "object": "0x",
+    "linkReferences": {}
+  },
+  "deployedBytecode": {
+    "object": "0x",
+    "linkReferences": {}
+  }
+  }
+        "#;
+
+        let artifact : ConfigurableContractArtifact = serde_json::from_str(empty).unwrap();
+        let contract = artifact.into_contract_bytecode();
+        let bytecode: ContractBytecode = contract.into();
+        let bytecode = bytecode.unwrap();
+       assert!(!bytecode.bytecode.object.is_unlinked());
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/3339

standalone sol files (without any contracts) were assigned the default `Bytecode` object, which was `Unlinked`. This should just be an empty `Bytes` object
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Updated the changelog
