### PR TITLE
feat(core): re-export H128

### DIFF
--- a/ethers-core/src/types/mod.rs
+++ b/ethers-core/src/types/mod.rs
@@ -5,7 +5,9 @@ pub type Selector = [u8; 4];
 /// A transaction Hash
 pub use ethabi::ethereum_types::H256 as TxHash;
 
-pub use ethabi::ethereum_types::{Address, Bloom, H128, H160, H256, H32, H512, H64, U128, U256, U64};
+pub use ethabi::ethereum_types::{
+    Address, Bloom, H128, H160, H256, H32, H512, H64, U128, U256, U64,
+};
 
 pub mod transaction;
 pub use transaction::{

--- a/ethers-core/src/types/mod.rs
+++ b/ethers-core/src/types/mod.rs
@@ -5,7 +5,7 @@ pub type Selector = [u8; 4];
 /// A transaction Hash
 pub use ethabi::ethereum_types::H256 as TxHash;
 
-pub use ethabi::ethereum_types::{Address, Bloom, H160, H256, H32, H512, H64, U128, U256, U64};
+pub use ethabi::ethereum_types::{Address, Bloom, H128, H160, H256, H32, H512, H64, U128, U256, U64};
 
 pub mod transaction;
 pub use transaction::{

--- a/examples/remove_liquidity.rs
+++ b/examples/remove_liquidity.rs
@@ -52,8 +52,8 @@ async fn example() -> Result<()> {
     println!("Reserves (token A, Token B): ({}, {})", reserve0, reserve1);
 
     let price =
-        if reserve0 > reserve1 { 1000 * reserve0 / reserve1 } else { 1000 * reserve1 / reserve0 }
-            / 1000;
+        if reserve0 > reserve1 { 1000 * reserve0 / reserve1 } else { 1000 * reserve1 / reserve0 } /
+            1000;
     println!("token0 / token1 price = {}", price);
 
     let liquidity = 100.into();


### PR DESCRIPTION
## Motivation

It would be convenient to be import H128 in other projects that use ethers through a re-export.

## Solution

Re-exports H128 like the other `ethereum-types` types.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
