### PR TITLE
Add `op` field to `VMOperation` to determine executed opcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+-   Add 'ethers_core::types::OpCode' and use in 'ethers_core::types::VMOperation' [1857](https://github.com/gakonst/ethers-rs/issues/1857)
 -   Remove rust_decimals dependency for ethers-core
 -   Add support for numbers greater than 2^96 for `ethers_core::utils::parse_units` [#1822](https://github.com/gakonst/ethers-rs/issues/1822)
 -   Add comment about safety of u8 -> u64 cast in `ethers_core::types::Signature`

--- a/ethers-core/src/types/trace/example-trace-str.rs
+++ b/ethers-core/src/types/trace/example-trace-str.rs
@@ -43,8 +43,8 @@ r#"{
   "trace": [
     {
       "action": {
-        "callType": "call",
         "from": "0x01f0eb5c4b0a9d8285b67195f5f10ce22971a102",
+        "callType": "call",
         "gas": "0xa5f8",
         "input": "0x1a695230000000000000000000000000c227a75b32ed37d3f9d6341b9904d003dad3b1b3",
         "to": "0x0b95993a39a363d99280ac950f5e4536ab5c5566",
@@ -60,8 +60,8 @@ r#"{
     },
     {
       "action": {
-        "callType": "call",
         "from": "0x0b95993a39a363d99280ac950f5e4536ab5c5566",
+        "callType": "call",
         "gas": "0x8fc",
         "input": "0x",
         "to": "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3",
@@ -92,7 +92,9 @@ r#"{
           "used": 42485
         },
         "pc": 0,
-        "sub": null
+        "sub": null,
+        "op": "PUSH1",
+        "idx": "15-0"
       },
       {
         "cost": 3,
@@ -105,7 +107,9 @@ r#"{
           "used": 42482
         },
         "pc": 2,
-        "sub": null
+        "sub": null,
+        "op": "PUSH1",
+        "idx": "15-1"
       },
       {
         "cost": 12,
@@ -119,7 +123,9 @@ r#"{
           "used": 42470
         },
         "pc": 4,
-        "sub": null
+        "sub": null,
+        "op": "MSTORE",
+        "idx": "15-2"
       },
       {
         "cost": 2,
@@ -132,7 +138,9 @@ r#"{
           "used": 42468
         },
         "pc": 5,
-        "sub": null
+        "sub": null,
+        "op": "CALLDATASIZE",
+        "idx": "15-3"
       },
       {
         "cost": 3,
@@ -145,7 +153,9 @@ r#"{
           "used": 42465
         },
         "pc": 6,
-        "sub": null
+        "sub": null,
+        "op": "ISZERO",
+        "idx": "15-4"
       },
       {
         "cost": 3,
@@ -158,7 +168,9 @@ r#"{
           "used": 42462
         },
         "pc": 7,
-        "sub": null
+        "sub": null,
+        "op": "PUSH2",
+        "idx": "15-5"
       },
       {
         "cost": 10,
@@ -169,7 +181,9 @@ r#"{
           "used": 42452
         },
         "pc": 10,
-        "sub": null
+        "sub": null,
+        "op": "JUMPI",
+        "idx": "15-6"
       },
       {
         "cost": 3,
@@ -182,7 +196,9 @@ r#"{
           "used": 42449
         },
         "pc": 11,
-        "sub": null
+        "sub": null,
+        "op": "PUSH1",
+        "idx": "15-7"
       },
       {
         "cost": 3,
@@ -195,7 +211,9 @@ r#"{
           "used": 42446
         },
         "pc": 13,
-        "sub": null
+        "sub": null,
+        "op": "CALLDATALOAD",
+        "idx": "15-8"
       },
       {
         "cost": 3,
@@ -208,7 +226,9 @@ r#"{
           "used": 42443
         },
         "pc": 14,
-        "sub": null
+        "sub": null,
+        "op": "PUSH29",
+        "idx": "15-9"
       },
       {
         "cost": 3,
@@ -222,7 +242,9 @@ r#"{
           "used": 42440
         },
         "pc": 44,
-        "sub": null
+        "sub": null,
+        "op": "SWAP1",
+        "idx": "15-10"
       },
       {
         "cost": 5,
@@ -235,7 +257,9 @@ r#"{
           "used": 42435
         },
         "pc": 45,
-        "sub": null
+        "sub": null,
+        "op": "DIV",
+        "idx": "15-11"
       },
       {
         "cost": 3,
@@ -248,7 +272,9 @@ r#"{
           "used": 42432
         },
         "pc": 46,
-        "sub": null
+        "sub": null,
+        "op": "PUSH4",
+        "idx": "15-12"
       },
       {
         "cost": 3,
@@ -261,7 +287,9 @@ r#"{
           "used": 42429
         },
         "pc": 51,
-        "sub": null
+        "sub": null,
+        "op": "AND",
+        "idx": "15-13"
       },
       {
         "cost": 3,
@@ -275,7 +303,9 @@ r#"{
           "used": 42426
         },
         "pc": 52,
-        "sub": null
+        "sub": null,
+        "op": "DUP1",
+        "idx": "15-14"
       },
       {
         "cost": 3,
@@ -288,7 +318,9 @@ r#"{
           "used": 42423
         },
         "pc": 53,
-        "sub": null
+        "sub": null,
+        "op": "PUSH4",
+        "idx": "15-15"
       },
       {
         "cost": 3,
@@ -301,7 +333,9 @@ r#"{
           "used": 42420
         },
         "pc": 58,
-        "sub": null
+        "sub": null,
+        "op": "EQ",
+        "idx": "15-16"
       },
       {
         "cost": 3,
@@ -314,7 +348,9 @@ r#"{
           "used": 42417
         },
         "pc": 59,
-        "sub": null
+        "sub": null,
+        "op": "PUSH2",
+        "idx": "15-17"
       },
       {
         "cost": 10,
@@ -325,7 +361,9 @@ r#"{
           "used": 42407
         },
         "pc": 62,
-        "sub": null
+        "sub": null,
+        "op": "JUMPI",
+        "idx": "15-18"
       },
       {
         "cost": 1,
@@ -336,7 +374,9 @@ r#"{
           "used": 42406
         },
         "pc": 94,
-        "sub": null
+        "sub": null,
+        "op": "JUMPDEST",
+        "idx": "15-19"
       },
       {
         "cost": 3,
@@ -349,7 +389,9 @@ r#"{
           "used": 42403
         },
         "pc": 95,
-        "sub": null
+        "sub": null,
+        "op": "PUSH2",
+        "idx": "15-20"
       },
       {
         "cost": 3,
@@ -362,7 +404,9 @@ r#"{
           "used": 42400
         },
         "pc": 98,
-        "sub": null
+        "sub": null,
+        "op": "PUSH1",
+        "idx": "15-21"
       },
       {
         "cost": 3,
@@ -376,7 +420,9 @@ r#"{
           "used": 42397
         },
         "pc": 100,
-        "sub": null
+        "sub": null,
+        "op": "DUP1",
+        "idx": "15-22"
       },
       {
         "cost": 3,
@@ -390,7 +436,9 @@ r#"{
           "used": 42394
         },
         "pc": 101,
-        "sub": null
+        "sub": null,
+        "op": "DUP1",
+        "idx": "15-23"
       },
       {
         "cost": 3,
@@ -403,7 +451,9 @@ r#"{
           "used": 42391
         },
         "pc": 102,
-        "sub": null
+        "sub": null,
+        "op": "CALLDATALOAD",
+        "idx": "15-24"
       },
       {
         "cost": 3,
@@ -416,7 +466,9 @@ r#"{
           "used": 42388
         },
         "pc": 103,
-        "sub": null
+        "sub": null,
+        "op": "PUSH20",
+        "idx": "15-25"
       },
       {
         "cost": 3,
@@ -429,7 +481,9 @@ r#"{
           "used": 42385
         },
         "pc": 124,
-        "sub": null
+        "sub": null,
+        "op": "AND",
+        "idx": "15-26"
       },
       {
         "cost": 3,
@@ -443,7 +497,9 @@ r#"{
           "used": 42382
         },
         "pc": 125,
-        "sub": null
+        "sub": null,
+        "op": "SWAP1",
+        "idx": "15-27"
       },
       {
         "cost": 3,
@@ -456,7 +512,9 @@ r#"{
           "used": 42379
         },
         "pc": 126,
-        "sub": null
+        "sub": null,
+        "op": "PUSH1",
+        "idx": "15-28"
       },
       {
         "cost": 3,
@@ -469,7 +527,9 @@ r#"{
           "used": 42376
         },
         "pc": 128,
-        "sub": null
+        "sub": null,
+        "op": "ADD",
+        "idx": "15-29"
       },
       {
         "cost": 3,
@@ -483,7 +543,9 @@ r#"{
           "used": 42373
         },
         "pc": 129,
-        "sub": null
+        "sub": null,
+        "op": "SWAP1",
+        "idx": "15-30"
       },
       {
         "cost": 3,
@@ -498,7 +560,9 @@ r#"{
           "used": 42370
         },
         "pc": 130,
-        "sub": null
+        "sub": null,
+        "op": "SWAP2",
+        "idx": "15-31"
       },
       {
         "cost": 3,
@@ -512,7 +576,9 @@ r#"{
           "used": 42367
         },
         "pc": 131,
-        "sub": null
+        "sub": null,
+        "op": "SWAP1",
+        "idx": "15-32"
       },
       {
         "cost": 2,
@@ -523,7 +589,9 @@ r#"{
           "used": 42365
         },
         "pc": 132,
-        "sub": null
+        "sub": null,
+        "op": "POP",
+        "idx": "15-33"
       },
       {
         "cost": 2,
@@ -534,7 +602,9 @@ r#"{
           "used": 42363
         },
         "pc": 133,
-        "sub": null
+        "sub": null,
+        "op": "POP",
+        "idx": "15-34"
       },
       {
         "cost": 3,
@@ -547,7 +617,9 @@ r#"{
           "used": 42360
         },
         "pc": 134,
-        "sub": null
+        "sub": null,
+        "op": "PUSH2",
+        "idx": "15-35"
       },
       {
         "cost": 8,
@@ -558,7 +630,9 @@ r#"{
           "used": 42352
         },
         "pc": 137,
-        "sub": null
+        "sub": null,
+        "op": "JUMP",
+        "idx": "15-36"
       },
       {
         "cost": 1,
@@ -569,7 +643,9 @@ r#"{
           "used": 42351
         },
         "pc": 246,
-        "sub": null
+        "sub": null,
+        "op": "JUMPDEST",
+        "idx": "15-37"
       },
       {
         "cost": 3,
@@ -583,7 +659,9 @@ r#"{
           "used": 42348
         },
         "pc": 247,
-        "sub": null
+        "sub": null,
+        "op": "DUP1",
+        "idx": "15-38"
       },
       {
         "cost": 3,
@@ -596,7 +674,9 @@ r#"{
           "used": 42345
         },
         "pc": 248,
-        "sub": null
+        "sub": null,
+        "op": "PUSH20",
+        "idx": "15-39"
       },
       {
         "cost": 3,
@@ -609,7 +689,9 @@ r#"{
           "used": 42342
         },
         "pc": 269,
-        "sub": null
+        "sub": null,
+        "op": "AND",
+        "idx": "15-40"
       },
       {
         "cost": 3,
@@ -622,7 +704,9 @@ r#"{
           "used": 42339
         },
         "pc": 270,
-        "sub": null
+        "sub": null,
+        "op": "PUSH2",
+        "idx": "15-41"
       },
       {
         "cost": 2,
@@ -635,7 +719,9 @@ r#"{
           "used": 42337
         },
         "pc": 273,
-        "sub": null
+        "sub": null,
+        "op": "CALLVALUE",
+        "idx": "15-42"
       },
       {
         "cost": 3,
@@ -649,7 +735,9 @@ r#"{
           "used": 42334
         },
         "pc": 274,
