### PR TITLE
fix: generated crate not using generated version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@
 ## ethers-contract-abigen
 
 ### Unreleased
-
+-   Fix Cargo.toml generation issue that could cause dependency conflicts [#1852](https://github.com/gakonst/ethers-rs/pull/1852)
 -   Use corresponding rust structs for event fields if they're solidity structs [#1674](https://github.com/gakonst/ethers-rs/pull/1674)
 -   Add `ContractFilter` to filter contracts in `MultiAbigen` [#1564](https://github.com/gakonst/ethers-rs/pull/1564)
 -   generate error bindings for custom errors [#1549](https://github.com/gakonst/ethers-rs/pull/1549)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,6 +1278,7 @@ dependencies = [
  "serde_json",
  "syn",
  "tempfile",
+ "toml",
  "url",
  "walkdir",
 ]
@@ -4101,9 +4102,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]

--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -29,6 +29,7 @@ dunce = "1.0.2"
 walkdir = "2.3.2"
 eyre = "0.6"
 regex = "1.6.0"
+toml = "0.5.9"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 # NOTE: this enables wasm compatibility for getrandom indirectly

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -596,9 +596,9 @@ impl MultiBindingsInner {
                         return Ok("ethers = {{ git = \"https://github.com/gakonst/ethers-rs\", default-features = false, features = [\"abigen\"] }}".to_string());
                     }
                 } else {
-                    let regex = Regex::new("ethers=\"[^\"]*\"")?;
+                    let regex = Regex::new("\"[^\"]*\"")?;
                     let Some(version) = regex.captures(&parsed) else { eyre::bail!("couldn't parse version regex")};
-                    let res = &version.get(0).unwrap().as_str()[7..];
+                    let res = &version.get(0).unwrap().as_str();
                     return Ok(format!("ethers = {{ version={}, default-features = false, features = [\"abigen\"] }}", res));
                 }
             }

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -576,17 +576,17 @@ impl MultiBindingsInner {
         let file = File::open(cargo_dir)?;
         let reader = BufReader::new(file).lines();
         for line in reader.flatten() {
-            let parsed = line.trim();
+            let parsed: String = line.split_whitespace().collect();
             if parsed.starts_with("ethers") {
-                if parsed.contains("{{") {
+                if parsed.contains('{') {
                     if parsed.contains("git") && parsed.contains("rev") {
                         let regex = Regex::new("rev=\"[^\"]*\"")?;
-                        let Some(rev) = regex.captures(parsed) else { eyre::bail!("couldn't capture revision regex")};
+                        let Some(rev) = regex.captures(&parsed) else { eyre::bail!("couldn't capture revision regex")};
                         let res = rev.get(0).unwrap().as_str();
                         return Ok(format!("ethers = {{ git = \"https://github.com/gakonst/ethers-rs\", {}, default-features = false, features = [\"abigen\"] }}", res));
                     } else if parsed.contains("version") {
                         let regex = Regex::new("version=\"[^\"]*\"")?;
-                        let Some(version) = regex.captures(parsed) else { eyre::bail!("couldn't parse extra args version regex")};
+                        let Some(version) = regex.captures(&parsed) else { eyre::bail!("couldn't parse extra args version regex")};
                         let res = version.get(0).unwrap().as_str();
                         return Ok(format!(
                             "ethers = {{ {}, default-features = false, features = [\"abigen\"] }}",
@@ -597,7 +597,7 @@ impl MultiBindingsInner {
                     }
                 } else {
                     let regex = Regex::new("ethers=\"[^\"]*\"")?;
-                    let Some(version) = regex.captures(parsed) else { eyre::bail!("couldn't parse version regex")};
+                    let Some(version) = regex.captures(&parsed) else { eyre::bail!("couldn't parse version regex")};
                     let res = &version.get(0).unwrap().as_str()[7..];
                     return Ok(format!("ethers = {{ version={}, default-features = false, features = [\"abigen\"] }}", res));
                 }
@@ -1370,7 +1370,7 @@ contract Enum {
                 .ensure_consistent_crate(name, version, mod_root, single_file, true)
                 .expect("Inconsistent bindings");
         });
-        
+
         run_test(|context| {
             let Context { multi_gen, mod_root } = context;
             let tmp = TempProject::dapptools().unwrap();

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -589,7 +589,7 @@ impl MultiBindingsInner {
                         let Some(version) = regex.captures(parsed) else { eyre::bail!("couldn't parse extra args version regex")};
                         let res = version.get(0).unwrap().as_str();
                         return Ok(format!(
-                            "ethers = {{ {} default-features = false, features = [\"abigen\"] }}",
+                            "ethers = {{ {}, default-features = false, features = [\"abigen\"] }}",
                             res
                         ))
                     } else {

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -572,7 +572,7 @@ impl MultiBindingsInner {
 
     /// parses the active Cargo.toml to get what version of ethers we are using
     fn find_crate_version(&self) -> Result<String> {
-        let cargo_dir = env!("CARGO_MANIFEST_DIR");
+        let cargo_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
         let file = File::open(cargo_dir)?;
         let reader = BufReader::new(file).lines();
         for line in reader.flatten() {
@@ -1280,10 +1280,12 @@ contract Enum {
         // gotta bunch these all together as we are overwriting env vars
         run_test(|context| {
             let Context { multi_gen, mod_root } = context;
-            env::set_var(
-                "CARGO_MANIFEST_DIR",
-                r#"
-         [package]
+            let tmp = TempProject::dapptools().unwrap();
+
+            tmp.add_source(
+            "Cargo.toml",
+            r#"
+ [package]
         name = "ethers-contract"
         version = "1.0.0"
         edition = "2018"
@@ -1297,8 +1299,12 @@ contract Enum {
 
         [dependencies]
         ethers-providers = { version = "^1.0.0", path = "../ethers-providers", default-features = false }
-    "#,
-            );
+"#,
+        )
+        .unwrap();
+
+            let _ = tmp.compile().unwrap();
+            env::set_var("CARGO_MANIFEST_DIR", tmp.root());
             let single_file = false;
             let name = "a-name";
             let version = "290.3782.3";
@@ -1320,11 +1326,12 @@ contract Enum {
 
         run_test(|context| {
             let Context { multi_gen, mod_root } = context;
+            let tmp = TempProject::dapptools().unwrap();
 
-            env::set_var(
-                "CARGO_MANIFEST_DIR",
+            tmp.add_source(
+                "Cargo.toml",
                 r#"
-         [package]
+ [package]
         name = "ethers-contract"
         version = "1.0.0"
         edition = "2018"
@@ -1338,8 +1345,12 @@ contract Enum {
 
         [dependencies]
         ethers-contracts = "0.4.0"
-    "#,
-            );
+"#,
+            )
+            .unwrap();
+
+            let _ = tmp.compile().unwrap();
+            env::set_var("CARGO_MANIFEST_DIR", tmp.root());
 
             let single_file = false;
             let name = "a-name";
@@ -1359,14 +1370,15 @@ contract Enum {
                 .ensure_consistent_crate(name, version, mod_root, single_file, true)
                 .expect("Inconsistent bindings");
         });
-
+        
         run_test(|context| {
             let Context { multi_gen, mod_root } = context;
+            let tmp = TempProject::dapptools().unwrap();
 
-            env::set_var(
-                "CARGO_MANIFEST_DIR",
-                r#"
-         [package]
+            tmp.add_source(
+            "Cargo.toml",
+            r#"
+    [package]
         name = "ethers-contract"
         version = "1.0.0"
         edition = "2018"
@@ -1380,8 +1392,12 @@ contract Enum {
 
         [dependencies]
         ethers = {git="https://github.com/gakonst/ethers-rs", rev = "fd8ebf5",features = ["ws", "rustls", "ipc"] }
-    "#,
-            );
+"#,
+        )
+        .unwrap();
+
+            let _ = tmp.compile().unwrap();
+            env::set_var("CARGO_MANIFEST_DIR", tmp.root());
 
             let single_file = false;
             let name = "a-name";
@@ -1404,53 +1420,12 @@ contract Enum {
 
         run_test(|context| {
             let Context { multi_gen, mod_root } = context;
+            let tmp = TempProject::dapptools().unwrap();
 
-            env::set_var(
-                "CARGO_MANIFEST_DIR",
+            tmp.add_source(
+                "Cargo.toml",
                 r#"
-         [package]
-        name = "ethers-contract"
-        version = "1.0.0"
-        edition = "2018"
-        rust-version = "1.62"
-        authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
-        license = "MIT OR Apache-2.0"
-        description = "Smart contract bindings for the ethers-rs crate"
-        homepage = "https://docs.rs/ethers"
-        repository = "https://github.com/gakonst/ethers-rs"
-        keywords = ["ethereum", "web3", "celo", "ethers"]
-
-        [dependencies]
-        ethers = {git="https://github.com/gakonst/ethers-rs", rev = "fd8ebf5",features = ["ws", "rustls", "ipc"] }
-    "#,
-            );
-
-            let single_file = false;
-            let name = "a-name";
-            let version = "290.3782.3";
-
-            multi_gen
-                .clone()
-                .build()
-                .unwrap()
-                .write_to_crate(name, version, mod_root, single_file)
-                .unwrap();
-
-            multi_gen
-                .clone()
-                .build()
-                .unwrap()
-                .ensure_consistent_crate(name, version, mod_root, single_file, true)
-                .expect("Inconsistent bindings");
-        });
-
-        run_test(|context| {
-            let Context { multi_gen, mod_root } = context;
-
-            env::set_var(
-                "CARGO_MANIFEST_DIR",
-                r#"
-         [package]
+    [package]
         name = "ethers-contract"
         version = "1.0.0"
         edition = "2018"
@@ -1464,8 +1439,12 @@ contract Enum {
 
         [dependencies]
         ethers = {git="https://github.com/gakonst/ethers-rs" ,features = ["ws", "rustls", "ipc"] }
-    "#,
-            );
+"#,
+            )
+            .unwrap();
+
+            let _ = tmp.compile().unwrap();
+            env::set_var("CARGO_MANIFEST_DIR", tmp.root());
 
             let single_file = false;
             let name = "a-name";

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -598,7 +598,7 @@ impl MultiBindingsInner {
                 } else {
                     let regex = Regex::new("\"[^\"]*\"")?;
                     let Some(version) = regex.captures(&parsed) else { eyre::bail!("couldn't parse version regex")};
-                    let res = &version.get(0).unwrap().as_str();
+                    let res = version.get(0).unwrap().as_str();
                     return Ok(format!("ethers = {{ version={}, default-features = false, features = [\"abigen\"] }}", res));
                 }
             }

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -576,7 +576,7 @@ impl MultiBindingsInner {
         let toml = data.parse::<Value>()?;
 
         let Some(ethers) = toml.get("dependencies")
-            .or_else(||toml.get("build-dependencies")).and_then (|v| v.get("ethers").or_else(|| v.get("ethers-contract")))
+            .and_then (|v| v.get("ethers").or_else(|| v.get("ethers-contract")))
             else { eyre::bail!("couldn't find ethers or ethers-contract dependency")};
         if let Some(rev) = ethers.get("rev") {
             Ok(format!("ethers = {{ git = \"https://github.com/gakonst/ethers-rs\", rev = {}, default-features = false, features = [\"abigen\"] }}", rev))

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -591,7 +591,7 @@ impl MultiBindingsInner {
                         });
                     res.extend(path);
 
-                    Ok(format!("ethers = {{ version = {}, path = {} default-features = false, features = [\"abigen\"] }}", version, res.to_string_lossy()))
+                    Ok(format!("ethers = {{ version = {}, path = {}, default-features = false, features = [\"abigen\"] }}", version, res.to_string_lossy()))
                 } else {
                     Ok(format!("ethers = {{ version = {}, default-features = false, features = [\"abigen\"] }}", version ))
                 }

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -570,6 +570,7 @@ impl MultiBindingsInner {
         Ok(toml)
     }
 
+    /// parses the active Cargo.toml to get what version of ethers we are using
     fn find_crate_version(&self) -> Result<String> {
         let cargo_dir = env!("CARGO_MANIFEST_DIR");
         let file = File::open(cargo_dir)?;
@@ -577,7 +578,6 @@ impl MultiBindingsInner {
         for line in reader.flatten() {
             let parsed = line.trim();
             if parsed.starts_with("ethers") {
-                // going to be a bit tricker due to cases
                 if parsed.contains("{{") {
                     if parsed.contains("git") && parsed.contains("rev") {
                         let regex = Regex::new("rev=\"[^\"]*\"")?;
@@ -1271,4 +1271,7 @@ contract Enum {
         let content = fs::read_to_string(&mod_).unwrap();
         assert!(content.contains("pub mod mod_ {"));
     }
+
+    #[test]
+    fn parse_ethers_crate_version() {}
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
currently when abigen generates a new crate. it uses the git version of the repo. However this is wrong as if someone set there ethers-rs dep to version 1.0.0, if they generated a crate for bindings. it would be the git version causing a dependency conflict 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
to fix this problem we simply read from the cargo manifest directory and then parse what version the bindings are being generated from and use that over the default hardcoded version

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [x] Updated the changelog
