### PR TITLE
chore: bump trezor, fix clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
  "impl-serde",
@@ -1197,11 +1197,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81224dc661606574f5a0f28c9947d0ee1d93ff11c5f1c4e7272f52e8c0b5483c"
 dependencies = [
  "ethbloom",
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
  "impl-serde",
- "primitive-types 0.12.1",
+ "primitive-types",
  "scale-info",
  "uint",
 ]
@@ -1548,15 +1548,6 @@ checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "static_assertions",
 ]
 
 [[package]]
@@ -2861,21 +2852,11 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
-dependencies = [
- "fixed-hash 0.7.0",
- "uint",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
  "impl-serde",
@@ -4207,15 +4188,13 @@ dependencies = [
 
 [[package]]
 name = "trezor-client"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659ac74f0f26e4150ad6ffe155db8ee1727ea13a1b1b0ff0e7807e5befdb3aaf"
+version = "0.0.7"
 dependencies = [
  "byteorder",
  "hex",
  "hidapi-rusb",
  "log",
- "primitive-types 0.11.1",
+ "primitive-types",
  "protobuf",
  "rusb",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,6 +4189,8 @@ dependencies = [
 [[package]]
 name = "trezor-client"
 version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3e4b569b95a8d24d10b2e8f60196348eb15023d50d2b38a4463e7f150afd27"
 dependencies = [
  "byteorder",
  "hex",

--- a/ethers-core/src/types/block.rs
+++ b/ethers-core/src/types/block.rs
@@ -186,7 +186,7 @@ impl<TX> Block<TX> {
         // Casting to i64 is safe because the timestamp is guaranteed to be less than 2^63.
         // TODO: It would be nice if there was `TryInto<i64> for U256`.
         let secs = self.timestamp.as_u64() as i64;
-        Ok(Utc.timestamp(secs, 0))
+        Ok(Utc.timestamp_opt(secs, 0).unwrap())
     }
 }
 

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -29,7 +29,7 @@ yubihsm = { version = "0.41.0", features = ["secp256k1", "http", "usb"], optiona
 futures-util = { version = "^0.3", optional = true }
 futures-executor = { version = "^0.3", optional = true }
 semver = { version = "1.0.14", optional = true }
-trezor-client = { version = "0.0.6", optional = true, default-features = false, features = [
+trezor-client = { version = "0.0.7", optional = true, default-features = false, features = [
     "f_ethereum",
 ] }
 


### PR DESCRIPTION
## Motivation
Fix CI issues.

## Solution
Bump to trezor.

Please note requires: https://github.com/joshieDo/rust-trezor-api/pull/5 in order to get the new version of Trezor and fix the CI issues around primitive-types.
