### PR TITLE
Examples event streams

### DIFF
--- a/examples/subscribe_contract_events.rs
+++ b/examples/subscribe_contract_events.rs
@@ -1,0 +1,41 @@
+use ethers::prelude::*;
+use eyre::Result;
+use std::sync::Arc;
+
+// Generate the type-safe contract bindings by providing the ABI
+// definition in human readable format
+abigen!(
+    ERC20,
+    r#"[
+        event  Transfer(address indexed src, address indexed dst, uint wad)
+    ]"#,
+);
+
+// In order to run this example you need to include Ws and TLS features
+// Run this example with `cargo run -p ethers --example subscribe_contract_events --features="ws","rust-ls"`
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Provider::<Ws>::connect( "wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27")
+        .await?;
+
+    let client = Arc::new(client);
+
+    // WETH Token
+    let address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".parse::<Address>()?;
+    let weth = ERC20::new(address, Arc::clone(&client));
+
+    // Subscribe Transfer events
+    let events = weth.events();
+    let mut stream = events.stream().await?;
+
+    while let Some(Ok(event)) = stream.next().await {
+        println!(
+            "src: {:?}, dst: {:?}, wad: {:?}",
+            event.src,
+            event.dst,
+            event.wad
+        );
+    }
+
+    Ok(())
+}

--- a/examples/subscribe_contract_events.rs
+++ b/examples/subscribe_contract_events.rs
@@ -12,11 +12,13 @@ abigen!(
 );
 
 // In order to run this example you need to include Ws and TLS features
-// Run this example with `cargo run -p ethers --example subscribe_contract_events --features="ws","rust-ls"`
+// Run this example with
+// `cargo run -p ethers --example subscribe_contract_events --features="ws","rust-ls"`
 #[tokio::main]
 async fn main() -> Result<()> {
-    let client = Provider::<Ws>::connect( "wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27")
-        .await?;
+    let client =
+        Provider::<Ws>::connect("wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27")
+            .await?;
 
     let client = Arc::new(client);
 
@@ -29,12 +31,7 @@ async fn main() -> Result<()> {
     let mut stream = events.stream().await?;
 
     while let Some(Ok(event)) = stream.next().await {
-        println!(
-            "src: {:?}, dst: {:?}, wad: {:?}",
-            event.src,
-            event.dst,
-            event.wad
-        );
+        println!("src: {:?}, dst: {:?}, wad: {:?}", event.src, event.dst, event.wad);
     }
 
     Ok(())

--- a/examples/subscribe_contract_events_with_meta.rs
+++ b/examples/subscribe_contract_events_with_meta.rs
@@ -12,7 +12,8 @@ abigen!(
 );
 
 // In order to run this example you need to include Ws and TLS features
-// Run this example with `cargo run -p ethers --example subscribe_contract_events_with_meta --features="ws","rust-ls"`
+// Run this example with
+// `cargo run -p ethers --example subscribe_contract_events_with_meta --features="ws","rust-ls"`
 #[tokio::main]
 async fn main() -> Result<()> {
     let client =
@@ -29,12 +30,7 @@ async fn main() -> Result<()> {
     let events = weth.events();
     let mut stream = events.stream().await?.with_meta();
     while let Some(Ok((event, meta))) = stream.next().await {
-        println!(
-            "src: {:?}, dst: {:?}, wad: {:?}",
-            event.src,
-            event.dst,
-            event.wad
-        );
+        println!("src: {:?}, dst: {:?}, wad: {:?}", event.src, event.dst, event.wad);
 
         println!(
             r#"address: {:?}, 

--- a/examples/subscribe_contract_events_with_meta.rs
+++ b/examples/subscribe_contract_events_with_meta.rs
@@ -1,0 +1,57 @@
+use ethers::prelude::*;
+use eyre::Result;
+use std::sync::Arc;
+
+// Generate the type-safe contract bindings by providing the ABI
+// definition in human readable format
+abigen!(
+    ERC20,
+    r#"[
+        event  Transfer(address indexed src, address indexed dst, uint wad)
+    ]"#,
+);
+
+// In order to run this example you need to include Ws and TLS features
+// Run this example with `cargo run -p ethers --example subscribe_contract_events_with_meta --features="ws","rust-ls"`
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client =
+        Provider::<Ws>::connect("wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27")
+            .await?;
+
+    let client = Arc::new(client);
+
+    // WETH Token
+    let address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".parse::<Address>()?;
+    let weth = ERC20::new(address, Arc::clone(&client));
+
+    // Subscribe Transfer events
+    let events = weth.events();
+    let mut stream = events.stream().await?.with_meta();
+    while let Some(Ok((event, meta))) = stream.next().await {
+        println!(
+            "src: {:?}, dst: {:?}, wad: {:?}",
+            event.src,
+            event.dst,
+            event.wad
+        );
+
+        println!(
+            r#"address: {:?}, 
+               block_number: {:?}, 
+               block_hash: {:?}, 
+               transaction_hash: {:?}, 
+               transaction_index: {:?}, 
+               log_index: {:?}
+            "#,
+            meta.address,
+            meta.block_number,
+            meta.block_hash,
+            meta.transaction_hash,
+            meta.transaction_index,
+            meta.log_index
+        );
+    }
+
+    Ok(())
+}

--- a/examples/subscribe_logs.rs
+++ b/examples/subscribe_logs.rs
@@ -2,6 +2,8 @@ use ethers::{abi::AbiDecode, prelude::*, utils::keccak256};
 use eyre::Result;
 use std::sync::Arc;
 
+// In order to run this example you need to include Ws and TLS features
+// Run this example with `cargo run -p ethers --example subscribe_logs --features="ws","rust-ls"`
 #[tokio::main]
 async fn main() -> Result<()> {
     let client =


### PR DESCRIPTION
## Motivation
As a library user I spent sometime to figure out how to manage event streams from `abigen` compiled contracts.
For such reason I added a couple of examples that can help new coming users.

## Solution
Two new examples were added:
1. Stream events from a compiled contract
2. Stream events and log meta from a compiled contract

## PR Checklist

-   [ ] Added Tests
- [x]  Added Documentation
-   [ ] Updated the changelog