-        "sub": null
+        "sub": null,
+        "op": "SWAP1",
+        "idx": "15-43"
       },
       {
         "cost": 3,
@@ -664,7 +752,9 @@ r#"{
           "used": 42331
         },
         "pc": 275,
-        "sub": null
+        "sub": null,
+        "op": "DUP2",
+        "idx": "15-44"
       },
       {
         "cost": 3,
@@ -677,7 +767,9 @@ r#"{
           "used": 42328
         },
         "pc": 276,
-        "sub": null
+        "sub": null,
+        "op": "ISZERO",
+        "idx": "15-45"
       },
       {
         "cost": 5,
@@ -690,7 +782,9 @@ r#"{
           "used": 42323
         },
         "pc": 277,
-        "sub": null
+        "sub": null,
+        "op": "MUL",
+        "idx": "15-46"
       },
       {
         "cost": 3,
@@ -704,7 +798,9 @@ r#"{
           "used": 42320
         },
         "pc": 278,
-        "sub": null
+        "sub": null,
+        "op": "SWAP1",
+        "idx": "15-47"
       },
       {
         "cost": 3,
@@ -717,7 +813,9 @@ r#"{
           "used": 42317
         },
         "pc": 279,
-        "sub": null
+        "sub": null,
+        "op": "PUSH1",
+        "idx": "15-48"
       },
       {
         "cost": 3,
@@ -733,7 +831,9 @@ r#"{
           "used": 42314
         },
         "pc": 281,
-        "sub": null
+        "sub": null,
+        "op": "MLOAD",
+        "idx": "15-49"
       },
       {
         "cost": 3,
@@ -746,7 +846,9 @@ r#"{
           "used": 42311
         },
         "pc": 282,
-        "sub": null
+        "sub": null,
+        "op": "PUSH1",
+        "idx": "15-50"
       },
       {
         "cost": 3,
@@ -759,7 +861,9 @@ r#"{
           "used": 42308
         },
         "pc": 284,
-        "sub": null
+        "sub": null,
+        "op": "PUSH1",
+        "idx": "15-51"
       },
       {
         "cost": 3,
@@ -775,7 +879,9 @@ r#"{
           "used": 42305
         },
         "pc": 286,
-        "sub": null
+        "sub": null,
+        "op": "MLOAD",
+        "idx": "15-52"
       },
       {
         "cost": 3,
@@ -789,7 +895,9 @@ r#"{
           "used": 42302
         },
         "pc": 287,
-        "sub": null
+        "sub": null,
+        "op": "DUP1",
+        "idx": "15-53"
       },
       {
         "cost": 3,
@@ -806,7 +914,9 @@ r#"{
           "used": 42299
         },
         "pc": 288,
-        "sub": null
+        "sub": null,
+        "op": "DUP4",
+        "idx": "15-54"
       },
       {
         "cost": 3,
@@ -819,7 +929,9 @@ r#"{
           "used": 42296
         },
         "pc": 289,
-        "sub": null
+        "sub": null,
+        "op": "SUB",
+        "idx": "15-55"
       },
       {
         "cost": 3,
@@ -834,7 +946,9 @@ r#"{
           "used": 42293
         },
         "pc": 290,
-        "sub": null
+        "sub": null,
+        "op": "DUP2",
+        "idx": "15-56"
       },
       {
         "cost": 3,
@@ -853,7 +967,9 @@ r#"{
           "used": 42290
         },
         "pc": 291,
-        "sub": null
+        "sub": null,
+        "op": "DUP6",
+        "idx": "15-57"
       },
       {
         "cost": 3,
@@ -875,7 +991,9 @@ r#"{
           "used": 42287
         },
         "pc": 292,
-        "sub": null
+        "sub": null,
+        "op": "DUP9",
+        "idx": "15-58"
       },
       {
         "cost": 3,
@@ -897,7 +1015,9 @@ r#"{
           "used": 42284
         },
         "pc": 293,
-        "sub": null
+        "sub": null,
+        "op": "DUP9",
+        "idx": "15-59"
       },
       {
         "cost": 9700,
@@ -913,7 +1033,9 @@ r#"{
         "sub": {
           "code": "0x",
           "ops": []
-        }
+        },
+        "op": "CALL",
+        "idx": "15-60"
       },
       {
         "cost": 3,
@@ -930,7 +1052,9 @@ r#"{
           "used": 34881
         },
         "pc": 295,
-        "sub": null
+        "sub": null,
+        "op": "SWAP4",
+        "idx": "15-61"
       },
       {
         "cost": 2,
@@ -941,7 +1065,9 @@ r#"{
           "used": 34879
         },
         "pc": 296,
-        "sub": null
+        "sub": null,
+        "op": "POP",
+        "idx": "15-62"
       },
       {
         "cost": 2,
@@ -952,7 +1078,9 @@ r#"{
           "used": 34877
         },
         "pc": 297,
-        "sub": null
+        "sub": null,
+        "op": "POP",
+        "idx": "15-63"
       },
       {
         "cost": 2,
@@ -963,7 +1091,9 @@ r#"{
           "used": 34875
         },
         "pc": 298,
-        "sub": null
+        "sub": null,
+        "op": "POP",
+        "idx": "15-64"
       },
       {
         "cost": 2,
@@ -974,7 +1104,9 @@ r#"{
           "used": 34873
         },
         "pc": 299,
-        "sub": null
+        "sub": null,
+        "op": "POP",
+        "idx": "15-65"
       },
       {
         "cost": 3,
@@ -987,7 +1119,9 @@ r#"{
           "used": 34870
         },
         "pc": 300,
-        "sub": null
+        "sub": null,
+        "op": "ISZERO",
+        "idx": "15-66"
       },
       {
         "cost": 3,
@@ -1000,7 +1134,9 @@ r#"{
           "used": 34867
         },
         "pc": 301,
-        "sub": null
+        "sub": null,
+        "op": "ISZERO",
+        "idx": "15-67"
       },
       {
         "cost": 3,
@@ -1013,7 +1149,9 @@ r#"{
           "used": 34864
         },
         "pc": 302,
-        "sub": null
+        "sub": null,
+        "op": "PUSH2",
+        "idx": "15-68"
       },
       {
         "cost": 10,
@@ -1024,7 +1162,9 @@ r#"{
           "used": 34854
         },
         "pc": 305,
-        "sub": null
+        "sub": null,
+        "op": "JUMPI",
+        "idx": "15-69"
       },
       {
         "cost": 1,
@@ -1035,7 +1175,9 @@ r#"{
           "used": 34853
         },
         "pc": 310,
-        "sub": null
+        "sub": null,
+        "op": "JUMPDEST",
+        "idx": "15-70"
       },
       {
         "cost": 1,
@@ -1046,7 +1188,9 @@ r#"{
           "used": 34852
         },
         "pc": 311,
-        "sub": null
+        "sub": null,
+        "op": "JUMPDEST",
+        "idx": "15-71"
       },
       {
         "cost": 2,
@@ -1057,7 +1201,9 @@ r#"{
           "used": 34850
         },
         "pc": 312,
-        "sub": null
+        "sub": null,
+        "op": "POP",
+        "idx": "15-72"
       },
       {
         "cost": 8,
@@ -1068,7 +1214,9 @@ r#"{
           "used": 34842
         },
         "pc": 313,
-        "sub": null
+        "sub": null,
+        "op": "JUMP",
+        "idx": "15-73"
       },
       {
         "cost": 1,
@@ -1079,7 +1227,9 @@ r#"{
           "used": 34841
         },
         "pc": 138,
-        "sub": null
+        "sub": null,
+        "op": "JUMPDEST",
+        "idx": "15-74"
       },
       {
         "cost": 0,
@@ -1090,7 +1240,9 @@ r#"{
           "used": 34841
         },
         "pc": 139,
-        "sub": null
+        "sub": null,
+        "op": "STOP",
+        "idx": "15-75"
       }
     ]
   }

--- a/ethers-core/src/types/trace/example-trace-str.rs
+++ b/ethers-core/src/types/trace/example-trace-str.rs
@@ -1,1249 +1,1249 @@
 r#"{
