### PR TITLE
fix cargo doc build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## ethers-core
 
 ### Unreleased
-
+-   Fix breaking docs in `ethers-contract::ethers-contract-abigen::filter` [#1821] (https://github.com/gakonst/ethers-rs/pull/1821)
 -   Add comment about safety of u8 -> u64 cast in `ethers_core::types::Signature`
 -   Stop defaulting to the `"latest"` block in `eth_estimateGas` params [#1657](https://github.com/gakonst/ethers-rs/pull/1657)
 -   Fix geth trace types for debug_traceTransaction rpc

--- a/ethers-contract/ethers-contract-abigen/src/filter.rs
+++ b/ethers-contract/ethers-contract-abigen/src/filter.rs
@@ -1,4 +1,4 @@
-//! Filtering support for contracts used in [`Abigen`]
+//! Filtering support for contracts used in [`crate::Abigen`]
 
 use regex::Regex;
 use std::collections::HashSet;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

running `cargo doc --open` previously failed with this error:

```txt
 Documenting ethers-contract-derive v1.0.0 (/home/dev/code/ethers-rs/ethers-contract/ethers-contract-derive)
error: unresolved link to `crate::lib::Abigen`
 --> ethers-contract/ethers-contract-abigen/src/filter.rs:1:47
  |
1 | //! Filtering support for contracts used in [`crate::lib::Abigen`]
  |                                               ^^^^^^^^^^^^^^^^^^ no item named `lib` in module `ethers_contract_abigen`
  |
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

use the proper import path in the breaking file

## PR Checklist

-   [x] Added Tests (NA)
-   [x] Added Documentation
-   [x] Updated the changelog
