### PR TITLE
fix: get_logs_paginated fetches past latest block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 -   [#1632](https://github.com/gakonst/ethers-rs/pull/1632) Re-export `H32` from `ethabi`.
 -   [#1634](https://github.com/gakonst/ethers-rs/pull/1634) Derive missing `Clone`, `Copy` and `Debug` impls in ethers-etherscan.
 -   Bytes debug format now displays hex literals [#1658](https://github.com/gakonst/ethers-rs/pull/1658)
+-   Fix `get_logs_paginated` trying to fetch beyond the latest block
 
 ## ethers-contract-abigen
 

--- a/ethers-providers/src/log_query.rs
+++ b/ethers-providers/src/log_query.rs
@@ -93,7 +93,7 @@ where
                         // this is okay because we will only enter this state when the filter is
                         // paginatable i.e. from block is set
                         let from_block = self.filter.get_from_block().unwrap();
-                        let to_block = from_block + self.page_size;
+                        let to_block = std::cmp::min(from_block + self.page_size, last_block);
                         self.from_block = Some(to_block + 1);
 
                         let filter = self.filter.clone().from_block(from_block).to_block(to_block);
@@ -122,7 +122,7 @@ where
                         // load new logs if there are still more pages to go through
                         // can safely assume this will always be set in this state
                         let from_block = self.from_block.unwrap();
-                        let to_block = from_block + self.page_size;
+                        let to_block = std::cmp::min(from_block + self.page_size, self.last_block.unwrap());
 
                         // no more pages to load, and everything is consumed
                         // can safely assume this will always be set in this state

--- a/ethers-providers/tests/log_query.rs
+++ b/ethers-providers/tests/log_query.rs
@@ -1,0 +1,21 @@
+#![cfg(not(target_arch = "wasm32"))]
+use ethers_core::{
+    types::{Filter, BlockNumber},
+    utils::Anvil,
+};
+use ethers_providers::{Http, Middleware, Provider, StreamExt};
+use std::convert::TryFrom;
+
+#[tokio::test]
+async fn get_logs_paginated() {
+    let geth = Anvil::new().block_time(20u64).spawn();
+    let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
+
+    let filter = Filter::new().from_block(BlockNumber::Latest);
+    // try to get beyond the number of blocks available
+    let mut stream = provider.get_logs_paginated(&filter, 10);
+    let res = stream.next().await;
+    assert!(res.is_some());
+    let log = res.unwrap();
+    assert!(log.is_ok());
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

`provider.get_logs_paginated` would try to fetch more blocks than are available, because it only considers `page_size` when fetching blocks.

## Solution

Only fetch up to `from_block + page_size` or the last block available, whichever is lower.

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [x] Updated the changelog
