### PR TITLE
fix(solc): handle absolute paths properly on conflict

### DIFF
--- a/ethers-solc/src/compile/project.rs
+++ b/ethers-solc/src/compile/project.rs
@@ -305,10 +305,20 @@ impl<'a, T: ArtifactOutput> CompiledState<'a, T> {
         // write all artifacts via the handler but only if the build succeeded and project wasn't
         // configured with `no_artifacts == true`
         let compiled_artifacts = if project.no_artifacts {
-            project.artifacts_handler().output_to_artifacts(&output.contracts, &output.sources, ctx)
+            project.artifacts_handler().output_to_artifacts(
+                &output.contracts,
+                &output.sources,
+                ctx,
+                &project.paths,
+            )
         } else if output.has_error() {
             trace!("skip writing cache file due to solc errors: {:?}", output.errors);
-            project.artifacts_handler().output_to_artifacts(&output.contracts, &output.sources, ctx)
+            project.artifacts_handler().output_to_artifacts(
+                &output.contracts,
+                &output.sources,
+                ctx,
+                &project.paths,
+            )
         } else {
             trace!(
                 "handling artifact output for {} contracts and {} sources",

--- a/ethers-solc/src/lib.rs
+++ b/ethers-solc/src/lib.rs
@@ -933,8 +933,9 @@ impl<T: ArtifactOutput> ArtifactOutput for Project<T> {
         contracts: &VersionedContracts,
         sources: &VersionedSourceFiles,
         ctx: OutputContext,
+        layout: &ProjectPathsConfig,
     ) -> Artifacts<Self::Artifact> {
-        self.artifacts_handler().output_to_artifacts(contracts, sources, ctx)
+        self.artifacts_handler().output_to_artifacts(contracts, sources, ctx, layout)
     }
 
     fn standalone_source_file_to_artifact(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
this should finally close https://github.com/foundry-rs/foundry/issues/3268

thanks to @CarterAppleton for sharing logs.

this bug happened because `conflict_free_output_file` wasn't tested against absolute paths. so if there are duplicate contracts the previous implemented could end up prefixing the entire path with `_1` which is used to find a new unused path...

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
fixes by stripping the output path and treating it relatively as intended.
added new test to confirm

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
