### PR TITLE
Drop anvil subprocess stdout

### DIFF
--- a/ethers-core/src/utils/anvil.rs
+++ b/ethers-core/src/utils/anvil.rs
@@ -250,7 +250,7 @@ impl Anvil {
 
         let mut child = cmd.spawn().expect("couldnt start anvil");
 
-        let stdout = child.stdout.expect("Unable to get stdout for anvil child process");
+        let stdout = child.stdout.take().expect("Unable to get stdout for anvil child process");
 
         let start = Instant::now();
         let mut reader = BufReader::new(stdout);
@@ -283,8 +283,6 @@ impl Anvil {
                 private_keys.push(key);
             }
         }
-
-        child.stdout = Some(reader.into_inner());
 
         AnvilInstance { pid: child, private_keys, addresses, port, chain_id: self.chain_id }
     }


### PR DESCRIPTION
## Motivation

Fixes #1758

## Solution

Drop stdout to match the behavior documented in comment above "stdout redirected to /dev/null".
Keeping it around can cause problems when many logs are generated.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
