### PR TITLE
add safe and finalized  tag to BlockNumber

### DIFF
--- a/examples/subscribe_logs.rs
+++ b/examples/subscribe_logs.rs
@@ -12,6 +12,9 @@ async fn main() -> Result<()> {
     let last_block = client.get_block(BlockNumber::Latest).await?.unwrap().number.unwrap();
     println!("last_block: {}", last_block);
 
+    let finalized_block = client.get_block(BlockNumber::Finalized).await?.unwrap().number.unwrap();
+    println!("finalized_block: {}", finalized_block);
+
     let erc20_transfer_filter = Filter::new()
         .from_block(last_block - 25)
         .topic0(ValueOrArray::Value(H256::from(keccak256("Transfer(address,address,uint256)"))));

--- a/examples/subscribe_logs.rs
+++ b/examples/subscribe_logs.rs
@@ -12,9 +12,6 @@ async fn main() -> Result<()> {
     let last_block = client.get_block(BlockNumber::Latest).await?.unwrap().number.unwrap();
     println!("last_block: {}", last_block);
 
-    let finalized_block = client.get_block(BlockNumber::Finalized).await?.unwrap().number.unwrap();
-    println!("finalized_block: {}", finalized_block);
-
     let erc20_transfer_filter = Filter::new()
         .from_block(last_block - 25)
         .topic0(ValueOrArray::Value(H256::from(keccak256("Transfer(address,address,uint256)"))));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Add safe and finalized block tagsa to `BlockNumber`

```rust
pub enum BlockNumber {
    /// Latest block
    Latest,
    /// Finalized block accepted as canonical
    Finalized,
    /// Safe head block
    Safe,
    /// Earliest block (genesis)
    Earliest,
    /// Pending block (not yet part of the blockchain)
    Pending,
    /// Block by number from canon chain
    Number(U64),
}

```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [ ] Updated the changelog
