### PR TITLE
Fix: use cwd manifest

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -571,7 +571,7 @@ impl MultiBindingsInner {
 
     /// parses the active Cargo.toml to get what version of ethers we are using
     fn find_crate_version(&self) -> Result<String> {
-        let cargo_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+        let cargo_dir = std::env::current_dir()?.join("Cargo.toml");
         let data = std::fs::read_to_string(cargo_dir)?;
         let toml = data.parse::<Value>()?;
 

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -575,9 +575,11 @@ impl MultiBindingsInner {
         let data = std::fs::read_to_string(cargo_dir)?;
         let toml = data.parse::<Value>()?;
 
-        let Some(ethers) = toml.get("dependencies")
-            .and_then (|v| v.get("ethers").or_else(|| v.get("ethers-contract")))
-            else { eyre::bail!("couldn't find ethers or ethers-contract dependency")};
+        let ethers = toml
+            .get("dependencies")
+            .and_then(|v| v.get("ethers").or_else(|| v.get("ethers-contract")))
+            .ok_or(eyre::eyre!("couldn't find ethers or ethers-contract dependency"))?;
+
         if let Some(rev) = ethers.get("rev") {
             Ok(format!("ethers = {{ git = \"https://github.com/gakonst/ethers-rs\", rev = {}, default-features = false, features = [\"abigen\"] }}", rev))
         } else if let Some(version) = ethers.get("version") {

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -578,7 +578,7 @@ impl MultiBindingsInner {
         let ethers = toml
             .get("dependencies")
             .and_then(|v| v.get("ethers").or_else(|| v.get("ethers-contract")))
-            .ok_or(eyre::eyre!("couldn't find ethers or ethers-contract dependency"))?;
+            .ok_or_else(||eyre::eyre!("couldn't find ethers or ethers-contract dependency"))?;
 
         if let Some(rev) = ethers.get("rev") {
             Ok(format!("ethers = {{ git = \"https://github.com/gakonst/ethers-rs\", rev = {}, default-features = false, features = [\"abigen\"] }}", rev))

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -578,7 +578,7 @@ impl MultiBindingsInner {
         let ethers = toml
             .get("dependencies")
             .and_then(|v| v.get("ethers").or_else(|| v.get("ethers-contract")))
-            .ok_or_else(||eyre::eyre!("couldn't find ethers or ethers-contract dependency"))?;
+            .ok_or_else(|| eyre::eyre!("couldn't find ethers or ethers-contract dependency"))?;
 
         if let Some(rev) = ethers.get("rev") {
             Ok(format!("ethers = {{ git = \"https://github.com/gakonst/ethers-rs\", rev = {}, default-features = false, features = [\"abigen\"] }}", rev))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
the previous fix used CARGO_MANIFEST_DIR however this turns out to return the crate directory rather than the dependant crate directory making this impl wrong 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
use the cwd instead. This doesn't cover all cases but is better than the current which misses all the cases
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