-  "output": "0x",
-  "stateDiff": {
-    "0x01f0eb5c4b0a9d8285b67195f5f10ce22971a102": {
-      "balance": {
-        "*": {
-          "from": "0x7361af5818297800",
-          "to": "0x734a36bb22448000"
+    "output": "0x",
+    "stateDiff": {
+        "0x01f0eb5c4b0a9d8285b67195f5f10ce22971a102": {
+            "balance": {
+                "*": {
+                    "from": "0x7361af5818297800",
+                    "to": "0x734a36bb22448000"
+                }
+            },
+            "code": "=",
+            "nonce": {
+                "*": {
+                    "from": "0x1d6",
+                    "to": "0x1d7"
+                }
+            },
+            "storage": {}
+        },
+        "0xb2930b35844a230f00e51431acae96fe543a0347": {
+            "balance": {
+                "*": {
+                    "from": "0x11b39d46046d14d44e5",
+                    "to": "0x11b39d687ebea8b3ce5"
+                }
+            },
+            "code": "=",
+            "nonce": "=",
+            "storage": {}
+        },
+        "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3": {
+            "balance": {
+                "*": {
+                    "from": "0x109397d7f6f000",
+                    "to": "0x25e48fb49df000"
+                }
+            },
+            "code": "=",
+            "nonce": "=",
+            "storage": {}
         }
-      },
-      "code": "=",
-      "nonce": {
-        "*": {
-          "from": "0x1d6",
-          "to": "0x1d7"
-        }
-      },
-      "storage": {}
     },
-    "0xb2930b35844a230f00e51431acae96fe543a0347": {
-      "balance": {
-        "*": {
-          "from": "0x11b39d46046d14d44e5",
-          "to": "0x11b39d687ebea8b3ce5"
+    "trace": [
+        {
+            "action": {
+                "from": "0x01f0eb5c4b0a9d8285b67195f5f10ce22971a102",
+                "callType": "call",
+                "gas": "0xa5f8",
+                "input": "0x1a695230000000000000000000000000c227a75b32ed37d3f9d6341b9904d003dad3b1b3",
+                "to": "0x0b95993a39a363d99280ac950f5e4536ab5c5566",
+                "value": "0x1550f7dca70000"
+            },
+            "result": {
+                "gasUsed": "0x1ddf",
+                "output": "0x"
+            },
+            "subtraces": 1,
+            "traceAddress": [],
+            "type": "call"
+        },
+        {
+            "action": {
+                "from": "0x0b95993a39a363d99280ac950f5e4536ab5c5566",
+                "callType": "call",
+                "gas": "0x8fc",
+                "input": "0x",
+                "to": "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3",
+                "value": "0x1550f7dca70000"
+            },
+            "result": {
+                "gasUsed": "0x0",
+                "output": "0x"
+            },
+            "subtraces": 0,
+            "traceAddress": [
+                0
+            ],
+            "type": "call"
         }
-      },
-      "code": "=",
-      "nonce": "=",
-      "storage": {}
-    },
-    "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3": {
-      "balance": {
-        "*": {
-          "from": "0x109397d7f6f000",
-          "to": "0x25e48fb49df000"
-        }
-      },
-      "code": "=",
-      "nonce": "=",
-      "storage": {}
+    ],
+    "vmTrace": {
+        "code": "0x60606040523615610055576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680631a6952301461005e5780637362377b1461008c5780638da5cb5b146100a1575b61005c5b5b565b005b61008a600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919050506100f6565b005b341561009757600080fd5b61009f61013a565b005b34156100ac57600080fd5b6100b4610210565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b8073ffffffffffffffffffffffffffffffffffffffff166108fc349081150290604051600060405180830381858888f19350505050151561013657600080fd5b5b50565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614151561019557600080fd5b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166108fc3073ffffffffffffffffffffffffffffffffffffffff16319081150290604051600060405180830381858888f19350505050151561020d57600080fd5b5b565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff16815600a165627a7a7230582029eabe8a624d811f3ea09c310d65be79ddefa23e3b702541dc1687b475f091690029",
+        "ops": [
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x60"
+                    ],
+                    "store": null,
+                    "used": 42485
+                },
+                "pc": 0,
+                "sub": null,
+                "op": "PUSH1",
+                "idx": "15-0"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x40"
+                    ],
+                    "store": null,
+                    "used": 42482
+                },
+                "pc": 2,
+                "sub": null,
+                "op": "PUSH1",
+                "idx": "15-1"
+            },
+            {
+                "cost": 12,
+                "ex": {
+                    "mem": {
+                        "data": "0x0000000000000000000000000000000000000000000000000000000000000060",
+                        "off": 64
+                    },
+                    "push": [],
+                    "store": null,
+                    "used": 42470
+                },
+                "pc": 4,
+                "sub": null,
+                "op": "MSTORE",
+                "idx": "15-2"
+            },
+            {
+                "cost": 2,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x24"
+                    ],
+                    "store": null,
+                    "used": 42468
+                },
+                "pc": 5,
+                "sub": null,
+                "op": "CALLDATASIZE",
+                "idx": "15-3"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x0"
+                    ],
+                    "store": null,
+                    "used": 42465
+                },
+                "pc": 6,
+                "sub": null,
+                "op": "ISZERO",
+                "idx": "15-4"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x55"
+                    ],
+                    "store": null,
+                    "used": 42462
+                },
+                "pc": 7,
+                "sub": null,
+                "op": "PUSH2",
+                "idx": "15-5"
+            },
+            {
+                "cost": 10,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 42452
+                },
+                "pc": 10,
+                "sub": null,
+                "op": "JUMPI",
+                "idx": "15-6"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x0"
+                    ],
+                    "store": null,
+                    "used": 42449
+                },
+                "pc": 11,
+                "sub": null,
+                "op": "PUSH1",
+                "idx": "15-7"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x1a695230000000000000000000000000c227a75b32ed37d3f9d6341b9904d003"
+                    ],
+                    "store": null,
+                    "used": 42446
+                },
+                "pc": 13,
+                "sub": null,
+                "op": "CALLDATALOAD",
+                "idx": "15-8"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x100000000000000000000000000000000000000000000000000000000"
+                    ],
+                    "store": null,
+                    "used": 42443
+                },
+                "pc": 14,
+                "sub": null,
+                "op": "PUSH29",
+                "idx": "15-9"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x100000000000000000000000000000000000000000000000000000000",
+                        "0x1a695230000000000000000000000000c227a75b32ed37d3f9d6341b9904d003"
+                    ],
+                    "store": null,
+                    "used": 42440
+                },
+                "pc": 44,
+                "sub": null,
+                "op": "SWAP1",
+                "idx": "15-10"
+            },
+            {
+                "cost": 5,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x1a695230"
+                    ],
+                    "store": null,
+                    "used": 42435
+                },
+                "pc": 45,
+                "sub": null,
+                "op": "DIV",
+                "idx": "15-11"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0xffffffff"
+                    ],
+                    "store": null,
+                    "used": 42432
+                },
+                "pc": 46,
+                "sub": null,
+                "op": "PUSH4",
+                "idx": "15-12"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x1a695230"
+                    ],
+                    "store": null,
+                    "used": 42429
+                },
+                "pc": 51,
+                "sub": null,
+                "op": "AND",
+                "idx": "15-13"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x1a695230",
+                        "0x1a695230"
+                    ],
+                    "store": null,
+                    "used": 42426
+                },
+                "pc": 52,
+                "sub": null,
+                "op": "DUP1",
+                "idx": "15-14"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x1a695230"
+                    ],
+                    "store": null,
+                    "used": 42423
+                },
+                "pc": 53,
+                "sub": null,
+                "op": "PUSH4",
+                "idx": "15-15"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x1"
+                    ],
+                    "store": null,
+                    "used": 42420
+                },
+                "pc": 58,
+                "sub": null,
+                "op": "EQ",
+                "idx": "15-16"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x5e"
+                    ],
+                    "store": null,
+                    "used": 42417
+                },
+                "pc": 59,
+                "sub": null,
+                "op": "PUSH2",
+                "idx": "15-17"
+            },
+            {
+                "cost": 10,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 42407
+                },
+                "pc": 62,
+                "sub": null,
+                "op": "JUMPI",
+                "idx": "15-18"
+            },
+            {
+                "cost": 1,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 42406
+                },
+                "pc": 94,
+                "sub": null,
+                "op": "JUMPDEST",
+                "idx": "15-19"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x8a"
+                    ],
+                    "store": null,
+                    "used": 42403
+                },
+                "pc": 95,
+                "sub": null,
+                "op": "PUSH2",
+                "idx": "15-20"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x4"
+                    ],
+                    "store": null,
+                    "used": 42400
+                },
+                "pc": 98,
+                "sub": null,
+                "op": "PUSH1",
+                "idx": "15-21"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x4",
+                        "0x4"
+                    ],
+                    "store": null,
+                    "used": 42397
+                },
+                "pc": 100,
+                "sub": null,
+                "op": "DUP1",
+                "idx": "15-22"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x4",
+                        "0x4"
+                    ],
+                    "store": null,
+                    "used": 42394
+                },
+                "pc": 101,
+                "sub": null,
+                "op": "DUP1",
+                "idx": "15-23"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
+                    ],
+                    "store": null,
+                    "used": 42391
+                },
+                "pc": 102,
+                "sub": null,
+                "op": "CALLDATALOAD",
+                "idx": "15-24"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0xffffffffffffffffffffffffffffffffffffffff"
+                    ],
+                    "store": null,
+                    "used": 42388
+                },
+                "pc": 103,
+                "sub": null,
+                "op": "PUSH20",
+                "idx": "15-25"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
+                    ],
+                    "store": null,
+                    "used": 42385
+                },
+                "pc": 124,
+                "sub": null,
+                "op": "AND",
+                "idx": "15-26"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3",
+                        "0x4"
+                    ],
+                    "store": null,
+                    "used": 42382
+                },
+                "pc": 125,
+                "sub": null,
+                "op": "SWAP1",
+                "idx": "15-27"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x20"
+                    ],
+                    "store": null,
+                    "used": 42379
+                },
+                "pc": 126,
+                "sub": null,
+                "op": "PUSH1",
+                "idx": "15-28"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x24"
+                    ],
+                    "store": null,
+                    "used": 42376
+                },
+                "pc": 128,
+                "sub": null,
+                "op": "ADD",
+                "idx": "15-29"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x24",
+                        "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
+                    ],
+                    "store": null,
+                    "used": 42373
+                },
+                "pc": 129,
+                "sub": null,
+                "op": "SWAP1",
+                "idx": "15-30"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3",
+                        "0x24",
+                        "0x4"
+                    ],
+                    "store": null,
+                    "used": 42370
+                },
+                "pc": 130,
+                "sub": null,
+                "op": "SWAP2",
+                "idx": "15-31"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x4",
+                        "0x24"
+                    ],
+                    "store": null,
+                    "used": 42367
+                },
+                "pc": 131,
+                "sub": null,
+                "op": "SWAP1",
+                "idx": "15-32"
+            },
+            {
+                "cost": 2,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 42365
+                },
+                "pc": 132,
+                "sub": null,
+                "op": "POP",
+                "idx": "15-33"
+            },
+            {
+                "cost": 2,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 42363
+                },
+                "pc": 133,
+                "sub": null,
+                "op": "POP",
+                "idx": "15-34"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0xf6"
+                    ],
+                    "store": null,
+                    "used": 42360
+                },
+                "pc": 134,
+                "sub": null,
+                "op": "PUSH2",
+                "idx": "15-35"
+            },
+            {
+                "cost": 8,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 42352
+                },
+                "pc": 137,
+                "sub": null,
+                "op": "JUMP",
+                "idx": "15-36"
+            },
+            {
+                "cost": 1,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 42351
+                },
+                "pc": 246,
+                "sub": null,
+                "op": "JUMPDEST",
+                "idx": "15-37"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3",
+                        "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
+                    ],
+                    "store": null,
+                    "used": 42348
+                },
+                "pc": 247,
+                "sub": null,
+                "op": "DUP1",
+                "idx": "15-38"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0xffffffffffffffffffffffffffffffffffffffff"
+                    ],
+                    "store": null,
+                    "used": 42345
+                },
+                "pc": 248,
+                "sub": null,
+                "op": "PUSH20",
+                "idx": "15-39"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
+                    ],
+                    "store": null,
+                    "used": 42342
+                },
+                "pc": 269,
+                "sub": null,
+                "op": "AND",
+                "idx": "15-40"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x8fc"
+                    ],
+                    "store": null,
+                    "used": 42339
+                },
+                "pc": 270,
+                "sub": null,
+                "op": "PUSH2",
+                "idx": "15-41"
+            },
+            {
+                "cost": 2,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x1550f7dca70000"
+                    ],
+                    "store": null,
+                    "used": 42337
+                },
+                "pc": 273,
+                "sub": null,
+                "op": "CALLVALUE",
+                "idx": "15-42"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x1550f7dca70000",
+                        "0x8fc"
+                    ],
+                    "store": null,
+                    "used": 42334
+                },
+                "pc": 274,
+                "sub": null,
+                "op": "SWAP1",
+                "idx": "15-43"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x1550f7dca70000",
+                        "0x8fc",
+                        "0x1550f7dca70000"
+                    ],
+                    "store": null,
+                    "used": 42331
+                },
+                "pc": 275,
+                "sub": null,
+                "op": "DUP2",
+                "idx": "15-44"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x0"
+                    ],
+                    "store": null,
+                    "used": 42328
+                },
+                "pc": 276,
+                "sub": null,
+                "op": "ISZERO",
+                "idx": "15-45"
+            },
+            {
+                "cost": 5,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x0"
+                    ],
+                    "store": null,
+                    "used": 42323
+                },
+                "pc": 277,
+                "sub": null,
+                "op": "MUL",
+                "idx": "15-46"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x0",
+                        "0x1550f7dca70000"
+                    ],
+                    "store": null,
+                    "used": 42320
+                },
+                "pc": 278,
+                "sub": null,
+                "op": "SWAP1",
+                "idx": "15-47"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x40"
+                    ],
+                    "store": null,
+                    "used": 42317
+                },
+                "pc": 279,
+                "sub": null,
+                "op": "PUSH1",
+                "idx": "15-48"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": {
+                        "data": "0x0000000000000000000000000000000000000000000000000000000000000060",
+                        "off": 64
+                    },
+                    "push": [
+                        "0x60"
+                    ],
+                    "store": null,
+                    "used": 42314
+                },
+                "pc": 281,
+                "sub": null,
+                "op": "MLOAD",
+                "idx": "15-49"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x0"
+                    ],
+                    "store": null,
+                    "used": 42311
+                },
+                "pc": 282,
+                "sub": null,
+                "op": "PUSH1",
+                "idx": "15-50"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x40"
+                    ],
+                    "store": null,
+                    "used": 42308
+                },
+                "pc": 284,
+                "sub": null,
+                "op": "PUSH1",
+                "idx": "15-51"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": {
+                        "data": "0x0000000000000000000000000000000000000000000000000000000000000060",
+                        "off": 64
+                    },
+                    "push": [
+                        "0x60"
+                    ],
+                    "store": null,
+                    "used": 42305
+                },
+                "pc": 286,
+                "sub": null,
+                "op": "MLOAD",
+                "idx": "15-52"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x60",
+                        "0x60"
+                    ],
+                    "store": null,
+                    "used": 42302
+                },
+                "pc": 287,
+                "sub": null,
+                "op": "DUP1",
+                "idx": "15-53"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x60",
+                        "0x0",
+                        "0x60",
+                        "0x60",
+                        "0x60"
+                    ],
+                    "store": null,
+                    "used": 42299
+                },
+                "pc": 288,
+                "sub": null,
+                "op": "DUP4",
+                "idx": "15-54"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x0"
+                    ],
+                    "store": null,
+                    "used": 42296
+                },
+                "pc": 289,
+                "sub": null,
+                "op": "SUB",
+                "idx": "15-55"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x60",
+                        "0x0",
+                        "0x60"
+                    ],
+                    "store": null,
+                    "used": 42293
+                },
+                "pc": 290,
+                "sub": null,
+                "op": "DUP2",
+                "idx": "15-56"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x1550f7dca70000",
+                        "0x60",
+                        "0x0",
+                        "0x60",
+                        "0x0",
+                        "0x60",
+                        "0x1550f7dca70000"
+                    ],
+                    "store": null,
+                    "used": 42290
+                },
+                "pc": 291,
+                "sub": null,
+                "op": "DUP6",
+                "idx": "15-57"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3",
+                        "0x0",
+                        "0x1550f7dca70000",
+                        "0x60",
+                        "0x0",
+                        "0x60",
+                        "0x0",
+                        "0x60",
+                        "0x1550f7dca70000",
+                        "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
+                    ],
+                    "store": null,
+                    "used": 42287
+                },
+                "pc": 292,
+                "sub": null,
+                "op": "DUP9",
+                "idx": "15-58"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x0",
+                        "0x1550f7dca70000",
+                        "0x60",
+                        "0x0",
+                        "0x60",
+                        "0x0",
+                        "0x60",
+                        "0x1550f7dca70000",
+                        "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3",
+                        "0x0"
+                    ],
+                    "store": null,
+                    "used": 42284
+                },
+                "pc": 293,
+                "sub": null,
+                "op": "DUP9",
+                "idx": "15-59"
+            },
+            {
+                "cost": 9700,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x1"
+                    ],
+                    "store": null,
+                    "used": 34884
+                },
+                "pc": 294,
+                "sub": {
+                    "code": "0x",
+                    "ops": []
+                },
+                "op": "CALL",
+                "idx": "15-60"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x1",
+                        "0x0",
+                        "0x1550f7dca70000",
+                        "0x60",
+                        "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
+                    ],
+                    "store": null,
+                    "used": 34881
+                },
+                "pc": 295,
+                "sub": null,
+                "op": "SWAP4",
+                "idx": "15-61"
+            },
+            {
+                "cost": 2,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 34879
+                },
+                "pc": 296,
+                "sub": null,
+                "op": "POP",
+                "idx": "15-62"
+            },
+            {
+                "cost": 2,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 34877
+                },
+                "pc": 297,
+                "sub": null,
+                "op": "POP",
+                "idx": "15-63"
+            },
+            {
+                "cost": 2,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 34875
+                },
+                "pc": 298,
+                "sub": null,
+                "op": "POP",
+                "idx": "15-64"
+            },
+            {
+                "cost": 2,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 34873
+                },
+                "pc": 299,
+                "sub": null,
+                "op": "POP",
+                "idx": "15-65"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x0"
+                    ],
+                    "store": null,
+                    "used": 34870
+                },
+                "pc": 300,
+                "sub": null,
+                "op": "ISZERO",
+                "idx": "15-66"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x1"
+                    ],
+                    "store": null,
+                    "used": 34867
+                },
+                "pc": 301,
+                "sub": null,
+                "op": "ISZERO",
+                "idx": "15-67"
+            },
+            {
+                "cost": 3,
+                "ex": {
+                    "mem": null,
+                    "push": [
+                        "0x136"
+                    ],
+                    "store": null,
+                    "used": 34864
+                },
+                "pc": 302,
+                "sub": null,
+                "op": "PUSH2",
+                "idx": "15-68"
+            },
+            {
+                "cost": 10,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 34854
+                },
+                "pc": 305,
+                "sub": null,
+                "op": "JUMPI",
+                "idx": "15-69"
+            },
+            {
+                "cost": 1,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 34853
+                },
+                "pc": 310,
+                "sub": null,
+                "op": "JUMPDEST",
+                "idx": "15-70"
+            },
+            {
+                "cost": 1,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 34852
+                },
+                "pc": 311,
+                "sub": null,
+                "op": "JUMPDEST",
+                "idx": "15-71"
+            },
+            {
+                "cost": 2,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 34850
+                },
+                "pc": 312,
+                "sub": null,
+                "op": "POP",
+                "idx": "15-72"
+            },
+            {
+                "cost": 8,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 34842
+                },
+                "pc": 313,
+                "sub": null,
+                "op": "JUMP",
+                "idx": "15-73"
+            },
+            {
+                "cost": 1,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 34841
+                },
+                "pc": 138,
+                "sub": null,
+                "op": "JUMPDEST",
+                "idx": "15-74"
+            },
+            {
+                "cost": 0,
+                "ex": {
+                    "mem": null,
+                    "push": [],
+                    "store": null,
+                    "used": 34841
+                },
+                "pc": 139,
+                "sub": null,
+                "op": "STOP",
+                "idx": "15-75"
+            }
+        ]
     }
