### PR TITLE
fix: support eip712 domain chain ids as string

### DIFF
--- a/ethers-core/src/types/serde_helpers.rs
+++ b/ethers-core/src/types/serde_helpers.rs
@@ -255,7 +255,6 @@ where
     Ok(num)
 }
 
-
 #[cfg(test)]
 mod tests {
 
@@ -265,16 +264,15 @@ mod tests {
         use crate::types::transaction::eip712::EIP712Domain;
 
         let val = serde_json::json!(
-            {
-    "name": "Seaport",
-    "version": "1.1",
-    "chainId": "137",
-    "verifyingContract": "0x00000000006c3852cbEf3e08E8dF289169EdE581"
-  }
-        );
+                  {
+          "name": "Seaport",
+          "version": "1.1",
+          "chainId": "137",
+          "verifyingContract": "0x00000000006c3852cbEf3e08E8dF289169EdE581"
+        }
+              );
 
         let domain: EIP712Domain = serde_json::from_value(val).unwrap();
         assert_eq!(domain.chain_id, Some(137u64.into()));
-
     }
 }

--- a/ethers-core/src/types/serde_helpers.rs
+++ b/ethers-core/src/types/serde_helpers.rs
@@ -254,3 +254,27 @@ where
     let num = <[LenientBlockNumber; 1]>::deserialize(deserializer)?[0].into();
     Ok(num)
 }
+
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    #[cfg(feature = "eip712")]
+    fn test_deserialize_string_chain_id() {
+        use crate::types::transaction::eip712::EIP712Domain;
+
+        let val = serde_json::json!(
+            {
+    "name": "Seaport",
+    "version": "1.1",
+    "chainId": "137",
+    "verifyingContract": "0x00000000006c3852cbEf3e08E8dF289169EdE581"
+  }
+        );
+
+        let domain: EIP712Domain = serde_json::from_value(val).unwrap();
+        assert_eq!(domain.chain_id, Some(137u64.into()));
+
+    }
+}

--- a/ethers-core/src/types/transaction/eip712.rs
+++ b/ethers-core/src/types/transaction/eip712.rs
@@ -131,7 +131,7 @@ pub struct EIP712Domain {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "crate::types::serde_helpers::deserialize_number_opt"
+        deserialize_with = "crate::types::serde_helpers::deserialize_stringified_numeric_opt"
     )]
     pub chain_id: Option<U256>,
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/3409

use correct decoding for chain id, in `EIP712Domain` which can also be a string
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
