### PR TITLE
fix(core, etherscan): RawAbi and Abi

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -7,12 +7,9 @@ pub(crate) mod structs;
 mod types;
 
 use super::{util, Abigen};
-use crate::{
-    contract::{methods::MethodAlias, structs::InternalStructs},
-    rawabi::JsonAbi,
-};
+use crate::contract::{methods::MethodAlias, structs::InternalStructs};
 use ethers_core::{
-    abi::{Abi, AbiParser, ErrorExt, EventExt},
+    abi::{Abi, AbiParser, ErrorExt, EventExt, JsonAbi},
     macros::{ethers_contract_crate, ethers_core_crate, ethers_providers_crate},
     types::Bytes,
 };

--- a/ethers-contract/ethers-contract-abigen/src/contract/structs.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/structs.rs
@@ -1,13 +1,12 @@
 //! Methods for expanding structs
 use crate::{
     contract::{types, Context},
-    rawabi::{Component, RawAbi},
     util,
 };
 use ethers_core::{
     abi::{
         struct_def::{FieldDeclaration, FieldType, StructFieldType, StructType},
-        HumanReadableParser, ParamType, SolStruct,
+        Component, HumanReadableParser, ParamType, RawAbi, SolStruct,
     },
     macros::ethers_contract_crate,
 };

--- a/ethers-contract/ethers-contract-abigen/src/lib.rs
+++ b/ethers-contract/ethers-contract-abigen/src/lib.rs
@@ -16,9 +16,6 @@ pub mod contract;
 pub use contract::structs::InternalStructs;
 use contract::Context;
 