-  },
-  "trace": [
-    {
-      "action": {
-        "from": "0x01f0eb5c4b0a9d8285b67195f5f10ce22971a102",
-        "callType": "call",
-        "gas": "0xa5f8",
-        "input": "0x1a695230000000000000000000000000c227a75b32ed37d3f9d6341b9904d003dad3b1b3",
-        "to": "0x0b95993a39a363d99280ac950f5e4536ab5c5566",
-        "value": "0x1550f7dca70000"
-      },
-      "result": {
-        "gasUsed": "0x1ddf",
-        "output": "0x"
-      },
-      "subtraces": 1,
-      "traceAddress": [],
-      "type": "call"
-    },
-    {
-      "action": {
-        "from": "0x0b95993a39a363d99280ac950f5e4536ab5c5566",
-        "callType": "call",
-        "gas": "0x8fc",
-        "input": "0x",
-        "to": "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3",
-        "value": "0x1550f7dca70000"
-      },
-      "result": {
-        "gasUsed": "0x0",
-        "output": "0x"
-      },
-      "subtraces": 0,
-      "traceAddress": [
-        0
-      ],
-      "type": "call"
-    }
-  ],
-  "vmTrace": {
-    "code": "0x60606040523615610055576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680631a6952301461005e5780637362377b1461008c5780638da5cb5b146100a1575b61005c5b5b565b005b61008a600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919050506100f6565b005b341561009757600080fd5b61009f61013a565b005b34156100ac57600080fd5b6100b4610210565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b8073ffffffffffffffffffffffffffffffffffffffff166108fc349081150290604051600060405180830381858888f19350505050151561013657600080fd5b5b50565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614151561019557600080fd5b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff166108fc3073ffffffffffffffffffffffffffffffffffffffff16319081150290604051600060405180830381858888f19350505050151561020d57600080fd5b5b565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff16815600a165627a7a7230582029eabe8a624d811f3ea09c310d65be79ddefa23e3b702541dc1687b475f091690029",
-    "ops": [
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x60"
-          ],
-          "store": null,
-          "used": 42485
-        },
-        "pc": 0,
-        "sub": null,
-        "op": "PUSH1",
-        "idx": "15-0"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x40"
-          ],
-          "store": null,
-          "used": 42482
-        },
-        "pc": 2,
-        "sub": null,
-        "op": "PUSH1",
-        "idx": "15-1"
-      },
-      {
-        "cost": 12,
-        "ex": {
-          "mem": {
-            "data": "0x0000000000000000000000000000000000000000000000000000000000000060",
-            "off": 64
-          },
-          "push": [],
-          "store": null,
-          "used": 42470
-        },
-        "pc": 4,
-        "sub": null,
-        "op": "MSTORE",
-        "idx": "15-2"
-      },
-      {
-        "cost": 2,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x24"
-          ],
-          "store": null,
-          "used": 42468
-        },
-        "pc": 5,
-        "sub": null,
-        "op": "CALLDATASIZE",
-        "idx": "15-3"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x0"
-          ],
-          "store": null,
-          "used": 42465
-        },
-        "pc": 6,
-        "sub": null,
-        "op": "ISZERO",
-        "idx": "15-4"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x55"
-          ],
-          "store": null,
-          "used": 42462
-        },
-        "pc": 7,
-        "sub": null,
-        "op": "PUSH2",
-        "idx": "15-5"
-      },
-      {
-        "cost": 10,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 42452
-        },
-        "pc": 10,
-        "sub": null,
-        "op": "JUMPI",
-        "idx": "15-6"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x0"
-          ],
-          "store": null,
-          "used": 42449
-        },
-        "pc": 11,
-        "sub": null,
-        "op": "PUSH1",
-        "idx": "15-7"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x1a695230000000000000000000000000c227a75b32ed37d3f9d6341b9904d003"
-          ],
-          "store": null,
-          "used": 42446
-        },
-        "pc": 13,
-        "sub": null,
-        "op": "CALLDATALOAD",
-        "idx": "15-8"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x100000000000000000000000000000000000000000000000000000000"
-          ],
-          "store": null,
-          "used": 42443
-        },
-        "pc": 14,
-        "sub": null,
-        "op": "PUSH29",
-        "idx": "15-9"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x100000000000000000000000000000000000000000000000000000000",
-            "0x1a695230000000000000000000000000c227a75b32ed37d3f9d6341b9904d003"
-          ],
-          "store": null,
-          "used": 42440
-        },
-        "pc": 44,
-        "sub": null,
-        "op": "SWAP1",
-        "idx": "15-10"
-      },
-      {
-        "cost": 5,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x1a695230"
-          ],
-          "store": null,
-          "used": 42435
-        },
-        "pc": 45,
-        "sub": null,
-        "op": "DIV",
-        "idx": "15-11"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0xffffffff"
-          ],
-          "store": null,
-          "used": 42432
-        },
-        "pc": 46,
-        "sub": null,
-        "op": "PUSH4",
-        "idx": "15-12"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x1a695230"
-          ],
-          "store": null,
-          "used": 42429
-        },
-        "pc": 51,
-        "sub": null,
-        "op": "AND",
-        "idx": "15-13"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x1a695230",
-            "0x1a695230"
-          ],
-          "store": null,
-          "used": 42426
-        },
-        "pc": 52,
-        "sub": null,
-        "op": "DUP1",
-        "idx": "15-14"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x1a695230"
-          ],
-          "store": null,
-          "used": 42423
-        },
-        "pc": 53,
-        "sub": null,
-        "op": "PUSH4",
-        "idx": "15-15"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x1"
-          ],
-          "store": null,
-          "used": 42420
-        },
-        "pc": 58,
-        "sub": null,
-        "op": "EQ",
-        "idx": "15-16"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x5e"
-          ],
-          "store": null,
-          "used": 42417
-        },
-        "pc": 59,
-        "sub": null,
-        "op": "PUSH2",
-        "idx": "15-17"
-      },
-      {
-        "cost": 10,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 42407
-        },
-        "pc": 62,
-        "sub": null,
-        "op": "JUMPI",
-        "idx": "15-18"
-      },
-      {
-        "cost": 1,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 42406
-        },
-        "pc": 94,
-        "sub": null,
-        "op": "JUMPDEST",
-        "idx": "15-19"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x8a"
-          ],
-          "store": null,
-          "used": 42403
-        },
-        "pc": 95,
-        "sub": null,
-        "op": "PUSH2",
-        "idx": "15-20"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x4"
-          ],
-          "store": null,
-          "used": 42400
-        },
-        "pc": 98,
-        "sub": null,
-        "op": "PUSH1",
-        "idx": "15-21"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x4",
-            "0x4"
-          ],
-          "store": null,
-          "used": 42397
-        },
-        "pc": 100,
-        "sub": null,
-        "op": "DUP1",
-        "idx": "15-22"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x4",
-            "0x4"
-          ],
-          "store": null,
-          "used": 42394
-        },
-        "pc": 101,
-        "sub": null,
-        "op": "DUP1",
-        "idx": "15-23"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
-          ],
-          "store": null,
-          "used": 42391
-        },
-        "pc": 102,
-        "sub": null,
-        "op": "CALLDATALOAD",
-        "idx": "15-24"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0xffffffffffffffffffffffffffffffffffffffff"
-          ],
-          "store": null,
-          "used": 42388
-        },
-        "pc": 103,
-        "sub": null,
-        "op": "PUSH20",
-        "idx": "15-25"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
-          ],
-          "store": null,
-          "used": 42385
-        },
-        "pc": 124,
-        "sub": null,
-        "op": "AND",
-        "idx": "15-26"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3",
-            "0x4"
-          ],
-          "store": null,
-          "used": 42382
-        },
-        "pc": 125,
-        "sub": null,
-        "op": "SWAP1",
-        "idx": "15-27"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x20"
-          ],
-          "store": null,
-          "used": 42379
-        },
-        "pc": 126,
-        "sub": null,
-        "op": "PUSH1",
-        "idx": "15-28"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x24"
-          ],
-          "store": null,
-          "used": 42376
-        },
-        "pc": 128,
-        "sub": null,
-        "op": "ADD",
-        "idx": "15-29"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x24",
-            "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
-          ],
-          "store": null,
-          "used": 42373
-        },
-        "pc": 129,
-        "sub": null,
-        "op": "SWAP1",
-        "idx": "15-30"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3",
-            "0x24",
-            "0x4"
-          ],
-          "store": null,
-          "used": 42370
-        },
-        "pc": 130,
-        "sub": null,
-        "op": "SWAP2",
-        "idx": "15-31"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x4",
-            "0x24"
-          ],
-          "store": null,
-          "used": 42367
-        },
-        "pc": 131,
-        "sub": null,
-        "op": "SWAP1",
-        "idx": "15-32"
-      },
-      {
-        "cost": 2,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 42365
-        },
-        "pc": 132,
-        "sub": null,
-        "op": "POP",
-        "idx": "15-33"
-      },
-      {
-        "cost": 2,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 42363
-        },
-        "pc": 133,
-        "sub": null,
-        "op": "POP",
-        "idx": "15-34"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0xf6"
-          ],
-          "store": null,
-          "used": 42360
-        },
-        "pc": 134,
-        "sub": null,
-        "op": "PUSH2",
-        "idx": "15-35"
-      },
-      {
-        "cost": 8,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 42352
-        },
-        "pc": 137,
-        "sub": null,
-        "op": "JUMP",
-        "idx": "15-36"
-      },
-      {
-        "cost": 1,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 42351
-        },
-        "pc": 246,
-        "sub": null,
-        "op": "JUMPDEST",
-        "idx": "15-37"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3",
-            "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
-          ],
-          "store": null,
-          "used": 42348
-        },
-        "pc": 247,
-        "sub": null,
-        "op": "DUP1",
-        "idx": "15-38"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0xffffffffffffffffffffffffffffffffffffffff"
-          ],
-          "store": null,
-          "used": 42345
-        },
-        "pc": 248,
-        "sub": null,
-        "op": "PUSH20",
-        "idx": "15-39"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
-          ],
-          "store": null,
-          "used": 42342
-        },
-        "pc": 269,
-        "sub": null,
-        "op": "AND",
-        "idx": "15-40"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x8fc"
-          ],
-          "store": null,
-          "used": 42339
-        },
-        "pc": 270,
-        "sub": null,
-        "op": "PUSH2",
-        "idx": "15-41"
-      },
-      {
-        "cost": 2,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x1550f7dca70000"
-          ],
-          "store": null,
-          "used": 42337
-        },
-        "pc": 273,
-        "sub": null,
-        "op": "CALLVALUE",
-        "idx": "15-42"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x1550f7dca70000",
-            "0x8fc"
-          ],
-          "store": null,
-          "used": 42334
-        },
-        "pc": 274,
-        "sub": null,
-        "op": "SWAP1",
-        "idx": "15-43"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x1550f7dca70000",
-            "0x8fc",
-            "0x1550f7dca70000"
-          ],
-          "store": null,
-          "used": 42331
-        },
-        "pc": 275,
-        "sub": null,
-        "op": "DUP2",
-        "idx": "15-44"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x0"
-          ],
-          "store": null,
-          "used": 42328
-        },
-        "pc": 276,
-        "sub": null,
-        "op": "ISZERO",
-        "idx": "15-45"
-      },
-      {
-        "cost": 5,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x0"
-          ],
-          "store": null,
-          "used": 42323
-        },
-        "pc": 277,
-        "sub": null,
-        "op": "MUL",
-        "idx": "15-46"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x0",
-            "0x1550f7dca70000"
-          ],
-          "store": null,
-          "used": 42320
-        },
-        "pc": 278,
-        "sub": null,
-        "op": "SWAP1",
-        "idx": "15-47"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x40"
-          ],
-          "store": null,
-          "used": 42317
-        },
-        "pc": 279,
-        "sub": null,
-        "op": "PUSH1",
-        "idx": "15-48"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": {
-            "data": "0x0000000000000000000000000000000000000000000000000000000000000060",
-            "off": 64
-          },
-          "push": [
-            "0x60"
-          ],
-          "store": null,
-          "used": 42314
-        },
-        "pc": 281,
-        "sub": null,
-        "op": "MLOAD",
-        "idx": "15-49"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x0"
-          ],
-          "store": null,
-          "used": 42311
-        },
-        "pc": 282,
-        "sub": null,
-        "op": "PUSH1",
-        "idx": "15-50"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x40"
-          ],
-          "store": null,
-          "used": 42308
-        },
-        "pc": 284,
-        "sub": null,
-        "op": "PUSH1",
-        "idx": "15-51"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": {
-            "data": "0x0000000000000000000000000000000000000000000000000000000000000060",
-            "off": 64
-          },
-          "push": [
-            "0x60"
-          ],
-          "store": null,
-          "used": 42305
-        },
-        "pc": 286,
-        "sub": null,
-        "op": "MLOAD",
-        "idx": "15-52"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x60",
-            "0x60"
-          ],
-          "store": null,
-          "used": 42302
-        },
-        "pc": 287,
-        "sub": null,
-        "op": "DUP1",
-        "idx": "15-53"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x60",
-            "0x0",
-            "0x60",
-            "0x60",
-            "0x60"
-          ],
-          "store": null,
-          "used": 42299
-        },
-        "pc": 288,
-        "sub": null,
-        "op": "DUP4",
-        "idx": "15-54"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x0"
-          ],
-          "store": null,
-          "used": 42296
-        },
-        "pc": 289,
-        "sub": null,
-        "op": "SUB",
-        "idx": "15-55"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x60",
-            "0x0",
-            "0x60"
-          ],
-          "store": null,
-          "used": 42293
-        },
-        "pc": 290,
-        "sub": null,
-        "op": "DUP2",
-        "idx": "15-56"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x1550f7dca70000",
-            "0x60",
-            "0x0",
-            "0x60",
-            "0x0",
-            "0x60",
-            "0x1550f7dca70000"
-          ],
-          "store": null,
-          "used": 42290
-        },
-        "pc": 291,
-        "sub": null,
-        "op": "DUP6",
-        "idx": "15-57"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3",
-            "0x0",
-            "0x1550f7dca70000",
-            "0x60",
-            "0x0",
-            "0x60",
-            "0x0",
-            "0x60",
-            "0x1550f7dca70000",
-            "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
-          ],
-          "store": null,
-          "used": 42287
-        },
-        "pc": 292,
-        "sub": null,
-        "op": "DUP9",
-        "idx": "15-58"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x0",
-            "0x1550f7dca70000",
-            "0x60",
-            "0x0",
-            "0x60",
-            "0x0",
-            "0x60",
-            "0x1550f7dca70000",
-            "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3",
-            "0x0"
-          ],
-          "store": null,
-          "used": 42284
-        },
-        "pc": 293,
-        "sub": null,
-        "op": "DUP9",
-        "idx": "15-59"
-      },
-      {
-        "cost": 9700,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x1"
-          ],
-          "store": null,
-          "used": 34884
-        },
-        "pc": 294,
-        "sub": {
-          "code": "0x",
-          "ops": []
-        },
-        "op": "CALL",
-        "idx": "15-60"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x1",
-            "0x0",
-            "0x1550f7dca70000",
-            "0x60",
-            "0xc227a75b32ed37d3f9d6341b9904d003dad3b1b3"
-          ],
-          "store": null,
-          "used": 34881
-        },
-        "pc": 295,
-        "sub": null,
-        "op": "SWAP4",
-        "idx": "15-61"
-      },
-      {
-        "cost": 2,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 34879
-        },
-        "pc": 296,
-        "sub": null,
-        "op": "POP",
-        "idx": "15-62"
-      },
-      {
-        "cost": 2,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 34877
-        },
-        "pc": 297,
-        "sub": null,
-        "op": "POP",
-        "idx": "15-63"
-      },
-      {
-        "cost": 2,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 34875
-        },
-        "pc": 298,
-        "sub": null,
-        "op": "POP",
-        "idx": "15-64"
-      },
-      {
-        "cost": 2,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 34873
-        },
-        "pc": 299,
-        "sub": null,
-        "op": "POP",
-        "idx": "15-65"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x0"
-          ],
-          "store": null,
-          "used": 34870
-        },
-        "pc": 300,
-        "sub": null,
-        "op": "ISZERO",
-        "idx": "15-66"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x1"
-          ],
-          "store": null,
-          "used": 34867
-        },
-        "pc": 301,
-        "sub": null,
-        "op": "ISZERO",
-        "idx": "15-67"
-      },
-      {
-        "cost": 3,
-        "ex": {
-          "mem": null,
-          "push": [
-            "0x136"
-          ],
-          "store": null,
-          "used": 34864
-        },
-        "pc": 302,
-        "sub": null,
-        "op": "PUSH2",
-        "idx": "15-68"
-      },
-      {
-        "cost": 10,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 34854
-        },
-        "pc": 305,
-        "sub": null,
-        "op": "JUMPI",
-        "idx": "15-69"
-      },
-      {
-        "cost": 1,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 34853
-        },
-        "pc": 310,
-        "sub": null,
-        "op": "JUMPDEST",
-        "idx": "15-70"
-      },
-      {
-        "cost": 1,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 34852
-        },
-        "pc": 311,
-        "sub": null,
-        "op": "JUMPDEST",
-        "idx": "15-71"
-      },
-      {
-        "cost": 2,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 34850
-        },
-        "pc": 312,
-        "sub": null,
-        "op": "POP",
-        "idx": "15-72"
-      },
-      {
-        "cost": 8,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 34842
-        },
-        "pc": 313,
-        "sub": null,
-        "op": "JUMP",
-        "idx": "15-73"
-      },
-      {
-        "cost": 1,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 34841
-        },
-        "pc": 138,
-        "sub": null,
-        "op": "JUMPDEST",
-        "idx": "15-74"
-      },
-      {
-        "cost": 0,
-        "ex": {
-          "mem": null,
-          "push": [],
-          "store": null,
-          "used": 34841
-        },
-        "pc": 139,
-        "sub": null,
-        "op": "STOP",
-        "idx": "15-75"
-      }
-    ]
-  }
 }"#

