### PR TITLE
docs: fix Event type not pointing to docs 

### DIFF
--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -18,7 +18,7 @@ mod factory;
 pub use factory::{ContractDeployer, ContractFactory};
 
 mod event;
-pub use event::EthEvent;
+pub use event::{EthEvent, Event};
 
 mod log;
 pub use log::{decode_logs, EthLogDecode, LogMeta};


### PR DESCRIPTION
## Motivation

Addressing the issue #1676

## Solution

The event builder type is part of the [builders mod in lib.rs](https://github.com/gakonst/ethers-rs/blob/a07581489a12b1007c3a261dc8df2bbdc4e27918/ethers-contract/src/lib.rs#L44) which has the `#[doc(hidden)]` attribute. Moving Event into scope generates docs for the Event type and fixes the [dead Event type link](https://docs.rs/ethers-contract/0.17.0/ethers_contract/struct.Contract.html#method.event) under the Contract documentation. 

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [ ] Updated the changelog
