### PR TITLE
I256 parse support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,9 +94,11 @@
 -   [#1632](https://github.com/gakonst/ethers-rs/pull/1632) Re-export `H32` from `ethabi`.
 -   [#1634](https://github.com/gakonst/ethers-rs/pull/1634) Derive missing `Clone`, `Copy` and `Debug` impls in ethers-etherscan.
 -   Bytes debug format now displays hex literals [#1658](https://github.com/gakonst/ethers-rs/pull/1658)
--   [#1451](https://github.com/gakonst/ethers-rs/issues/1451) Add Arithemtic Shift Left operation for I256
--   [#1860](https://github.com/gakonst/ethers-rs/pull/1860)Update I256 type documentation calling out the inconsistency 
+-   [#1451](https://github.com/gakonst/ethers-rs/issues/1451) Add Arithmetic Shift Left operation for I256
+-   [#1860](https://github.com/gakonst/ethers-rs/pull/1860) Update I256 type documentation calling out the inconsistency 
     between its right shift operator and standard library numeric types.
+-   [#842](https://github.com/gakonst/ethers-rs/issues/842) Add support for I256 types in `parse_units` and `format_units`. 
+    Added `twos_complement` function for I256.
 
 ## ethers-contract-abigen
 

--- a/ethers-core/src/types/i256.rs
+++ b/ethers-core/src/types/i256.rs
@@ -4,6 +4,7 @@
 use crate::{
     abi::{InvalidOutputType, Token, Tokenizable},
     types::U256,
+    utils::ParseUnits,
 };
 use ethabi::ethereum_types::FromDecStrErr;
 use serde::{Deserialize, Serialize};
@@ -1050,6 +1051,15 @@ impl TryFrom<I256> for U256 {
     }
 }
 
+impl From<ParseUnits> for I256 {
+    fn from(n: ParseUnits) -> Self {
+        match n {
+            ParseUnits::U256(n) => Self::from_raw(n),
+            ParseUnits::I256(n) => n,
+        }
+    }
+}
+
 impl str::FromStr for I256 {
     type Err = ParseI256Error;
 
@@ -1841,12 +1851,24 @@ mod tests {
     fn twos_complement() {
         macro_rules! assert_twos_complement {
             ($signed:ty, $unsigned:ty) => {
-                assert_eq!(I256::from(<$signed>::MAX).twos_complement(), U256::from(<$signed>::MAX));
-                assert_eq!(I256::from(<$signed>::MIN).twos_complement(), U256::from(<$signed>::MIN.unsigned_abs()));
+                assert_eq!(
+                    I256::from(<$signed>::MAX).twos_complement(),
+                    U256::from(<$signed>::MAX)
+                );
+                assert_eq!(
+                    I256::from(<$signed>::MIN).twos_complement(),
+                    U256::from(<$signed>::MIN.unsigned_abs())
+                );
                 assert_eq!(I256::from(0 as $signed).twos_complement(), U256::from(0 as $signed));
 
-                assert_eq!(I256::from(<$unsigned>::MAX).twos_complement(), U256::from(<$unsigned>::MAX));
-                assert_eq!(I256::from(0 as $unsigned).twos_complement(), U256::from(0 as $unsigned));
+                assert_eq!(
+                    I256::from(<$unsigned>::MAX).twos_complement(),
+                    U256::from(<$unsigned>::MAX)
+                );
+                assert_eq!(
+                    I256::from(0 as $unsigned).twos_complement(),
+                    U256::from(0 as $unsigned)
+                );
             };
         }
 

--- a/ethers-core/src/types/i256.rs
+++ b/ethers-core/src/types/i256.rs
@@ -971,11 +971,19 @@ impl I256 {
         } else {
             let result = self << shift;
             if result.sign() != self.sign() {
-                // Overflow occured
+                // Overflow occurred
                 None
             } else {
                 Some(result)
             }
+        }
+    }
+
+    /// Compute the twos complement of the I256
+    pub fn twos_complement(self) -> U256 {
+        match self.sign() {
+            Sign::Positive => self.into_raw(),
+            Sign::Negative => twos_complement(self.into_raw()),
         }
     }
 }
@@ -1821,5 +1829,26 @@ mod tests {
 
         assert_eq!(I256::from_token(42i32.into_token()).unwrap(), I256::from(42),);
         assert_eq!(I256::from_token(U256::MAX.into_token()).unwrap(), I256::minus_one(),);
+    }
+
+    #[test]
+    fn twos_complement() {
+        macro_rules! assert_twos_complement {
+            ($signed:ty, $unsigned:ty) => {
+                assert_eq!(I256::from(<$signed>::MAX).twos_complement(), U256::from(<$signed>::MAX));
+                assert_eq!(I256::from(<$signed>::MIN).twos_complement(), U256::from(<$signed>::MIN.unsigned_abs()));
+                assert_eq!(I256::from(0 as $signed).twos_complement(), U256::from(0 as $signed));
+
+                assert_eq!(I256::from(<$unsigned>::MAX).twos_complement(), U256::from(<$unsigned>::MAX));
+                assert_eq!(I256::from(0 as $unsigned).twos_complement(), U256::from(0 as $unsigned));
+            };
+        }
+
+        assert_twos_complement!(i8, u8);
+        assert_twos_complement!(i16, u16);
+        assert_twos_complement!(i32, u32);
+        assert_twos_complement!(i64, u64);
+        assert_twos_complement!(i128, u128);
+        assert_twos_complement!(isize, usize);
     }
 }

--- a/ethers-core/src/types/mod.rs
+++ b/ethers-core/src/types/mod.rs
@@ -30,7 +30,7 @@ mod uint8;
 pub use uint8::*;
 
 mod i256;
-pub use i256::{Sign, I256};
+pub use i256::{ParseI256Error, Sign, I256};
 
 mod bytes;
 pub use self::bytes::{deserialize_bytes, serialize_bytes, Bytes, ParseBytesError};

--- a/ethers-middleware/tests/signer.rs
+++ b/ethers-middleware/tests/signer.rs
@@ -97,6 +97,7 @@ async fn pending_txs_with_confirmations_testnet() {
 
 #[cfg(not(feature = "celo"))]
 use ethers_core::types::{Address, Eip1559TransactionRequest};
+use ethers_core::utils::parse_ether;
 
 // different keys to avoid nonce errors
 #[tokio::test]
@@ -317,7 +318,7 @@ impl TestWallets {
                 .nonce(nonce)
                 .to(addr)
                 // 0.1 eth per wallet
-                .value(parse_units("1", 18).unwrap());
+                .value(parse_ether("1").unwrap());
             pending_txs.push(
                 provider.send_transaction(tx, Some(BlockNumber::Pending.into())).await.unwrap(),
             );


### PR DESCRIPTION
## Motivation
Close [#842](https://github.com/gakonst/ethers-rs/issues/842)

## Solution
Updated the `format_units` to take in a numeric that can be Into'd the enum. This should be a pretty transparent change for users, however the `From<&str> for U256` support will be dropped by the function. Given the existing tests cases I would suspect this doesn't impact a lot of users as they would be transforming into a U256 first before calling this function.

`format_units` also required to expose a `twos_complement` method on the I256 type. I thought of re-using the abs functions and taking one of the tuple results however throught this would enable better readability and help with presenting an API for I256 which a user would expect.

Tried to make the user updates required for `parse_units` as painless as possible by the `From<ParseUnits> for U256` and `From<ParseUnits> for I256` traits, which will enable the `.into()` call. However this does introduce breaking changes that cannot be avoided.

## PR Checklist

-   [X] Added Tests
-   [X] Added Documentation
-   [X] Updated the changelog