--- a/ethers-core/src/types/trace/example-traces-str.rs
+++ b/ethers-core/src/types/trace/example-traces-str.rs
@@ -1,68 +1,69 @@
 r#"[{
   "output": "0x",
   "stateDiff": {
-	"0x5df9b87991262f6ba471f09758cde1c0fc1de734": {
-	  "balance": {
-		"+": "0x7a69"
-	  },
-	  "code": {
-		"+": "0x"
-	  },
-	  "nonce": {
-		"+": "0x0"
-	  },
-	  "storage": {}
-	},
-	"0xa1e4380a3b1f749673e270229993ee55f35663b4": {
-	  "balance": {
-		"*": {
-		  "from": "0x6c6b935b8bbd400000",
-		  "to": "0x6c5d01021be7168597"
-		}
-	  },
-	  "code": "=",
-	  "nonce": {
-		"*": {
-		  "from": "0x0",
-		  "to": "0x1"
-		}
-	  },
-	  "storage": {}
-	},
-	"0xe6a7a1d47ff21b6321162aea7c6cb457d5476bca": {
-	  "balance": {
-		"*": {
-		  "from": "0xf3426785a8ab466000",
-		  "to": "0xf350f9df18816f6000"
-		}
-	  },
-	  "code": "=",
-	  "nonce": "=",
-	  "storage": {}
-	}
+    "0x5df9b87991262f6ba471f09758cde1c0fc1de734": {
+      "balance": {
+        "+": "0x7a69"
+      },
+      "code": {
+        "+": "0x"
+      },
+      "nonce": {
+        "+": "0x0"
+      },
+      "storage": {}
+    },
+    "0xa1e4380a3b1f749673e270229993ee55f35663b4": {
+      "balance": {
+        "*": {
+          "from": "0x6c6b935b8bbd400000",
+          "to": "0x6c5d01021be7168597"
+        }
+      },
+      "code": "=",
+      "nonce": {
+        "*": {
+          "from": "0x0",
+          "to": "0x1"
+        }
+      },
+      "storage": {}
+    },
+    "0xe6a7a1d47ff21b6321162aea7c6cb457d5476bca": {
+      "balance": {
+        "*": {
+          "from": "0xf3426785a8ab466000",
+          "to": "0xf350f9df18816f6000"
+        }
+      },
+      "code": "=",
+      "nonce": "=",
+      "storage": {}
+    }
   },
   "trace": [
-	{
-	  "action": {
-		"callType": "call",
-		"from": "0xa1e4380a3b1f749673e270229993ee55f35663b4",
-		"gas": "0x0",
-		"input": "0x",
-		"to": "0x5df9b87991262f6ba471f09758cde1c0fc1de734",
-		"value": "0x7a69"
-	  },
-	  "result": {
-		"gasUsed": "0x0",
-		"output": "0x"
-	  },
-	  "subtraces": 0,
-	  "traceAddress": [],
-	  "type": "call"
-	}
+    {
+      "action": {
+        "from": "0xa1e4380a3b1f749673e270229993ee55f35663b4",
+        "callType": "call",
+        "gas": "0x0",
+        "input": "0x",
+        "to": "0x5df9b87991262f6ba471f09758cde1c0fc1de734",
+        "value": "0x7a69"
+      },
+      "result": {
+        "gasUsed": "0x0",
+        "output": "0x"
+      },
+      "subtraces": 0,
+      "traceAddress": [],
+      "type": "call"
+    }
   ],
