### PR TITLE
fix: find_contract and find not working

### DIFF
--- a/ethers-solc/src/compile/output/mod.rs
+++ b/ethers-solc/src/compile/output/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use contracts::{VersionedContract, VersionedContracts};
 use semver::Version;
-use std::{collections::BTreeMap, fmt, path::Path};
+use std::{collections::BTreeMap, env, fmt, path::Path};
 use tracing::trace;
 
 pub mod contracts;
@@ -278,7 +278,9 @@ impl<T: ArtifactOutput> ProjectCompileOutput<T> {
     /// # }
     /// ```
     pub fn find(&self, path: impl AsRef<str>, contract: impl AsRef<str>) -> Option<&T::Artifact> {
-        let contract_path = path.as_ref();
+        let mut current_dir = env::current_dir().unwrap();
+        current_dir.push(path.as_ref());
+        let contract_path = current_dir.to_str().unwrap();
         let contract_name = contract.as_ref();
         if let artifact @ Some(_) = self.compiled_artifacts.find(contract_path, contract_name) {
             return artifact


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
`find` and `find_contract` method return None in `ethers_solc::output::ProjectCompileOutput`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
`find_contract` and `find` method do not working with relative path, so i change `contract_path` to absolute path, and it works as the example showed.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
