### PR TITLE
chore(solc): create artifacts folder on output

### DIFF
--- a/ethers-solc/src/utils.rs
+++ b/ethers-solc/src/utils.rs
@@ -469,6 +469,17 @@ mod tests {
     }
 
     #[test]
+    fn can_create_parent_dirs_versioned() {
+        let tmp_dir = tempdir("out").unwrap();
+        let path = tmp_dir.path().join("IVersioned.sol/IVersioned.0.8.16.json");
+        create_parent_dir_all(&path).unwrap();
+        assert!(path.parent().unwrap().is_dir());
+        let path = tmp_dir.path().join("IVersioned.sol/IVersioned.json");
+        create_parent_dir_all(&path).unwrap();
+        assert!(path.parent().unwrap().is_dir());
+    }
+
+    #[test]
     fn can_determine_local_paths() {
         assert!(is_local_source_name(&[""], "./local/contract.sol"));
         assert!(is_local_source_name(&[""], "../local/contract.sol"));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

This is weird filesystem permissions bug https://github.com/foundry-rs/foundry/issues/3268 that somehow is limited to the artifacts folder that occurs when artifacts are written.

this will create the artifacts folder _before_ files are written.

I haven't found the root cause for this yet, but this could be related.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