-  "transactionHash": "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060",
   "vmTrace": {
-	"code": "0x",
-	"ops": []
-  }
-}]"#
+    "code": "0x",
+    "ops": []
+  },
+  "transactionHash": "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060"
+}
+  ]"#

--- a/ethers-core/src/types/trace/example-traces-str.rs
+++ b/ethers-core/src/types/trace/example-traces-str.rs
@@ -1,69 +1,68 @@
 r#"[{
   "output": "0x",
   "stateDiff": {
-    "0x5df9b87991262f6ba471f09758cde1c0fc1de734": {
-      "balance": {
-        "+": "0x7a69"
-      },
-      "code": {
-        "+": "0x"
-      },
-      "nonce": {
-        "+": "0x0"
-      },
-      "storage": {}
-    },
-    "0xa1e4380a3b1f749673e270229993ee55f35663b4": {
-      "balance": {
-        "*": {
-          "from": "0x6c6b935b8bbd400000",
-          "to": "0x6c5d01021be7168597"
-        }
-      },
-      "code": "=",
-      "nonce": {
-        "*": {
-          "from": "0x0",
-          "to": "0x1"
-        }
-      },
-      "storage": {}
-    },
-    "0xe6a7a1d47ff21b6321162aea7c6cb457d5476bca": {
-      "balance": {
-        "*": {
-          "from": "0xf3426785a8ab466000",
-          "to": "0xf350f9df18816f6000"
-        }
-      },
-      "code": "=",
-      "nonce": "=",
-      "storage": {}
-    }
+	"0x5df9b87991262f6ba471f09758cde1c0fc1de734": {
+	  "balance": {
+		"+": "0x7a69"
+	  },
+	  "code": {
+		"+": "0x"
+	  },
+	  "nonce": {
+		"+": "0x0"
+	  },
+	  "storage": {}
+	},
+	"0xa1e4380a3b1f749673e270229993ee55f35663b4": {
+	  "balance": {
+		"*": {
+		  "from": "0x6c6b935b8bbd400000",
+		  "to": "0x6c5d01021be7168597"
+		}
+	  },
+	  "code": "=",
+	  "nonce": {
+		"*": {
+		  "from": "0x0",
+		  "to": "0x1"
+		}
+	  },
+	  "storage": {}
+	},
+	"0xe6a7a1d47ff21b6321162aea7c6cb457d5476bca": {
+	  "balance": {
+		"*": {
+		  "from": "0xf3426785a8ab466000",
+		  "to": "0xf350f9df18816f6000"
+		}
+	  },
+	  "code": "=",
+	  "nonce": "=",
+	  "storage": {}
+	}
   },
   "trace": [
-    {
-      "action": {
-        "from": "0xa1e4380a3b1f749673e270229993ee55f35663b4",
-        "callType": "call",
-        "gas": "0x0",
-        "input": "0x",
-        "to": "0x5df9b87991262f6ba471f09758cde1c0fc1de734",
-        "value": "0x7a69"
-      },
-      "result": {
-        "gasUsed": "0x0",
-        "output": "0x"
-      },
-      "subtraces": 0,
-      "traceAddress": [],
-      "type": "call"
-    }
+	{
+	  "action": {
+		"callType": "call",
+		"from": "0xa1e4380a3b1f749673e270229993ee55f35663b4",
+		"gas": "0x0",
+		"input": "0x",
+		"to": "0x5df9b87991262f6ba471f09758cde1c0fc1de734",
+		"value": "0x7a69"
+	  },
+	  "result": {
+		"gasUsed": "0x0",
+		"output": "0x"
+	  },
+	  "subtraces": 0,
+	  "traceAddress": [],
+	  "type": "call"
+	}
   ],
+  "transactionHash": "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060",
   "vmTrace": {
-    "code": "0x",
-    "ops": []
-  },
-  "transactionHash": "0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060"
-}
-  ]"#
+	"code": "0x",
+	"ops": []
+  }
+}]"#

--- a/ethers-core/src/types/trace/mod.rs
+++ b/ethers-core/src/types/trace/mod.rs
@@ -11,6 +11,9 @@ pub use filter::*;
 mod geth;
 pub use geth::*;
 
+mod opcodes;
+pub use opcodes::*;
+
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 /// Description of the type of trace to make
 pub enum TraceType {
@@ -131,6 +134,9 @@ pub struct VMOperation {
     /// Subordinate trace of the CALL/CREATE if applicable.
     // #[serde(bound="VMTrace: Deserialize")]
     pub sub: Option<VMTrace>,
+    /// The executed opcode name
+    #[serde(rename = "op")]
+    pub op: OpCode,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize, Serialize)]

