### PR TITLE
I256 asr doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,9 @@
 -   [#1632](https://github.com/gakonst/ethers-rs/pull/1632) Re-export `H32` from `ethabi`.
 -   [#1634](https://github.com/gakonst/ethers-rs/pull/1634) Derive missing `Clone`, `Copy` and `Debug` impls in ethers-etherscan.
 -   Bytes debug format now displays hex literals [#1658](https://github.com/gakonst/ethers-rs/pull/1658)
-- [#1451](https://github.com/gakonst/ethers-rs/issues/1451) Add Arithemtic Shift Left operation for I256 
+-   [#1451](https://github.com/gakonst/ethers-rs/issues/1451) Add Arithemtic Shift Left operation for I256
+-   Update I256 type documentation calling out the inconsistency between its right shift operator and
+    standard library numeric types.
 
 ## ethers-contract-abigen
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,8 @@
 -   [#1634](https://github.com/gakonst/ethers-rs/pull/1634) Derive missing `Clone`, `Copy` and `Debug` impls in ethers-etherscan.
 -   Bytes debug format now displays hex literals [#1658](https://github.com/gakonst/ethers-rs/pull/1658)
 -   [#1451](https://github.com/gakonst/ethers-rs/issues/1451) Add Arithemtic Shift Left operation for I256
--   Update I256 type documentation calling out the inconsistency between its right shift operator and
-    standard library numeric types.
+-   [#1860](https://github.com/gakonst/ethers-rs/pull/1860)Update I256 type documentation calling out the inconsistency 
+    between its right shift operator and standard library numeric types.
 
 ## ethers-contract-abigen
 

--- a/ethers-core/src/types/i256.rs
+++ b/ethers-core/src/types/i256.rs
@@ -89,6 +89,12 @@ impl Sign {
 }
 
 /// Little-endian 256-bit signed integer.
+///
+/// ## Diversion from standard numeric types
+/// The right shift operator on I256 doesn't act in the same manner as standard numeric types
+/// (e.g. `i8`, `i16` etc). On standard types if the number is negative right shift will perform
+/// an arithmetic shift, whereas on I256 this will perform a bit-wise shift.
+/// Arithmetic shift on I256 is done via the [asr](I256::asr) and [asl](I256::asl) functions.
 #[derive(Clone, Copy, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(transparent)]
 pub struct I256(U256);


### PR DESCRIPTION
…c types on the right shift operator

## Motivation
Discussion with @prestwich on telegram around [issue](https://github.com/gakonst/ethers-rs/issues/1840). Documentation was chosen over hidden breaking changes.

## Solution
Update documentation I256 on calling out the inconsistency between its right shift operator and standard numeric types.

## PR Checklist

-   [ ] Added Tests
-   [X] Added Documentation
-   [X] Updated the changelog
