### PR TITLE
Rust already exists on the platform - update it instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,13 +284,11 @@ jobs:
               uses: actions/checkout@v3
 
               # Run build
-            - name: Install Rustup using win.rustup.rs
+            - name: Update Rustup
               run: |
                   # disable download progress bar
                   $ProgressPreference = "SilentlyContinue"
-                  Invoke-WebRequest https://win.rustup.rs/ -OutFile rustup-init.exe
-                  .\rustup-init.exe -y --default-host=x86_64-pc-windows-msvc --default-toolchain=none
-                  del rustup-init.exe
+                  rustup update
                   rustup target add ${{ matrix.target }}
               shell: powershell
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Windows build failures on main line.

## Solution
Rust seems to already be installed on the platform, therefore rustup just exits. Moved to rustup update instead.

## PR Checklist

-   [-] Added Tests
-   [-] Added Documentation
-   [-] Updated the changelog
