### PR TITLE
fix: improve overloaded param diff matching

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -1,4 +1,4 @@
-use std::collections::{btree_map::Entry, BTreeMap, HashMap};
+use std::collections::{btree_map::Entry, BTreeMap, HashMap, HashSet};
 
 use super::{types, util, Context};
 use crate::{
@@ -534,11 +534,21 @@ impl Context {
             }
             // compare each overloaded function with the `first_fun`
             for (idx, overloaded_fun) in functions.into_iter().skip(1) {
+                // keep track of matched params
+                let mut already_matched_param_diff = HashSet::new();
                 // attempt to find diff in the input arguments
                 let mut diff = Vec::new();
                 let mut same_params = true;
                 for (idx, i1) in overloaded_fun.inputs.iter().enumerate() {
-                    if first_fun.inputs.iter().all(|i2| i1 != i2) {
+                    // Find the first param that differs and hasn't already been matched as diff
+                    if let Some((pos, _)) = first_fun
+                        .inputs
+                        .iter()
+                        .enumerate()
+                        .filter(|(pos, _)| !already_matched_param_diff.contains(pos))
+                        .find(|(_, i2)| i1 != *i2)
+                    {
+                        already_matched_param_diff.insert(pos);
                         diff.push(i1);
                         same_params = false;
                     } else {

--- a/ethers-contract/tests/it/abigen.rs
+++ b/ethers-contract/tests/it/abigen.rs
@@ -737,3 +737,16 @@ fn can_generate_event_with_structs() {
     assert_eq!("MyEvent((uint256,uint256),uint256)", MyEventFilter::abi_signature());
     assert_event::<MyEventFilter>();
 }
+
+#[test]
+fn can_handle_overloaded_function_with_array() {
+    abigen!(
+        Test,
+        r#"[
+         serializeString(string calldata, string calldata, string calldata) external returns (string memory)
+         serializeString(string calldata, string calldata, string[] calldata) external returns (string memory)
+         serializeBool(string calldata, string calldata, bool) external returns (string memory)
+         serializeBool(string calldata, string calldata, bool[] calldata) external returns (string memory)
+    ]"#,
+    );
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Fixes a bug discovered in foundry CI where params of overloaded functions are not matched correctly.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Keep track of all params already identified as diff when comparing two overloaded functions.
This prevents false positive where (`string`, `string`, `string`) compared to (`string`, `string[]`) resulted in no diffs because we used `iter::all()` as a comparator.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
