### PR TITLE
docs: updated logs event filtering for examples with new syntax

### DIFF
--- a/examples/paginated_logs.rs
+++ b/examples/paginated_logs.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<()> {
 
     let erc20_transfer_filter = Filter::new()
         .from_block(last_block - 10000)
-        .topic0(ValueOrArray::Value(H256::from(keccak256("Transfer(address,address,uint256)"))));
+        .event("Transfer(address,address,uint256)");
 
     let mut stream = client.get_logs_paginated(&erc20_transfer_filter, 10);
 

--- a/examples/subscribe_logs.rs
+++ b/examples/subscribe_logs.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<()> {
 
     let erc20_transfer_filter = Filter::new()
         .from_block(last_block - 25)
-        .topic0(ValueOrArray::Value(H256::from(keccak256("Transfer(address,address,uint256)"))));
+        .event("Transfer(address,address,uint256)");
 
     let mut stream = client.subscribe_logs(&erc20_transfer_filter).await?;
 


### PR DESCRIPTION
## Motivation

There is a separate function that does exactly same thing.

## Solution

Replaced:  
```rs
topic0(ValueOrArray::Value(H256::from(keccak256(...))))
```
with
```rs
event()
```
