### PR TITLE
Impl `IntoFuture` for `ContractCall`

### DIFF
--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -223,8 +223,9 @@ where
 /// Defaults to calling [`ContractCall::call`].
 impl<M, D> IntoFuture for ContractCall<M, D>
 where
-    M: Middleware + 'static,
-    D: Detokenize + 'static,
+    Self: 'static,
+    M: Middleware,
+    D: Detokenize,
 {
     type Output = Result<D, ContractError<M>>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output>>>;

--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -14,7 +14,14 @@ use ethers_providers::{
     Middleware, PendingTransaction, ProviderError,
 };
 
-use std::{borrow::Cow, fmt::Debug, future::Future, marker::PhantomData, sync::Arc};
+use std::{
+    borrow::Cow,
+    fmt::Debug,
+    future::{Future, IntoFuture},
+    marker::PhantomData,
+    pin::Pin,
+    sync::Arc,
+};
 
 use thiserror::Error as ThisError;
 
@@ -209,5 +216,20 @@ where
             .send_transaction(self.tx.clone(), self.block)
             .await
             .map_err(ContractError::MiddlewareError)
+    }
+}
+
+/// [`ContractCall`] can be turned into [`Future`] automatically with `.await`.
+/// Defaults to calling [`ContractCall::call`].
+impl<M, D> IntoFuture for ContractCall<M, D>
+where
+    M: Middleware + 'static,
+    D: Detokenize + 'static,
+{
+    type Output = Result<D, ContractError<M>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output>>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move { self.call().await })
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Continuation of #1797.

## Solution

Implement `IntoFuture` trait for `ContractCall`.
Defaults to calling `ContractCall::call()`.

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [ ] Updated the changelog