--- a/ethers-core/src/types/trace/opcodes.rs
+++ b/ethers-core/src/types/trace/opcodes.rs
@@ -67,7 +67,7 @@ pub enum OpCode {
 
     // 0x20 range - crypto.
     /// Opcode 0x20 - Compute Keccak-256 hash
-    KECCAK256,
+    SHA3,
 
     // 0x21 - 0x2F are invalid
 

--- a/ethers-core/src/types/trace/opcodes.rs
+++ b/ethers-core/src/types/trace/opcodes.rs
@@ -1,194 +1,343 @@
 use serde::{Deserialize, Serialize};
 
+// opcode descriptions taken from evm.codes https://github.com/comitylabs/evm.codes/blob/bc7f102808055d88365559d40c190c5bd6d164c3/opcodes.json
 // https://github.com/ethereum/go-ethereum/blob/2b1299b1c006077c56ecbad32e79fc16febe3dd6/core/vm/opcodes.go
 #[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize, Serialize)]
+/// Name of executed EVM opcode
 pub enum OpCode {
     // 0x0 range - arithmetic ops.
-    STOP,       // 0x0
-    ADD,        // 0x1
-    MUL,        // 0x2
-    SUB,        // 0x3
-    DIV,        // 0x4
-    SDIV,       // 0x5
-    MOD,        // 0x6
-    SMOD,       // 0x7
-    ADDMOD,     // 0x8
-    MULMOD,     // 0x9
-    EXP,        // 0xA
-    SIGNEXTEND, // 0xB
+    /// Opcode 0x0 - Halts execution
+    STOP,
+    /// Opcode 0x1 - Addition operation
+    ADD,
+    /// Opcode 0x2 - Multiplication operation
+    MUL,
+    /// Opcode 0x3 - Subtraction operation
+    SUB,
+    /// Opcode 0x4 - Integer division operation
+    DIV,
+    /// Opcode 0x5 - Signed integer division operation (truncated)
+    SDIV,
+    /// Opcode 0x6 - Modulo remainder operation
+    MOD,
+    /// Opcode 0x7 - Signed modulo remainder operation
+    SMOD,
+    /// Opcode 0x8 - Modulo addition operation
+    ADDMOD,
+    /// Opcode 0x9 - Modulo multiplication operation
+    MULMOD,
+    /// Opcode 0xA - Exponential operation
+    EXP,
+    /// Opcode 0xB - Extend length of two’s complement signed integer
+    SIGNEXTEND,
 
     // 0x0C - 0x0F are invalid
 
     // 0x10 range - comparison ops.
-    LT,     // 0x10
-    GT,     // 0x11
-    SLT,    // 0x12
-    SGT,    // 0x13
-    EQ,     // 0x14
-    ISZERO, // 0x15
-    AND,    // 0x16
-    OR,     // 0x17
-    XOR,    // 0x18
-    NOT,    // 0x19
-    BYTE,   // 0x1A
-    SHL,    // 0x1B
-    SHR,    // 0x1C
-    SAR,    // 0x1D
+    /// Opcode 0x10 - Less-than comparison
+    LT,
+    /// Opcode 0x11 - Greater-than comparison
+    GT,
+    /// Opcode 0x12 - Signed less-than comparison
+    SLT,
+    /// Opcode 0x13 - Signed greater-than comparison
+    SGT,
+    /// Opcode 0x14 - Equality comparison
+    EQ,
+    /// Opcode 0x15 - Simple not operator
+    ISZERO,
+    /// Opcode 0x16 - Bitwise AND operation
+    AND,
+    /// Opcode 0x17 - Bitwise OR operation
+    OR,
+    /// Opcode 0x18 - Bitwise XOR operation
+    XOR,
+    /// Opcode 0x19 - Bitwise NOT operation
+    NOT,
+    /// Opcode 0x1A - Retrieve single byte from word
+    BYTE,
+    /// Opcode 0x1B - Left shift operation
+    SHL,
+    /// Opcode 0x1C - Logical right shift operation
+    SHR,
+    /// Opcode 0x1D - Arithmetic (signed) right shift operation
+    SAR,
 
     // 0x1E - 0x1F are invalid
 
     // 0x20 range - crypto.
-    KECCAK256, // 0x20
+    /// Opcode 0x20 - Compute Keccak-256 hash
+    KECCAK256,
 
     // 0x21 - 0x2F are invalid
 
     // 0x30 range - closure state.
-    ADDRESS,        // 0x30
-    BALANCE,        // 0x31
-    ORIGIN,         // 0x32
-    CALLER,         // 0x33
-    CALLVALUE,      // 0x34
-    CALLDATALOAD,   // 0x35
-    CALLDATASIZE,   // 0x36
-    CALLDATACOPY,   // 0x37
-    CODESIZE,       // 0x38
-    CODECOPY,       // 0x39
-    GASPRICE,       // 0x3A
-    EXTCODESIZE,    // 0x3B
-    EXTCODECOPY,    // 0x3C
-    RETURNDATASIZE, // 0x3D
-    RETURNDATACOPY, // 0x3E
-    EXTCODEHASH,    // 0x3F
+    /// Opcode 0x30 - Get address of currently executing account
+    ADDRESS,
+    /// Opcode 0x31 - Get address of currently executing account
+    BALANCE,
+    /// Opcode 0x32 - Get execution origination address
+    ORIGIN,
+    /// Opcode 0x33 - Get caller address
+    CALLER,
+    /// Opcode 0x34 - Get deposited value by the instruction/transaction responsible for this
+    /// execution
+    CALLVALUE,
+    /// Opcode 0x35 - Get input data of current environment
+    CALLDATALOAD,
+    /// Opcode 0x36 - Get size of input data in current environment
+    CALLDATASIZE,
+    /// Opcode 0x37 - Copy input data in current environment to memory
+    CALLDATACOPY,
+    /// Opcode 0x38 - Get size of code running in current environment
+    CODESIZE,
+    /// Opcode 0x39 - Copy code running in current environment to memory
+    CODECOPY,
+    /// Opcode 0x3A - Get price of gas in current environment
+    GASPRICE,
+    /// Opcode 0x3B - Get size of an account’s code
+    EXTCODESIZE,
+    /// Opcode 0x3C - Copy an account’s code to memory
+    EXTCODECOPY,
+    /// Opcode 0x3D - Get size of output data from the previous call from the current environment
+    RETURNDATASIZE,
+    /// Opcode 0x3E - Copy output data from the previous call to memory
+    RETURNDATACOPY,
+    /// Opcode 0x3F - Get hash of an account’s code
+    EXTCODEHASH,
 
     // 0x40 range - block operations.
-    BLOCKHASH,  // 0x40
-    COINBASE,   // 0x41
-    TIMESTAMP,  // 0x42
-    NUMBER,     // 0x43
-    DIFFICULTY, // 0x44
+    /// Opcode 0x40 - Get the hash of one of the 256 most recent complete blocks
+    BLOCKHASH,
+    /// Opcode 0x41 - Get the block’s beneficiary address
+    COINBASE,
+    /// Opcode 0x42 - Get the block’s timestamp
+    TIMESTAMP,
+    /// Opcode 0x43 - Get the block’s number
+    NUMBER,
+    /// Opcode 0x44 - Get the block’s difficulty
+    DIFFICULTY,
     //RANDOM,      // 0x44 // Same as DIFFICULTY
     //PREVRANDAO,  // 0x44 // Same as DIFFICULTY
-    GASLIMIT,    // 0x45
-    CHAINID,     // 0x46
-    SELFBALANCE, // 0x47
-    BASEFEE,     // 0x48
+    /// Opcode 0x45 - Get the block’s gas limit
+    GASLIMIT,
+    /// Opcode 0x46 - Get the chain ID
+    CHAINID,
+    /// Opcode 0x47 - Get balance of currently executing account
+    SELFBALANCE,
+    /// Opcode 0x48 - Get the base fee
+    BASEFEE,
 
     // 0x49 - 0x4F are invalid
 
     // 0x50 range - 'storage' and execution.
-    POP,      // 0x50
-    MLOAD,    // 0x51
-    MSTORE,   // 0x52
-    MSTORE8,  // 0x53
-    SLOAD,    // 0x54
-    SSTORE,   // 0x55
-    JUMP,     // 0x56
-    JUMPI,    // 0x57
-    PC,       // 0x58
-    MSIZE,    // 0x59
-    GAS,      // 0x5A
-    JUMPDEST, // 0x5B
+    /// Opcode 0x50 - Remove item from stack
+    POP,
+    /// Opcode 0x51 - Load word from memory
+    MLOAD,
+    /// Opcode 0x52 - Save word to memory
+    MSTORE,
+    /// Opcode 0x53 - Save byte to memory
+    MSTORE8,
+    /// Opcode 0x54 - Load word from storage
+    SLOAD,
+    /// Opcode 0x55 - Save word to storage
+    SSTORE,
+    /// Opcode 0x56 - Alter the program counter
+    JUMP,
+    /// Opcode 0x57 - Conditionally alter the program counter
+    JUMPI,
+    /// Opcode 0x58 - Get the value of the program counter prior to the increment corresponding to
+    /// this instruction
+    PC,
+    /// Opcode 0x59 - Get the size of active memory in bytes
+    MSIZE,
+    /// Opcode 0x5A - Get the amount of available gas, including the corresponding reduction for
+    /// the cost of this instruction
+    GAS,
+    /// Opcode 0x5B - Mark a valid destination for jumps
+    JUMPDEST,
 
     // 0x5C - 0x5F are invalid
-    // PUSH0,    // 0x5F (https://eips.ethereum.org/EIPS/eip-3855)
 
     // 0x60 range - pushes.
-    PUSH1,  // 0x60
-    PUSH2,  // 0x61
-    PUSH3,  // 0x62
-    PUSH4,  // 0x63
-    PUSH5,  // 0x64
-    PUSH6,  // 0x65
-    PUSH7,  // 0x66
-    PUSH8,  // 0x67
-    PUSH9,  // 0x68
-    PUSH10, // 0x69
-    PUSH11, // 0x6A
-    PUSH12, // 0x6B
-    PUSH13, // 0x6C
-    PUSH14, // 0x6D
-    PUSH15, // 0x6E
-    PUSH16, // 0x6F
-    PUSH17, // 0x70
-    PUSH18, // 0x71
-    PUSH19, // 0x72
-    PUSH20, // 0x73
-    PUSH21, // 0x74
-    PUSH22, // 0x75
-    PUSH23, // 0x76
-    PUSH24, // 0x77
-    PUSH25, // 0x78
-    PUSH26, // 0x79
-    PUSH27, // 0x7A
-    PUSH28, // 0x7B
-    PUSH29, // 0x7C
-    PUSH30, // 0x7D
-    PUSH31, // 0x7E
-    PUSH32, // 0x7F
+    // PUSH0,    // 0x5F (https://eips.ethereum.org/EIPS/eip-3855)
+    /// Opcode 0x60 - Place 1 byte item on stack
+    PUSH1,
+    /// Opcode 0x61 - Place 2 byte item on stack
+    PUSH2,
+    /// Opcode 0x62 - Place 3 byte item on stack
+    PUSH3,
+    /// Opcode 0x63 - Place 4 byte item on stack
+    PUSH4,
+    /// Opcode 0x64 - Place 5 byte item on stack
+    PUSH5,
+    /// Opcode 0x65 - Place 6 byte item on stack
+    PUSH6,
+    /// Opcode 0x66 - Place 7 byte item on stack
+    PUSH7,
+    /// Opcode 0x67 - Place 8 byte item on stack
+    PUSH8,
+    /// Opcode 0x68 - Place 9 byte item on stack
+    PUSH9,
+    /// Opcode 0x69 - Place 10 byte item on stack
+    PUSH10,
+    /// Opcode 0x6A - Place 11 byte item on stack
+    PUSH11,
+    /// Opcode 0x6B - Place 12 byte item on stack
+    PUSH12,
+    /// Opcode 0x6C - Place 13 byte item on stack
+    PUSH13,
+    /// Opcode 0x6D - Place 14 byte item on stack
+    PUSH14,
+    /// Opcode 0x6E - Place 15 byte item on stack
+    PUSH15,
+    /// Opcode 0x6F - Place 16 byte item on stack
+    PUSH16,
+    /// Opcode 0x70 - Place 17 byte item on stack
+    PUSH17,
+    /// Opcode 0x71 - Place 18 byte item on stack
+    PUSH18,
+    /// Opcode 0x72 - Place 19 byte item on stack
+    PUSH19,
+    /// Opcode 0x73 - Place 20 byte item on stack
+    PUSH20,
+    /// Opcode 0x74 - Place 21 byte item on stack
+    PUSH21,
+    /// Opcode 0x75 - Place 22 byte item on stack
+    PUSH22,
+    /// Opcode 0x76 - Place 23 byte item on stack
+    PUSH23,
+    /// Opcode 0x77 - Place 24 byte item on stack
+    PUSH24,
+    /// Opcode 0x78 - Place 25 byte item on stack
+    PUSH25,
+    /// Opcode 0x79 - Place 26 byte item on stack
+    PUSH26,
+    /// Opcode 0x7A - Place 27 byte item on stack
+    PUSH27,
+    /// Opcode 0x7B - Place 28 byte item on stack
+    PUSH28,
+    /// Opcode 0x7C - Place 29 byte item on stack
+    PUSH29,
+    /// Opcode 0x7D - Place 30 byte item on stack
+    PUSH30,
+    /// Opcode 0x7E - Place 31 byte item on stack
+    PUSH31,
+    /// Opcode 0x7F - Place 32 byte item on stack
+    PUSH32,
 
     // 0x80 range - dups.
-    DUP1,  // 0x80
-    DUP2,  // 0x81
-    DUP3,  // 0x82
-    DUP4,  // 0x83
-    DUP5,  // 0x84
-    DUP6,  // 0x85
-    DUP7,  // 0x86
-    DUP8,  // 0x87
-    DUP9,  // 0x88
-    DUP10, // 0x89
-    DUP11, // 0x8A
-    DUP12, // 0x8B
-    DUP13, // 0x8C
-    DUP14, // 0x8D
-    DUP15, // 0x8E
-    DUP16, // 0x8F
+    /// Opcode 0x80 - Duplicate 1st stack item
+    DUP1,
+    /// Opcode 0x81 - Duplicate 2nd stack item
+    DUP2,
+    /// Opcode 0x82 - Duplicate 3rd stack item
+    DUP3,
+    /// Opcode 0x83 - Duplicate 4th stack item
+    DUP4,
+    /// Opcode 0x84 - Duplicate 5th stack item
+    DUP5,
+    /// Opcode 0x85 - Duplicate 6th stack item
+    DUP6,
+    /// Opcode 0x86 - Duplicate 7th stack item
+    DUP7,
+    /// Opcode 0x87 - Duplicate 8th stack item
+    DUP8,
+    /// Opcode 0x88 - Duplicate 9th stack item
+    DUP9,
+    /// Opcode 0x89 - Duplicate 10th stack item
+    DUP10,
+    /// Opcode 0x8A - Duplicate 11th stack item
+    DUP11,
+    /// Opcode 0x8B - Duplicate 12th stack item
+    DUP12,
+    /// Opcode 0x8C - Duplicate 13th stack item
+    DUP13,
+    /// Opcode 0x8D - Duplicate 14th stack item
+    DUP14,
+    /// Opcode 0x8E - Duplicate 15th stack item
+    DUP15,
+    /// Opcode 0x8F - Duplicate 16th stack item
+    DUP16,
 
     // 0x90 range - swaps.
-    SWAP1,  // 0x90
-    SWAP2,  // 0x91
-    SWAP3,  // 0x92
-    SWAP4,  // 0x93
-    SWAP5,  // 0x94
-    SWAP6,  // 0x95
-    SWAP7,  // 0x96
-    SWAP8,  // 0x97
-    SWAP9,  // 0x98
-    SWAP10, // 0x99
-    SWAP11, // 0x9A
-    SWAP12, // 0x9B
-    SWAP13, // 0x9C
-    SWAP14, // 0x9D
-    SWAP15, // 0x9E
-    SWAP16, // 0x9F
+    /// Opcode 0x90 - Exchange 1st and 1st stack items
+    SWAP1,
+    /// Opcode 0x91 - Exchange 1st and 2nd stack items
+    SWAP2,
+    /// Opcode 0x92 - Exchange 1st and 3rd stack items
+    SWAP3,
+    /// Opcode 0x93 - Exchange 1st and 4th stack items
+    SWAP4,
+    /// Opcode 0x94 - Exchange 1st and 5th stack items
+    SWAP5,
+    /// Opcode 0x95 - Exchange 1st and 6th stack items
+    SWAP6,
+    /// Opcode 0x96 - Exchange 1st and 7th stack items
+    SWAP7,
+    /// Opcode 0x97 - Exchange 1st and 8th stack items
+    SWAP8,
+    /// Opcode 0x98 - Exchange 1st and 9th stack items
+    SWAP9,
+    /// Opcode 0x99 - Exchange 1st and 10th stack items
+    SWAP10,
+    /// Opcode 0x9A - Exchange 1st and 11th stack items
+    SWAP11,
+    /// Opcode 0x9B - Exchange 1st and 12th stack items
+    SWAP12,
+    /// Opcode 0x9C - Exchange 1st and 13th stack items
+    SWAP13,
+    /// Opcode 0x9D - Exchange 1st and 14th stack items
+    SWAP14,
+    /// Opcode 0x9E - Exchange 1st and 15th stack items
+    SWAP15,
+    /// Opcode 0x9F - Exchange 1st and 16th stack items
+    SWAP16,
 
     // 0xA0 range - logging ops.
-    LOG0, // 0xA0
-    LOG1, // 0xA1
-    LOG2, // 0xA2
-    LOG3, // 0xA3
-    LOG4, // 0xA4
+    /// Opcode 0xA0 - Append log record with one topic
+    LOG0,
+    /// Opcode 0xA1 - Append log record with two topics
+    LOG1,
+    /// Opcode 0xA2 - Append log record with three topics
+    LOG2,
+    /// Opcode 0xA3 - Append log record with four topics
+    LOG3,
+    /// Opcode 0xA4 - Append log record with five topics
+    LOG4,
 
     // 0xA5 - 0xEF are invalid
 
     // 0xF0 range - closures.
-    CREATE,       // 0xF0
-    CALL,         // 0xF1
-    CALLCODE,     // 0xF2
-    RETURN,       // 0xF3
-    DELEGATECALL, // 0xF4
-    CREATE2,      // 0xF5
+    /// Opcode 0xF0 - Create a new account with associated code
+    CREATE,
+    /// Opcode 0xF1 - Message-call into an account
+    CALL,
+    /// Opcode 0xF2 - Message-call into this account with alternative account’s code
+    CALLCODE,
+    /// Opcode 0xF3 - Halt execution returning output data
+    RETURN,
+    /// Opcode 0xF4 - Message-call into this account with an alternative account’s code, but
+    /// persisting the current values for sender and value
+    DELEGATECALL,
+    /// Opcode 0xF5 - Create a new account with associated code at a predictable address
+    CREATE2,
 
     // 0xF6 - 0xF9 are invalid
 
     // 0xFA range - closures
-    STATICCALL, // 0xFA
+    /// Opcode 0xFA - Static message-call into an account
+    STATICCALL,
 
     // 0xFB - 0xFC are invalid
 
     // 0xfd range - closures
-    REVERT, // 0xFD
+    /// Opcode 0xFD - Halt execution reverting state changes but returning data and remaining gas
+    REVERT,
     #[default]
-    INVALID, // 0xFE
-    SELFDESTRUCT, // 0xFF
+    /// Opcode 0xFE - Designated invalid instruction
+    INVALID,
+    /// Opcode 0xFF - Halt execution and register account for later deletion
+    SELFDESTRUCT,
 }

--- a/ethers-core/src/types/trace/opcodes.rs
+++ b/ethers-core/src/types/trace/opcodes.rs
@@ -1,0 +1,194 @@
+use serde::{Deserialize, Serialize};
+
+// https://github.com/ethereum/go-ethereum/blob/2b1299b1c006077c56ecbad32e79fc16febe3dd6/core/vm/opcodes.go
+#[derive(Debug, Clone, PartialEq, Eq, Default, Deserialize, Serialize)]
+pub enum OpCode {
+    // 0x0 range - arithmetic ops.
+    STOP,       // 0x0
+    ADD,        // 0x1
+    MUL,        // 0x2
+    SUB,        // 0x3
+    DIV,        // 0x4
+    SDIV,       // 0x5
+    MOD,        // 0x6
+    SMOD,       // 0x7
+    ADDMOD,     // 0x8
+    MULMOD,     // 0x9
+    EXP,        // 0xA
+    SIGNEXTEND, // 0xB
+
+    // 0x0C - 0x0F are invalid
+
+    // 0x10 range - comparison ops.
+    LT,     // 0x10
+    GT,     // 0x11
+    SLT,    // 0x12
+    SGT,    // 0x13
+    EQ,     // 0x14
+    ISZERO, // 0x15
+    AND,    // 0x16
+    OR,     // 0x17
+    XOR,    // 0x18
+    NOT,    // 0x19
+    BYTE,   // 0x1A
+    SHL,    // 0x1B
+    SHR,    // 0x1C
+    SAR,    // 0x1D
+
+    // 0x1E - 0x1F are invalid
+
+    // 0x20 range - crypto.
+    KECCAK256, // 0x20
+
+    // 0x21 - 0x2F are invalid
+
+    // 0x30 range - closure state.
+    ADDRESS,        // 0x30
+    BALANCE,        // 0x31
+    ORIGIN,         // 0x32
+    CALLER,         // 0x33
+    CALLVALUE,      // 0x34
+    CALLDATALOAD,   // 0x35
+    CALLDATASIZE,   // 0x36
+    CALLDATACOPY,   // 0x37
+    CODESIZE,       // 0x38
+    CODECOPY,       // 0x39
+    GASPRICE,       // 0x3A
+    EXTCODESIZE,    // 0x3B
+    EXTCODECOPY,    // 0x3C
+    RETURNDATASIZE, // 0x3D
+    RETURNDATACOPY, // 0x3E
+    EXTCODEHASH,    // 0x3F
+
+    // 0x40 range - block operations.
+    BLOCKHASH,  // 0x40
+    COINBASE,   // 0x41
+    TIMESTAMP,  // 0x42
+    NUMBER,     // 0x43
+    DIFFICULTY, // 0x44
+    //RANDOM,      // 0x44 // Same as DIFFICULTY
+    //PREVRANDAO,  // 0x44 // Same as DIFFICULTY
+    GASLIMIT,    // 0x45
+    CHAINID,     // 0x46
+    SELFBALANCE, // 0x47
+    BASEFEE,     // 0x48
+
+    // 0x49 - 0x4F are invalid
+
+    // 0x50 range - 'storage' and execution.
+    POP,      // 0x50
+    MLOAD,    // 0x51
+    MSTORE,   // 0x52
+    MSTORE8,  // 0x53
+    SLOAD,    // 0x54
+    SSTORE,   // 0x55
+    JUMP,     // 0x56
+    JUMPI,    // 0x57
+    PC,       // 0x58
+    MSIZE,    // 0x59
+    GAS,      // 0x5A
+    JUMPDEST, // 0x5B
+
+    // 0x5C - 0x5F are invalid
+    // PUSH0,    // 0x5F (https://eips.ethereum.org/EIPS/eip-3855)
+
+    // 0x60 range - pushes.
+    PUSH1,  // 0x60
+    PUSH2,  // 0x61
+    PUSH3,  // 0x62
+    PUSH4,  // 0x63
+    PUSH5,  // 0x64
+    PUSH6,  // 0x65
+    PUSH7,  // 0x66
+    PUSH8,  // 0x67
+    PUSH9,  // 0x68
+    PUSH10, // 0x69
+    PUSH11, // 0x6A
+    PUSH12, // 0x6B
+    PUSH13, // 0x6C
+    PUSH14, // 0x6D
+    PUSH15, // 0x6E
+    PUSH16, // 0x6F
+    PUSH17, // 0x70
+    PUSH18, // 0x71
+    PUSH19, // 0x72
+    PUSH20, // 0x73
+    PUSH21, // 0x74
+    PUSH22, // 0x75
+    PUSH23, // 0x76
+    PUSH24, // 0x77
+    PUSH25, // 0x78
+    PUSH26, // 0x79
+    PUSH27, // 0x7A
+    PUSH28, // 0x7B
+    PUSH29, // 0x7C
+    PUSH30, // 0x7D
+    PUSH31, // 0x7E
+    PUSH32, // 0x7F
+
+    // 0x80 range - dups.
+    DUP1,  // 0x80
+    DUP2,  // 0x81
+    DUP3,  // 0x82
+    DUP4,  // 0x83
+    DUP5,  // 0x84
+    DUP6,  // 0x85
+    DUP7,  // 0x86
+    DUP8,  // 0x87
+    DUP9,  // 0x88
+    DUP10, // 0x89
+    DUP11, // 0x8A
+    DUP12, // 0x8B
+    DUP13, // 0x8C
+    DUP14, // 0x8D
+    DUP15, // 0x8E
+    DUP16, // 0x8F
+
+    // 0x90 range - swaps.
+    SWAP1,  // 0x90
+    SWAP2,  // 0x91
+    SWAP3,  // 0x92
+    SWAP4,  // 0x93
+    SWAP5,  // 0x94
+    SWAP6,  // 0x95
+    SWAP7,  // 0x96
+    SWAP8,  // 0x97
+    SWAP9,  // 0x98
+    SWAP10, // 0x99
+    SWAP11, // 0x9A
+    SWAP12, // 0x9B
+    SWAP13, // 0x9C
+    SWAP14, // 0x9D
+    SWAP15, // 0x9E
+    SWAP16, // 0x9F
+
+    // 0xA0 range - logging ops.
+    LOG0, // 0xA0
+    LOG1, // 0xA1
+    LOG2, // 0xA2
+    LOG3, // 0xA3
+    LOG4, // 0xA4
+
+    // 0xA5 - 0xEF are invalid
+
+    // 0xF0 range - closures.
+    CREATE,       // 0xF0
+    CALL,         // 0xF1
+    CALLCODE,     // 0xF2
+    RETURN,       // 0xF3
+    DELEGATECALL, // 0xF4
+    CREATE2,      // 0xF5
+
+    // 0xF6 - 0xF9 are invalid
+
+    // 0xFA range - closures
+    STATICCALL, // 0xFA
+
+    // 0xFB - 0xFC are invalid
+
+    // 0xfd range - closures
+    REVERT, // 0xFD
+    #[default]
+    INVALID, // 0xFE
+    SELFDESTRUCT, // 0xFF
+}


### PR DESCRIPTION
## Motivation

Addresses #1857

I needed to do comprehensive tx analysis by using `vmTrace` to retrieve and inspect the executed opcodes to a transaction. The vmTrace log type [ethers::core::types::VMOperation](https://docs.rs/ethers/0.17.0/ethers/core/types/struct.VMOperation.html) does not contain a field for the executed opcode. 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Created an `OpCode` enum at [ethers-core/src/types/trace/opcodes.rs](https://github.com/mouseless-eth/ethers-rs/blob/vmTrace/add_op_codes/ethers-core/src/types/trace/opcodes.rs) that holds all evm opcodes.

Add an `op` field to VMOperation that is of type `OpCode`.

To [test](https://github.com/gakonst/ethers-rs/blob/921dfa6b1c5ad9ba5f24033a414041f04da624ad/ethers-core/src/types/trace/mod.rs#L197) deserializing this new type, [**example-trace-str.rs**](https://github.com/gakonst/ethers-rs/blob/master/ethers-core/src/types/trace/example-trace-str.rs) had to be regenerated as it left out the op field. 
curl request used to regenerate **example-trace-str.rs** (same txhash and geth trace type as original).
```
curl http://localhost:8545 -X POST -H "Content-Type: application/json" --data '{"method":"trace_replayTransaction","params":["0x4a91b11dbd2b11c308cfe7775eac2036f20c501691e3f8005d83b2dcce62d6b5",["trace", "vmTrace", "stateDiff"]],"id":1,"jsonrpc":"2.0"}'
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [x] Updated the changelog