-pub mod rawabi;
-pub use rawabi::RawAbi;
-
 mod rustfmt;
 mod source;
 mod util;

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -49,7 +49,7 @@ pub mod builders {
 #[cfg(any(test, feature = "abigen"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "abigen")))]
 pub use ethers_contract_abigen::{
-    Abigen, ContractFilter, ExcludeContracts, InternalStructs, MultiAbigen, RawAbi, SelectContracts,
+    Abigen, ContractFilter, ExcludeContracts, InternalStructs, MultiAbigen, SelectContracts,
 };
 
 #[cfg(any(test, feature = "abigen"))]

--- a/ethers-core/src/abi/mod.rs
+++ b/ethers-core/src/abi/mod.rs
@@ -22,6 +22,10 @@ mod human_readable;
 pub use human_readable::{
     lexer::HumanReadableParser, parse as parse_abi, parse_str as parse_abi_str, AbiParser,
 };
+
+mod raw;
+pub use raw::{AbiObject, Component, Item, JsonAbi, RawAbi};
+
 mod sealed {
     use ethabi::{Event, Function};
 

--- a/ethers-core/src/abi/raw.rs
+++ b/ethers-core/src/abi/raw.rs
@@ -2,7 +2,7 @@
 //! raw content of the ABI.
 
 #![allow(missing_docs)]
-use ethers_core::types::Bytes;
+use crate::types::Bytes;
 use serde::{
     de::{MapAccess, SeqAccess, Visitor},
     Deserialize, Deserializer, Serialize,
@@ -109,7 +109,7 @@ pub struct Component {
 /// Represents contract ABI input variants
 #[derive(Deserialize)]
 #[serde(untagged)]
-pub(crate) enum JsonAbi {
+pub enum JsonAbi {
     /// json object input as `{"abi": [..], "bin": "..."}`
     Object(AbiObject),
     /// json array input as `[]`
@@ -125,7 +125,7 @@ where
 }
 
 /// Contract ABI and optional bytecode as JSON object
-pub(crate) struct AbiObject {
+pub struct AbiObject {
     pub abi: RawAbi,
     pub bytecode: Option<Bytes>,
 }
@@ -158,7 +158,7 @@ impl<'de> Visitor<'de> for AbiObjectVisitor {
             where
                 D: Deserializer<'de>,
             {
-                Ok(DeserializeBytes(ethers_core::types::deserialize_bytes(deserializer)?.into()))
+                Ok(DeserializeBytes(crate::types::deserialize_bytes(deserializer)?.into()))
             }
         }
 
@@ -204,7 +204,7 @@ impl<'de> Deserialize<'de> for AbiObject {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ethers_core::abi::Abi;
+    use crate::abi::Abi;
 
     fn assert_has_bytecode(s: &str) {
         match serde_json::from_str::<JsonAbi>(s).unwrap() {
@@ -219,14 +219,16 @@ mod tests {
 
     #[test]
     fn can_parse_raw_abi() {
-        const VERIFIER_ABI: &str = include_str!("../../tests/solidity-contracts/verifier_abi.json");
+        const VERIFIER_ABI: &str =
+            include_str!("../../../ethers-contract/tests/solidity-contracts/verifier_abi.json");
         let _ = serde_json::from_str::<RawAbi>(VERIFIER_ABI).unwrap();
     }
 
     #[test]
     fn can_parse_hardhat_raw_abi() {
-        const VERIFIER_ABI: &str =
-            include_str!("../../tests/solidity-contracts/verifier_abi_hardhat.json");
+        const VERIFIER_ABI: &str = include_str!(
+            "../../../ethers-contract/tests/solidity-contracts/verifier_abi_hardhat.json"
+        );
         let _ = serde_json::from_str::<RawAbi>(VERIFIER_ABI).unwrap();
     }
 
@@ -261,7 +263,9 @@ mod tests {
         let s = format!(r#"{{"abi": {}, "bytecode" : {{ "object": "{}" }} }}"#, abi_str, code);
         assert_has_bytecode(&s);
 
-        let hh_artifact = include_str!("../../tests/solidity-contracts/verifier_abi_hardhat.json");
+        let hh_artifact = include_str!(
+            "../../../ethers-contract/tests/solidity-contracts/verifier_abi_hardhat.json"
+        );
         match serde_json::from_str::<JsonAbi>(hh_artifact).unwrap() {
             JsonAbi::Object(abi) => {
                 assert!(abi.bytecode.is_none());
@@ -274,7 +278,8 @@ mod tests {
 
     #[test]
     fn can_parse_greeter_bytecode() {
-        let artifact = include_str!("../../tests/solidity-contracts/greeter.json");
+        let artifact =
+            include_str!("../../../ethers-contract/tests/solidity-contracts/greeter.json");
         assert_has_bytecode(artifact);
     }
 

--- a/ethers-etherscan/src/utils.rs
+++ b/ethers-etherscan/src/utils.rs
@@ -1,5 +1,5 @@
 use crate::{contract::SourceCodeMetadata, EtherscanError, Result};
-use ethers_core::{abi::Abi, types::Address};
+use ethers_core::types::Address;
 use semver::Version;
 use serde::{Deserialize, Deserializer};
 
@@ -51,14 +51,6 @@ pub fn deserialize_stringified_source_code<'de, D: Deserializer<'de>>(
     } else {
         Ok(SourceCodeMetadata::SourceCode(s))
     }
-}
-
-/// Deserializes as JSON: "\[...\]"
-pub fn deserialize_stringified_abi<'de, D: Deserializer<'de>>(
-    deserializer: D,
-) -> std::result::Result<Abi, D::Error> {
-    let s = String::deserialize(deserializer)?;
-    serde_json::from_str(&s).map_err(serde::de::Error::custom)
 }
 
 #[cfg(test)]
@@ -113,19 +105,6 @@ mod tests {
         let de: Test = serde_json::from_str(json).unwrap();
         let expected = "0x4af649ffde640ceb34b1afaba3e0bb8e9698cb01".parse().unwrap();
         assert_eq!(de.address, Some(expected));
-    }
-
-    #[test]
-    fn can_deserialize_stringified_abi() {
-        #[derive(Deserialize)]
-        struct Test {
-            #[serde(deserialize_with = "deserialize_stringified_abi")]
-            abi: Abi,
-        }
-
-        let json = r#"{"abi": "[]"}"#;
-        let de: Test = serde_json::from_str(json).unwrap();
-        assert_eq!(de.abi, Abi::default());
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

high priority since cast interface stuff is broken @gakonst thx ser

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- move (only) rawabi as raw.rs to core::abi, testdata not moved (abi jsons and contracts)
- revert etherscan parsing as Abi, add methods to conditionally parse as RawAbi or Abi

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
