### PR TITLE
feat(providers): add a subset of admin namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
     ETHERSCAN_API_KEY_ETHEREUM: I5BXNZYP5GEDWFINGVEZKYIVU2695NPQZB
     ETHERSCAN_API_KEY_CELO: B13XSMUT6Q3Q4WZ5DNQR8RXDBA2KNTMT4M
     GOERLI_PRIVATE_KEY: "fa4a1a79e869a96fcb42727f75e3232d6865a82ea675bb95de967a7fe6a773b2"
+    GETH_BUILD: 1.10.26-e5eb32ac
 
 jobs:
     tests:
@@ -36,9 +37,9 @@ jobs:
             - name: Install geth
               run: |
                   mkdir -p "$HOME/bin"
-                  wget -q https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.9.23-8c2f2715.tar.gz
-                  tar -xvf geth-linux-amd64-1.9.23-8c2f2715.tar.gz
-                  mv geth-linux-amd64-1.9.23-8c2f2715/geth $HOME/bin/geth
+                  wget -q https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-$GETH_BUILD.tar.gz
+                  tar -xvf geth-linux-amd64-$GETH_BUILD.tar.gz
+                  mv geth-linux-amd64-$GETH_BUILD/geth $HOME/bin/geth
                   chmod u+x "$HOME/bin/geth"
                   export PATH=$HOME/bin:$PATH
                   geth version
@@ -79,9 +80,9 @@ jobs:
             - name: Install geth
               run: |
                   mkdir -p "$HOME/bin"
-                  wget -q https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.9.23-8c2f2715.tar.gz
-                  tar -xvf geth-linux-amd64-1.9.23-8c2f2715.tar.gz
-                  mv geth-linux-amd64-1.9.23-8c2f2715/geth $HOME/bin/geth
+                  wget -q https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-$GETH_BUILD.tar.gz
+                  tar -xvf geth-linux-amd64-$GETH_BUILD.tar.gz
+                  mv geth-linux-amd64-$GETH_BUILD/geth $HOME/bin/geth
                   chmod u+x "$HOME/bin/geth"
                   export PATH=$HOME/bin:$PATH
                   geth version
@@ -201,9 +202,9 @@ jobs:
             - name: Install geth (for state overrides example)
               run: |
                   mkdir -p "$HOME/bin"
-                  wget -q https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.9.23-8c2f2715.tar.gz
-                  tar -xvf geth-linux-amd64-1.9.23-8c2f2715.tar.gz
-                  mv geth-linux-amd64-1.9.23-8c2f2715/geth $HOME/bin/geth
+                  wget -q https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-$GETH_BUILD.tar.gz
+                  tar -xvf geth-linux-amd64-$GETH_BUILD.tar.gz
+                  mv geth-linux-amd64-$GETH_BUILD/geth $HOME/bin/geth
                   chmod u+x "$HOME/bin/geth"
                   export PATH=$HOME/bin:$PATH
                   geth version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,8 @@
 
 ### Unreleased
 
+-   Add a subset of the `admin` namespace 
+    [????](https://github.com/gakonst/ethers-rs/pull/????)
 -   Return String for net version
     [1376](https://github.com/gakonst/ethers-rs/pull/1376)
 -   Stream of paginated logs that load logs in small pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,7 +222,7 @@
 ### Unreleased
 
 -   Add a subset of the `admin` namespace 
-    [????](https://github.com/gakonst/ethers-rs/pull/????)
+    [1880](https://github.com/gakonst/ethers-rs/pull/1880)
 -   Return String for net version
     [1376](https://github.com/gakonst/ethers-rs/pull/1376)
 -   Stream of paginated logs that load logs in small pages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "enr"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "492a7e5fc2504d5fdce8e124d3e263b244a68b283cac67a69eda0cd43e0aebad"
+dependencies = [
+ "base64 0.13.1",
+ "bs58",
+ "bytes",
+ "hex",
+ "k256",
+ "log",
+ "rand 0.8.5",
+ "rlp",
+ "serde",
+ "sha3",
+ "zeroize",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,6 +1498,7 @@ dependencies = [
  "auto_impl 1.0.1",
  "base64 0.13.1",
  "bytes",
+ "enr",
  "ethers-core",
  "futures-channel",
  "futures-core",

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -27,7 +27,7 @@ tiny-keccak = { version = "2.0.2", default-features = false }
 # misc
 chrono = { version = "0.4", default-features = false }
 serde = { version = "1.0.124", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.64", default-features = false }
+serde_json = { version = "1.0.64", default-features = false, features = ["arbitrary_precision"] }
 thiserror = { version = "1.0", default-features = false }
 bytes = { version = "1.3.0", features = ["serde"] }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }

--- a/ethers-core/src/types/fee.rs
+++ b/ethers-core/src/types/fee.rs
@@ -1,7 +1,5 @@
-use std::str::FromStr;
-
-use crate::types::U256;
-use serde::{de::Deserializer, Deserialize, Serialize};
+use crate::{types::U256, utils::from_int_or_hex};
+use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -18,20 +16,4 @@ pub struct FeeHistory {
     /// zeroes are returned if the block is empty.
     #[serde(default)]
     pub reward: Vec<Vec<U256>>,
-}
-
-fn from_int_or_hex<'de, D>(deserializer: D) -> Result<U256, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum IntOrHex {
-        Int(u64),
-        Hex(String),
-    }
-    match IntOrHex::deserialize(deserializer)? {
-        IntOrHex::Int(n) => Ok(U256::from(n)),
-        IntOrHex::Hex(s) => U256::from_str(s.as_str()).map_err(serde::de::Error::custom),
-    }
 }

--- a/ethers-core/src/utils/genesis.rs
+++ b/ethers-core/src/utils/genesis.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::types::{Address, Bytes, H256, U256};
+use crate::types::{Address, Bytes, H256, U256, U64};
 use serde::{Deserialize, Serialize};
 
 /// This represents the chain configuration, specifying the genesis block, header fields, and hard
@@ -12,16 +12,16 @@ pub struct Genesis {
     pub config: ChainConfig,
 
     /// The genesis header nonce.
-    pub nonce: u64,
+    pub nonce: U64,
 
     /// The genesis header timestamp.
-    pub timestamp: u64,
+    pub timestamp: U64,
 
     /// The genesis header extra data.
     pub extra_data: Bytes,
 
     /// The genesis header gas limit.
-    pub gas_limit: u64,
+    pub gas_limit: U64,
 
     /// The genesis header difficulty.
     pub difficulty: U256,
@@ -60,63 +60,82 @@ pub struct ChainConfig {
     pub chain_id: u64,
 
     /// The homestead switch block (None = no fork, 0 = already homestead).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub homestead_block: Option<u64>,
 
     /// The DAO fork switch block (None = no fork).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dao_fork_block: Option<u64>,
 
     /// Whether or not the node supports the DAO hard-fork.
     pub dao_fork_support: bool,
 
     /// The EIP-150 hard fork block (None = no fork).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub eip150_block: Option<u64>,
 
     /// The EIP-150 hard fork hash.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub eip150_hash: Option<H256>,
 
     /// The EIP-155 hard fork block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub eip155_block: Option<u64>,
 
     /// The EIP-158 hard fork block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub eip158_block: Option<u64>,
 
     /// The Byzantium hard fork block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub byzantium_block: Option<u64>,
 
     /// The Constantinople hard fork block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub constantinople_block: Option<u64>,
 
     /// The Petersburg hard fork block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub petersburg_block: Option<u64>,
 
     /// The Istanbul hard fork block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub istanbul_block: Option<u64>,
 
     /// The Muir Glacier hard fork block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub muir_glacier_block: Option<u64>,
 
     /// The Berlin hard fork block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub berlin_block: Option<u64>,
 
     /// The London hard fork block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub london_block: Option<u64>,
 
     /// The Arrow Glacier hard fork block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub arrow_glacier_block: Option<u64>,
 
     /// The Gray Glacier hard fork block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gray_glacier_block: Option<u64>,
 
     /// Virtual fork after the merge to use as a network splitter.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub merge_netsplit_block: Option<u64>,
 
     /// The Shanghai hard fork block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shanghai_block: Option<u64>,
 
     /// The Cancun hard fork block.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cancun_block: Option<u64>,
 
     /// Total difficulty reached that triggers the merge consensus upgrade.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub terminal_total_difficulty: Option<U256>,
 
     /// A flag specifying that the network already passed the terminal total difficulty. Its
@@ -124,9 +143,11 @@ pub struct ChainConfig {
     pub terminal_total_difficulty_passed: bool,
 
     /// Ethash parameters.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ethash: Option<EthashConfig>,
 
     /// Clique parameters.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clique: Option<CliqueConfig>,
 }
 

--- a/ethers-core/src/utils/genesis.rs
+++ b/ethers-core/src/utils/genesis.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use crate::types::{Address, Bytes, H256, U256, U64};
+use crate::{
+    types::{Address, Bytes, H256, U256, U64},
+    utils::{from_int_or_hex, from_int_or_hex_opt},
+};
 use serde::{Deserialize, Serialize};
 
 /// This represents the chain configuration, specifying the genesis block, header fields, and hard
@@ -24,6 +27,7 @@ pub struct Genesis {
     pub gas_limit: U64,
 
     /// The genesis header difficulty.
+    #[serde(deserialize_with = "from_int_or_hex")]
     pub difficulty: U256,
 
     /// The genesis header mix hash.
@@ -135,7 +139,7 @@ pub struct ChainConfig {
     pub cancun_block: Option<u64>,
 
     /// Total difficulty reached that triggers the merge consensus upgrade.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", deserialize_with = "from_int_or_hex_opt")]
     pub terminal_total_difficulty: Option<U256>,
 
     /// A flag specifying that the network already passed the terminal total difficulty. Its

--- a/ethers-core/src/utils/genesis.rs
+++ b/ethers-core/src/utils/genesis.rs
@@ -1,0 +1,103 @@
+use crate::types::{H256, U256};
+use serde::{Deserialize, Serialize};
+
+/// This represents the chain configuration, specifying the genesis block, header fields, and hard
+/// fork switch blocks.
+pub struct Genesis {}
+
+/// Represents a node's chain configuration.
+///
+/// See [geth's `ChainConfig`
+/// struct](https://github.com/ethereum/go-ethereum/blob/64dccf7aa411c5c7cd36090c3d9b9892945ae813/params/config.go#L349)
+/// for the source of each field.
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[serde(default, rename_all = "camelCase")]
+pub struct ChainConfig {
+    /// The network's chain ID.
+    pub chain_id: u64,
+
+    /// The homestead switch block (None = no fork, 0 = already homestead).
+    pub homestead_block: Option<u64>,
+
+    /// The DAO fork switch block (None = no fork).
+    pub dao_fork_block: Option<u64>,
+
+    /// Whether or not the node supports the DAO hard-fork.
+    pub dao_fork_support: bool,
+
+    /// The EIP-150 hard fork block (None = no fork).
+    pub eip150_block: Option<u64>,
+
+    /// The EIP-150 hard fork hash.
+    pub eip150_hash: Option<H256>,
+
+    /// The EIP-155 hard fork block.
+    pub eip155_block: Option<u64>,
+
+    /// The EIP-158 hard fork block.
+    pub eip158_block: Option<u64>,
+
+    /// The Byzantium hard fork block.
+    pub byzantium_block: Option<u64>,
+
+    /// The Constantinople hard fork block.
+    pub constantinople_block: Option<u64>,
+
+    /// The Petersburg hard fork block.
+    pub petersburg_block: Option<u64>,
+
+    /// The Istanbul hard fork block.
+    pub istanbul_block: Option<u64>,
+
+    /// The Muir Glacier hard fork block.
+    pub muir_glacier_block: Option<u64>,
+
+    /// The Berlin hard fork block.
+    pub berlin_block: Option<u64>,
+
+    /// The London hard fork block.
+    pub london_block: Option<u64>,
+
+    /// The Arrow Glacier hard fork block.
+    pub arrow_glacier_block: Option<u64>,
+
+    /// The Gray Glacier hard fork block.
+    pub gray_glacier_block: Option<u64>,
+
+    /// Virtual fork after the merge to use as a network splitter.
+    pub merge_netsplit_block: Option<u64>,
+
+    /// The Shanghai hard fork block.
+    pub shanghai_block: Option<u64>,
+
+    /// The Cancun hard fork block.
+    pub cancun_block: Option<u64>,
+
+    /// Total difficulty reached that triggers the merge consensus upgrade.
+    pub terminal_total_difficulty: Option<U256>,
+
+    /// A flag specifying that the network already passed the terminal total difficulty. Its
+    /// purpose is to disable legacy sync without having seen the TTD locally.
+    pub terminal_total_difficulty_passed: bool,
+
+    /// Ethash parameters.
+    pub ethash: Option<EthashConfig>,
+
+    /// Clique parameters.
+    pub clique: Option<CliqueConfig>,
+}
+
+/// Empty consensus configuration for proof-of-work networks.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EthashConfig {}
+
+/// Consensus configuration for Clique.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CliqueConfig {
+    /// Number of seconds between blocks to enforce.
+    pub period: u64,
+
+    /// Epoch length to reset votes and checkpoints.
+    pub epoch: u64,
+}
+

--- a/ethers-core/src/utils/genesis.rs
+++ b/ethers-core/src/utils/genesis.rs
@@ -1,9 +1,52 @@
-use crate::types::{H256, U256};
+use std::collections::HashMap;
+
+use crate::types::{Address, Bytes, H256, U256};
 use serde::{Deserialize, Serialize};
 
 /// This represents the chain configuration, specifying the genesis block, header fields, and hard
 /// fork switch blocks.
-pub struct Genesis {}
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Genesis {
+    /// The fork configuration for this network.
+    pub config: ChainConfig,
+
+    /// The genesis header nonce.
+    pub nonce: u64,
+
+    /// The genesis header timestamp.
+    pub timestamp: u64,
+
+    /// The genesis header extra data.
+    pub extra_data: Bytes,
+
+    /// The genesis header gas limit.
+    pub gas_limit: u64,
+
+    /// The genesis header difficulty.
+    pub difficulty: U256,
+
+    /// The genesis header mix hash.
+    pub mix_hash: H256,
+
+    /// The genesis header coinbase address.
+    pub coinbase: Address,
+
+    /// The initial state of the genesis block.
+    pub alloc: HashMap<Address, GenesisAccount>,
+}
+
+/// An account in the state of the genesis block.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GenesisAccount {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<u64>,
+    pub balance: U256,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<Bytes>,
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub storage: Option<HashMap<H256, H256>>,
+}
 
 /// Represents a node's chain configuration.
 ///
@@ -100,4 +143,3 @@ pub struct CliqueConfig {
     /// Epoch length to reset votes and checkpoints.
     pub epoch: u64,
 }
-

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -111,7 +111,6 @@ pub struct PrivateNetOptions {
 #[derive(Clone, Default)]
 pub struct Geth {
     port: Option<u16>,
-    block_time: Option<u64>,
     ipc_path: Option<PathBuf>,
     data_dir: Option<PathBuf>,
     mode: GethMode,
@@ -133,10 +132,11 @@ impl Geth {
 
     /// Sets the block-time which will be used when the `geth-cli` instance is launched.
     ///
-    /// This will set the `dev` flag to true.
+    /// This will put the geth instance in `dev` mode, discarding any previously set options that
+    /// cannot be used in dev mode.
     #[must_use]
     pub fn block_time<T: Into<u64>>(mut self, block_time: T) -> Self {
-        self.block_time = Some(block_time.into());
+        self.mode = GethMode::Dev(DevOptions { block_time: Some(block_time.into()) });
         self
     }
 

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -90,7 +90,6 @@ impl GethInstance {
             // geth ids are trunated
             let truncated_id = hex::encode(&id.0[..8]);
             if line.contains("Adding p2p peer") && line.contains(&truncated_id) {
-                println!("Found peer in log: {}", line);
                 return Ok(())
             }
         }

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -103,6 +103,8 @@ impl Geth {
     }
 
     /// Sets the block-time which will be used when the `geth-cli` instance is launched.
+    ///
+    /// This will set the `dev` flag to true.
     #[must_use]
     pub fn block_time<T: Into<u64>>(mut self, block_time: T) -> Self {
         self.block_time = Some(block_time.into());
@@ -119,10 +121,12 @@ impl Geth {
 
     /// Sets whether or not the geth instance will be run in `dev` mode.
     ///
-    /// This will automatically be `true` if `block_time` is set.
+    /// This will not be set to `false` if `block_time` is already set.
     #[must_use]
     pub fn dev(mut self, dev: bool) -> Self {
-        self.dev = dev;
+        if self.block_time.is_none() {
+            self.dev = dev;
+        }
         self
     }
 

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -101,9 +101,6 @@ impl GethInstance {
 impl Drop for GethInstance {
     fn drop(&mut self) {
         self.pid.kill().expect("could not kill geth");
-        // wait for the process to exit - we don't need to use the Result because the process could
-        // have already exited
-        _ = self.pid.wait();
     }
 }
 

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -140,7 +140,7 @@ impl Geth {
         cmd.arg("--ws.port").arg(port.to_string());
         cmd.arg("--ws.api").arg(API);
 
-        if let Some(data_dir) = self.data_dir {
+        if let Some(ref data_dir) = self.data_dir {
             cmd.arg("--datadir").arg(data_dir);
         }
 

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -85,6 +85,7 @@ pub struct Geth {
     block_time: Option<u64>,
     ipc_path: Option<PathBuf>,
     data_dir: Option<PathBuf>,
+    dev: bool,
 }
 
 impl Geth {
@@ -105,6 +106,7 @@ impl Geth {
     #[must_use]
     pub fn block_time<T: Into<u64>>(mut self, block_time: T) -> Self {
         self.block_time = Some(block_time.into());
+        self.dev = true;
         self
     }
 
@@ -112,6 +114,15 @@ impl Geth {
     #[must_use]
     pub fn ipc_path<T: Into<PathBuf>>(mut self, path: T) -> Self {
         self.ipc_path = Some(path.into());
+        self
+    }
+
+    /// Sets whether or not the geth instance will be run in `dev` mode.
+    ///
+    /// This will automatically be `true` if `block_time` is set.
+    #[must_use]
+    pub fn dev(mut self, dev: bool) -> Self {
+        self.dev = dev;
         self
     }
 
@@ -145,9 +156,11 @@ impl Geth {
         }
 
         // Dev mode with custom block time
-        cmd.arg("--dev");
-        if let Some(block_time) = self.block_time {
-            cmd.arg("--dev.period").arg(block_time.to_string());
+        if self.dev {
+            cmd.arg("--dev");
+            if let Some(block_time) = self.block_time {
+                cmd.arg("--dev.period").arg(block_time.to_string());
+            }
         }
 
         if let Some(ref ipc) = self.ipc_path {

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -2,7 +2,7 @@ use super::{unused_port, Genesis};
 use crate::types::H256;
 use std::{
     env::temp_dir,
-    fs::File,
+    fs::{create_dir, File},
     io::{BufRead, BufReader},
     path::PathBuf,
     process::{Child, Command, Stdio},
@@ -324,6 +324,11 @@ impl Geth {
 
         if let Some(ref data_dir) = self.data_dir {
             cmd.arg("--datadir").arg(data_dir);
+
+            // create the directory if it doesn't exist
+            if !data_dir.exists() {
+                create_dir(data_dir).expect("could not create data dir");
+            }
         }
 
         // Dev mode with custom block time
@@ -384,7 +389,8 @@ impl Geth {
             }
 
             // geth 1.9.23 uses "server started" while 1.9.18 uses "endpoint opened"
-            if line.contains("HTTP endpoint opened") || line.contains("HTTP server started") {
+            // the unauthenticated api is used for regular non-engine API requests
+            if line.contains("HTTP endpoint opened") || (line.contains("HTTP server started") && !line.contains("auth=true")) {
                 http_started = true;
             }
 

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -10,7 +10,7 @@ use std::{
 const GETH_STARTUP_TIMEOUT_MILLIS: u64 = 10_000;
 
 /// The exposed APIs
-const API: &str = "eth,net,web3,txpool";
+const API: &str = "eth,net,web3,txpool,admin";
 
 /// The geth command
 const GETH: &str = "geth";

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -95,6 +95,20 @@ impl GethInstance {
         }
         Err(GethInstanceError::Timeout("Timed out waiting for geth to add a peer".into()))
     }
+
+    /// Dumps the unread stderr of the geth instance to a string.
+    pub fn dump_stderr(&mut self) -> Result<String, GethInstanceError> {
+        let mut stderr = self.pid.stderr.as_mut().ok_or(GethInstanceError::NoStderr)?;
+        let mut err_reader = BufReader::new(&mut stderr);
+        let mut line = String::new();
+        let mut output = String::new();
+
+        while err_reader.read_line(&mut line).map_err(GethInstanceError::ReadLineError)? > 0 {
+            output.push_str(&line);
+            line.clear();
+        }
+        Ok(output)
+    }
 }
 
 impl Drop for GethInstance {

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -292,6 +292,7 @@ impl Geth {
         // geth uses stderr for its logs
         cmd.stderr(std::process::Stdio::piped());
         let port = if let Some(port) = self.port { port } else { unused_port() };
+        let authrpc_port = if let Some(port) = self.authrpc_port { port } else { unused_port() };
 
         // Open the HTTP API
         cmd.arg("--http");
@@ -304,9 +305,7 @@ impl Geth {
         cmd.arg("--ws.api").arg(API);
 
         // Set the port for authenticated APIs
-        if let Some(authrpc_port) = self.authrpc_port {
-            cmd.arg("--authrpc.port").arg(authrpc_port.to_string());
-        }
+        cmd.arg("--authrpc.port").arg(authrpc_port.to_string());
 
         // use geth init to initialize the datadir if the genesis exists
         if let Some(genesis) = self.genesis {

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -95,20 +95,6 @@ impl GethInstance {
         }
         Err(GethInstanceError::Timeout("Timed out waiting for geth to add a peer".into()))
     }
-
-    /// Dumps the unread stderr of the geth instance to a string.
-    pub fn dump_stderr(&mut self) -> Result<String, GethInstanceError> {
-        let mut stderr = self.pid.stderr.as_mut().ok_or(GethInstanceError::NoStderr)?;
-        let mut err_reader = BufReader::new(&mut stderr);
-        let mut line = String::new();
-        let mut output = String::new();
-
-        while err_reader.read_line(&mut line).map_err(GethInstanceError::ReadLineError)? > 0 {
-            output.push_str(&line);
-            line.clear();
-        }
-        Ok(output)
-    }
 }
 
 impl Drop for GethInstance {

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -12,7 +12,7 @@ use std::{
 /// How long we will wait for geth to indicate that it is ready.
 const GETH_STARTUP_TIMEOUT_MILLIS: u64 = 10_000;
 
-/// Timeout for waiting for geth's dial loop to start.
+/// Timeout for waiting for geth to add a peer.
 const GETH_DIAL_LOOP_TIMEOUT: Duration = Duration::new(20, 0);
 
 /// The exposed APIs
@@ -76,7 +76,7 @@ impl GethInstance {
         &self.data_dir
     }
 
-    /// Blocks until geth adds the specified peer, using [`GETH_DIAL_LOOP_TIMEOUT`] as the timeout.
+    /// Blocks until geth adds the specified peer, using 20s as the timeout.
     pub fn wait_to_add_peer(&mut self, id: H256) -> Result<(), GethInstanceError> {
         let mut stderr = self.pid.stderr.as_mut().ok_or(GethInstanceError::NoStderr)?;
         let mut err_reader = BufReader::new(&mut stderr);
@@ -94,7 +94,7 @@ impl GethInstance {
                 return Ok(())
             }
         }
-        Err(GethInstanceError::Timeout("Timed out waiting for dial loop to start".into()))
+        Err(GethInstanceError::Timeout("Timed out waiting for geth to add a peer".into()))
     }
 }
 

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -98,10 +98,7 @@ pub struct PrivateNetOptions {
 
 impl Default for PrivateNetOptions {
     fn default() -> Self {
-        Self {
-            p2p_port: None,
-            discovery: true,
-        }
+        Self { p2p_port: None, discovery: true }
     }
 }
 
@@ -156,10 +153,12 @@ impl Geth {
     #[must_use]
     pub fn p2p_port(mut self, port: u16) -> Self {
         match self.mode {
-            GethMode::Dev(_) => self.mode = GethMode::NonDev(PrivateNetOptions {
-                p2p_port: Some(port),
-                ..Default::default()
-            }),
+            GethMode::Dev(_) => {
+                self.mode = GethMode::NonDev(PrivateNetOptions {
+                    p2p_port: Some(port),
+                    ..Default::default()
+                })
+            }
             GethMode::NonDev(ref mut opts) => opts.p2p_port = Some(port),
         }
         self
@@ -189,10 +188,10 @@ impl Geth {
     #[must_use]
     pub fn disable_discovery(mut self) -> Self {
         match self.mode {
-            GethMode::Dev(_) => self.mode = GethMode::NonDev(PrivateNetOptions {
-                discovery: false,
-                ..Default::default()
-            }),
+            GethMode::Dev(_) => {
+                self.mode =
+                    GethMode::NonDev(PrivateNetOptions { discovery: false, ..Default::default() })
+            }
             GethMode::NonDev(ref mut opts) => opts.discovery = false,
         }
         self

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -339,22 +339,20 @@ impl Geth {
                     cmd.arg("--dev.period").arg(block_time.to_string());
                 }
             }
-            GethMode::NonDev(PrivateNetOptions { p2p_port, .. }) => {
+            GethMode::NonDev(PrivateNetOptions { p2p_port, discovery }) => {
                 if let Some(p2p_port) = p2p_port {
                     cmd.arg("--port").arg(p2p_port.to_string());
+                }
+
+                // disable discovery if the flag is set
+                if !discovery {
+                    cmd.arg("--nodiscover");
                 }
             }
         }
 
         if let Some(chain_id) = self.chain_id {
             cmd.arg("--networkid").arg(chain_id.to_string());
-        }
-
-        // disable discovery if the flag is set
-        if let GethMode::NonDev(PrivateNetOptions { discovery, .. }) = self.mode {
-            if !discovery {
-                cmd.arg("--nodiscover");
-            }
         }
 
         // debug verbosity is needed to check when peers are added
@@ -390,7 +388,9 @@ impl Geth {
 
             // geth 1.9.23 uses "server started" while 1.9.18 uses "endpoint opened"
             // the unauthenticated api is used for regular non-engine API requests
-            if line.contains("HTTP endpoint opened") || (line.contains("HTTP server started") && !line.contains("auth=true")) {
+            if line.contains("HTTP endpoint opened") ||
+                (line.contains("HTTP server started") && !line.contains("auth=true"))
+            {
                 http_started = true;
             }
 

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -481,8 +481,8 @@ where
     }
 }
 
-/// Deserializes the input into an Option<U256>, using [`from_int_or_hex`] to deserialize the inner
-/// value.
+/// Deserializes the input into an `Option<U256>`, using [`from_int_or_hex`] to deserialize the
+/// inner value.
 pub fn from_int_or_hex_opt<'de, D>(deserializer: D) -> Result<Option<U256>, D::Error>
 where
     D: Deserializer<'de>,

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -11,9 +11,7 @@ mod geth;
 pub use geth::{Geth, GethInstance};
 
 /// Utilities for working with a `genesis.json` and other chain config structs.
-#[cfg(not(target_arch = "wasm32"))]
 mod genesis;
-#[cfg(not(target_arch = "wasm32"))]
 pub use genesis::{ChainConfig, Genesis};
 
 /// Utilities for launching an anvil instance

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -466,18 +466,14 @@ where
 {
     #[derive(Deserialize)]
     #[serde(untagged)]
-    enum IntOrHexOrBigNum {
-        Int(u64),
+    enum IntOrHex {
+        Int(serde_json::Number),
         Hex(String),
-        BigNumber(serde_json::Number),
     }
 
-    match IntOrHexOrBigNum::deserialize(deserializer)? {
-        IntOrHexOrBigNum::Int(n) => Ok(U256::from(n)),
-        IntOrHexOrBigNum::Hex(s) => U256::from_str(s.as_str()).map_err(serde::de::Error::custom),
-        IntOrHexOrBigNum::BigNumber(b) => {
-            U256::from_dec_str(&b.to_string()).map_err(serde::de::Error::custom)
-        }
+    match IntOrHex::deserialize(deserializer)? {
+        IntOrHex::Hex(s) => U256::from_str(s.as_str()).map_err(serde::de::Error::custom),
+        IntOrHex::Int(n) => U256::from_dec_str(&n.to_string()).map_err(serde::de::Error::custom),
     }
 }
 

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -41,8 +41,8 @@ use ethabi::ethereum_types::FromDecStrErr;
 use k256::{ecdsa::SigningKey, PublicKey as K256PublicKey};
 use std::{
     convert::{TryFrom, TryInto},
-    str::FromStr,
     fmt,
+    str::FromStr,
 };
 use thiserror::Error;
 

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -9,8 +9,11 @@ pub use ganache::{Ganache, GanacheInstance};
 mod geth;
 #[cfg(not(target_arch = "wasm32"))]
 pub use geth::{Geth, GethInstance};
+
+/// Utilities for working with a `genesis.json` and other chain config structs.
 #[cfg(not(target_arch = "wasm32"))]
 mod genesis;
+#[cfg(not(target_arch = "wasm32"))]
 pub use genesis::{ChainConfig, Genesis};
 
 /// Utilities for launching an anvil instance

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -9,6 +9,9 @@ pub use ganache::{Ganache, GanacheInstance};
 mod geth;
 #[cfg(not(target_arch = "wasm32"))]
 pub use geth::{Geth, GethInstance};
+#[cfg(not(target_arch = "wasm32"))]
+mod genesis;
+pub use genesis::{ChainConfig, Genesis};
 
 /// Utilities for launching an anvil instance
 #[cfg(not(target_arch = "wasm32"))]

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -35,6 +35,9 @@ futures-timer = { version = "3.0.2", default-features = false }
 futures-channel = { version = "0.3.16", default-features = false, optional = true }
 pin-project = { version = "1.0.11", default-features = false }
 
+# peer-related amin namespace
+enr = { version = "0.7.0", default-features = false, features = ["k256", "serde"] }
+
 # tracing
 tracing = { version = "0.1.37", default-features = false }
 tracing-futures = { version = "0.2.5", default-features = false, features = ["std-future"] }

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -35,7 +35,7 @@ futures-timer = { version = "3.0.2", default-features = false }
 futures-channel = { version = "0.3.16", default-features = false, optional = true }
 pin-project = { version = "1.0.11", default-features = false }
 
-# peer-related amin namespace
+# peer-related admin namespace
 enr = { version = "0.7.0", default-features = false, features = ["k256", "serde"] }
 
 # tracing

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -187,7 +187,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn deserialize_peer_info_version() {
+    fn deserialize_peer_info() {
         let response = r#"{
             "enode":"enode://bb37b7302f79e47c1226d6e3ccf0ef6d51146019efdcc1f6e861fd1c1a78d5e84e486225a6a8a503b93d5c50125ee980835c92bde7f7d12f074c16f4e439a578@127.0.0.1:60872",
             "id":"ca23c04b7e796da5d6a5f04a62b81c88d41b1341537db85a2b6443e838d8339b",
@@ -215,7 +215,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialize_node_info_network() {
+    fn deserialize_node_info() {
         // this response also has an enr
         let response = r#"{
             "id":"6e2fe698f3064cd99410926ce16734e35e3cc947d4354461d2594f2d2dd9f7b6",
@@ -236,6 +236,41 @@ mod tests {
                     "config":{
                         "chainId":0,
                         "eip150Hash":"0x0000000000000000000000000000000000000000000000000000000000000000"
+                    },
+                    "head":"0xb04009ddf4b0763f42778e7d5937e49bebf1e11b2d26c9dac6cefb5f84b6f8ea"
+                },
+                "snap":{}
+            }
+        }"#;
+
+        let _: NodeInfo = serde_json::from_str(response).unwrap();
+    }
+
+    #[test]
+    fn deserialize_node_info_post_merge() {
+        // this response also has an enr
+        let response = r#"{
+            "id":"6e2fe698f3064cd99410926ce16734e35e3cc947d4354461d2594f2d2dd9f7b6",
+            "name":"Geth/v1.10.19-stable/darwin-arm64/go1.18.3",
+            "enode":"enode://d7dfaea49c7ef37701e668652bcf1bc63d3abb2ae97593374a949e175e4ff128730a2f35199f3462a56298b981dfc395a5abebd2d6f0284ffe5bdc3d8e258b86@***REMOVED***:30304?discport=0",
+            "enr":"enr:-Jy4QIvS0dKBLjTTV_RojS8hjriwWsJNHRVyOh4Pk4aUXc5SZjKRVIOeYc7BqzEmbCjLdIY4Ln7x5ZPf-2SsBAc2_zqGAYSwY1zog2V0aMfGhNegsXuAgmlkgnY0gmlwhBiT_DiJc2VjcDI1NmsxoQLX366knH7zdwHmaGUrzxvGPTq7Kul1kzdKlJ4XXk_xKIRzbmFwwIN0Y3CCdmA",
+            "ip":"***REMOVED***",
+            "ports":{
+                "discovery":0,
+                "listener":30304
+            },
+            "listenAddr":"[::]:30304",
+            "protocols":{
+                "eth":{
+                    "network":1337,
+                    "difficulty":0,
+                    "genesis":"0xb04009ddf4b0763f42778e7d5937e49bebf1e11b2d26c9dac6cefb5f84b6f8ea",
+                    "config":{
+                        "chainId":0,
+                        "eip150Hash":"0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "terminalTotalDifficulty":58750000000000000000000,
+                        "terminalTotalDifficultyPassed":true,
+                        "ethash":{}
                     },
                     "head":"0xb04009ddf4b0763f42778e7d5937e49bebf1e11b2d26c9dac6cefb5f84b6f8ea"
                 },

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -1,5 +1,6 @@
 use crate::{H256, U256};
 use enr::{k256::ecdsa::SigningKey, Enr};
+use ethers_core::utils::from_int_or_hex;
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, SocketAddr};
 
@@ -26,10 +27,11 @@ pub struct NodeInfo {
     pub ports: Ports,
 
     /// The client's listening address.
+    #[serde(rename = "listenAddr")]
     pub listen_addr: String,
 
     /// The protocols that the client supports, with protocol metadata.
-    pub protocols: Vec<ProtocolInfo>,
+    pub protocols: ProtocolInfo,
 }
 
 /// Represents a node's discovery and listener ports.
@@ -42,11 +44,11 @@ pub struct Ports {
     pub listener: u16,
 }
 
-/// Represents a protocol that the client supports.
+/// Represents the protocols that the client supports.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub enum ProtocolInfo {
-    Eth(Box<EthProtocolInfo>),
-    Snap(Box<SnapProtocolInfo>),
+pub struct ProtocolInfo {
+    pub eth: Option<EthProtocolInfo>,
+    pub snap: Option<SnapProtocolInfo>,
 }
 
 /// Represents a short summary of the `eth` sub-protocol metadata known about the host peer.
@@ -60,6 +62,7 @@ pub struct EthProtocolInfo {
     pub network: u64,
 
     /// The total difficulty of the host's blockchain.
+    #[serde(deserialize_with = "from_int_or_hex")]
     pub difficulty: U256,
 
     /// The Keccak hash of the host's genesis block.
@@ -80,73 +83,96 @@ pub struct EthProtocolInfo {
 pub struct SnapProtocolInfo {}
 
 /// Represents a node's chain configuration.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[serde(default)]
 pub struct ChainConfig {
     /// The network's chain ID.
+    #[serde(rename = "chainId")]
     pub chain_id: u64,
 
     /// The homestead switch block (None = no fork, 0 = already homestead).
+    #[serde(rename = "homesteadBlock")]
     pub homestead_block: Option<u64>,
 
     /// The DAO fork switch block (None = no fork).
+    #[serde(rename = "daoForkBlock")]
     pub dao_fork_block: Option<u64>,
 
     /// Whether or not the node supports the DAO hard-fork.
+    #[serde(rename = "daoForkSupport")]
     pub dao_fork_support: bool,
 
     /// The EIP-150 hard fork block (None = no fork).
+    #[serde(rename = "eip150Block")]
     pub eip150_block: Option<u64>,
 
     /// The EIP-150 hard fork hash.
+    #[serde(rename = "eip150Hash")]
     pub eip150_hash: Option<H256>,
 
     /// The EIP-155 hard fork block.
+    #[serde(rename = "eip155Block")]
     pub eip155_block: Option<u64>,
 
     /// The EIP-158 hard fork block.
+    #[serde(rename = "eip158Block")]
     pub eip158_block: Option<u64>,
 
     /// The Byzantium hard fork block.
+    #[serde(rename = "byzantiumBlock")]
     pub byzantium_block: Option<u64>,
 
     /// The Constantinople hard fork block.
+    #[serde(rename = "constantinopleBlock")]
     pub constantinople_block: Option<u64>,
 
     /// The Petersburg hard fork block.
+    #[serde(rename = "petersburgBlock")]
     pub petersburg_block: Option<u64>,
 
     /// The Istanbul hard fork block.
+    #[serde(rename = "istanbulBlock")]
     pub istanbul_block: Option<u64>,
 
     /// The Muir Glacier hard fork block.
+    #[serde(rename = "muirGlacierBlock")]
     pub muir_glacier_block: Option<u64>,
 
     /// The Berlin hard fork block.
+    #[serde(rename = "berlinBlock")]
     pub berlin_block: Option<u64>,
 
     /// The London hard fork block.
+    #[serde(rename = "londonBlock")]
     pub london_block: Option<u64>,
 
     /// The Arrow Glacier hard fork block.
+    #[serde(rename = "arrowGlacierBlock")]
     pub arrow_glacier_block: Option<u64>,
 
     /// The Gray Glacier hard fork block.
+    #[serde(rename = "grayGlacierBlock")]
     pub gray_glacier_block: Option<u64>,
 
     /// Virtual fork after the merge to use as a network splitter.
+    #[serde(rename = "mergeNetsplitBlock")]
     pub merge_netsplit_block: Option<u64>,
 
     /// The Shanghai hard fork block.
+    #[serde(rename = "shanghaiBlock")]
     pub shanghai_block: Option<u64>,
 
     /// The Cancun hard fork block.
+    #[serde(rename = "cancunBlock")]
     pub cancun_block: Option<u64>,
 
     /// Total difficulty reached that triggers the merge consensus upgrade.
+    #[serde(rename = "terminalTotalDifficulty")]
     pub terminal_total_difficulty: Option<U256>,
 
     /// A flag specifying that the network already passed the terminal total difficulty. Its
     /// purpose is to disable legacy sync without having seen the TTD locally.
+    #[serde(rename = "terminalTotalDifficultyPassed")]
     pub terminal_total_difficulty_passed: bool,
 
     /// Ethash parameters.

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -280,4 +280,53 @@ mod tests {
 
         let _: NodeInfo = serde_json::from_str(response).unwrap();
     }
+
+    #[test]
+    fn deserialize_node_info_mainnet_full() {
+        let actual_response = r#"{
+            "id": "74477ca052fcf55ee9eafb369fafdb3e91ad7b64fbd7ae15a4985bfdc43696f2",
+            "name": "Geth/v1.10.26-stable/darwin-arm64/go1.19.3",
+            "enode": "enode://962184c6f2a19e064e2ddf0d5c5a788c8c5ed3a4909b7f75fb4dad967392ff542772bcc498cd7f15e13eecbde830265f379779c6da1f71fb8fe1a4734dfc0a1e@127.0.0.1:13337?discport=0",
+            "enr": "enr:-J-4QFttJyL3f2-B2TQmBZNFxex99TSBv1YtB_8jqUbXWkf6LOREKQAPW2bIn8kJ8QvHbWxCQNFzTX6sehjbrz1ZkSuGAYSyQ0_rg2V0aMrJhPxk7ASDEYwwgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQKWIYTG8qGeBk4t3w1cWniMjF7TpJCbf3X7Ta2Wc5L_VIRzbmFwwIN0Y3CCNBk",
+            "ip": "127.0.0.1",
+            "ports": {
+                "discovery": 0,
+                "listener": 13337
+            },
+            "listenAddr": "[::]:13337",
+            "protocols": {
+                "eth": {
+                    "network": 1337,
+                    "difficulty": 17179869184,
+                    "genesis": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
+                    "config": {
+                        "chainId": 1,
+                        "homesteadBlock": 1150000,
+                        "daoForkBlock": 1920000,
+                        "daoForkSupport": true,
+                        "eip150Block": 2463000,
+                        "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
+                        "eip155Block": 2675000,
+                        "eip158Block": 2675000,
+                        "byzantiumBlock": 4370000,
+                        "constantinopleBlock": 7280000,
+                        "petersburgBlock": 7280000,
+                        "istanbulBlock": 9069000,
+                        "muirGlacierBlock": 9200000,
+                        "berlinBlock": 12244000,
+                        "londonBlock": 12965000,
+                        "arrowGlacierBlock": 13773000,
+                        "grayGlacierBlock": 15050000,
+                        "terminalTotalDifficulty": 58750000000000000000000,
+                        "terminalTotalDifficultyPassed": true,
+                        "ethash": {}
+                    },
+                    "head": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+                },
+                "snap": {}
+            }
+        }"#;
+
+        let _: NodeInfo = serde_json::from_str(actual_response).unwrap();
+    }
 }

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -1,0 +1,151 @@
+use crate::{H256, U256};
+use enr::{k256::ecdsa::SigningKey, Enr};
+use serde::{Deserialize, Serialize};
+use std::net::{IpAddr, SocketAddr};
+
+/// This includes general information about a running node, spanning networking and protocol
+/// details.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct NodeInfo {
+    /// TODO: docs - what kind of key is this?
+    pub id: String,
+
+    /// The client user agent, containing a client name, version, OS, and other metadata.
+    pub name: String,
+
+    /// The enode URL of the running client.
+    pub enode: String,
+
+    /// The [ENR](https://eips.ethereum.org/EIPS/eip-778) of the running client.
+    pub enr: Enr<SigningKey>,
+
+    /// The IP address of the running client.
+    pub ip: IpAddr,
+
+    /// The client's listening ports.
+    pub ports: Ports,
+
+    /// The client's listening address.
+    pub listen_addr: String,
+
+    /// The protocols that the client supports, with protocol metadata.
+    pub protocols: Vec<ProtocolInfo>,
+}
+
+/// Represents a node's discovery and listener ports.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Ports {
+    /// The discovery port of the running client.
+    pub discovery: u16,
+
+    /// The listener port of the running client.
+    pub listener: u16,
+}
+
+/// Represents a protocol that the client supports.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ProtocolInfo {
+    Eth(EthProtocolInfo),
+    Snap(SnapProtocolInfo),
+}
+
+/// Represents a short summary of the `eth` sub-protocol metadata known about the host peer.
+///
+/// See [geth's `NodeInfo`
+/// struct](https://github.com/ethereum/go-ethereum/blob/c2e0abce2eedc1ba2a1b32c46fd07ef18a25354a/eth/protocols/eth/handler.go#L129)
+/// for how these fields are determined.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EthProtocolInfo {
+    /// The ethereum network ID.
+    pub network: u64,
+
+    /// The total difficulty of the host's blockchain.
+    pub difficulty: U256,
+
+    /// The Keccak hash of the host's genesis block.
+    pub genesis: H256,
+
+    /// The chain configuration for the host's fork rules.
+    pub config: ChainConfig,
+
+    /// The hash of the host's best known block.
+    pub head: H256,
+}
+
+/// Represents a short summary of the `snap` sub-protocol metadata known about the host peer.
+///
+/// This is just an empty struct, because [geth's internal representation is
+/// empty](https://github.com/ethereum/go-ethereum/blob/c2e0abce2eedc1ba2a1b32c46fd07ef18a25354a/eth/protocols/snap/handler.go#L571-L576).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SnapProtocolInfo {}
+
+/// Represents a node's chain configuration.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ChainConfig {
+    /// The network's chain ID.
+    pub chain_id: u64,
+
+    /// The homestead switch block (None = no fork, 0 = already homestead).
+    pub homestead_block: Option<u64>,
+
+    /// The DAO fork switch block (None = no fork).
+    pub dao_fork_block: Option<u64>,
+
+    /// Whether or not the node supports the DAO hard-fork.
+    pub dao_fork_support: bool,
+
+    /// The EIP-150 hard fork block (None = no fork).
+    pub eip150_block: Option<u64>,
+
+    /// The EIP-150 hard fork hash.
+    // TODO: confirm that this is the right type - should it be an Option?
+    pub eip150_hash: H256,
+
+    /// The EIP-155 hard fork block.
+    pub eip155_block: Option<u64>,
+    // TODO: rest
+}
+
+/// Represents a short summary of information known about a connected peer.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PeerInfo {
+    /// The peer's ENR.
+    pub enr: Option<Enr<SigningKey>>,
+
+    /// The peer's enode URL.
+    pub enode: String,
+
+    /// The peer's network ID.
+    pub id: String,
+
+    /// The peer's name.
+    pub name: String,
+
+    /// The peer's capabilities.
+    pub caps: Vec<String>,
+
+    pub network: PeerNetworkInfo,
+
+    /// The protocols that the peer supports, with protocol metadata.
+    pub protocols: Vec<ProtocolInfo>,
+}
+
+/// Represents networking related information about the peer, including details about whether or
+/// not it is inbound, trusted, or static.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PeerNetworkInfo {
+    /// The local endpoint of the TCP connection.
+    pub local_address: SocketAddr,
+
+    /// The remote endpoint of the TCP connection.
+    pub remote_address: SocketAddr,
+
+    /// Whether or not the peer is inbound.
+    pub inbound: bool,
+
+    /// Whether or not the peer is trusted.
+    pub trusted: bool,
+
+    /// Whether or not the peer is a static peer.
+    pub static_node: bool,
+}

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -45,8 +45,8 @@ pub struct Ports {
 /// Represents a protocol that the client supports.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum ProtocolInfo {
-    Eth(EthProtocolInfo),
-    Snap(SnapProtocolInfo),
+    Eth(Box<EthProtocolInfo>),
+    Snap(Box<SnapProtocolInfo>),
 }
 
 /// Represents a short summary of the `eth` sub-protocol metadata known about the host peer.
@@ -98,12 +98,62 @@ pub struct ChainConfig {
     pub eip150_block: Option<u64>,
 
     /// The EIP-150 hard fork hash.
-    // TODO: confirm that this is the right type - should it be an Option?
-    pub eip150_hash: H256,
+    pub eip150_hash: Option<H256>,
 
     /// The EIP-155 hard fork block.
     pub eip155_block: Option<u64>,
-    // TODO: rest
+
+    /// The EIP-158 hard fork block.
+    pub eip158_block: Option<u64>,
+
+    /// The Byzantium hard fork block.
+    pub byzantium_block: Option<u64>,
+
+    /// The Constantinople hard fork block.
+    pub constantinople_block: Option<u64>,
+
+    /// The Petersburg hard fork block.
+    pub petersburg_block: Option<u64>,
+
+    /// The Istanbul hard fork block.
+    pub istanbul_block: Option<u64>,
+
+    /// The Muir Glacier hard fork block.
+    pub muir_glacier_block: Option<u64>,
+
+    /// The Berlin hard fork block.
+    pub berlin_block: Option<u64>,
+
+    /// The London hard fork block.
+    pub london_block: Option<u64>,
+
+    /// The Arrow Glacier hard fork block.
+    pub arrow_glacier_block: Option<u64>,
+
+    /// The Gray Glacier hard fork block.
+    pub gray_glacier_block: Option<u64>,
+
+    /// Virtual fork after the merge to use as a network splitter.
+    pub merge_netsplit_block: Option<u64>,
+
+    /// The Shanghai hard fork block.
+    pub shanghai_block: Option<u64>,
+
+    /// The Cancun hard fork block.
+    pub cancun_block: Option<u64>,
+
+    /// Total difficulty reached that triggers the merge consensus upgrade.
+    pub terminal_total_difficulty: Option<U256>,
+
+    /// A flag specifying that the network already passed the terminal total difficulty. Its
+    /// purpose is to disable legacy sync without having seen the TTD locally.
+    pub terminal_total_difficulty_passed: bool,
+
+    /// Ethash parameters.
+    pub ethash: Option<EthashConfig>,
+
+    /// Clique parameters.
+    pub clique: Option<CliqueConfig>,
 }
 
 /// Represents a short summary of information known about a connected peer.
@@ -124,6 +174,7 @@ pub struct PeerInfo {
     /// The peer's capabilities.
     pub caps: Vec<String>,
 
+    /// Networking information about the peer.
     pub network: PeerNetworkInfo,
 
     /// The protocols that the peer supports, with protocol metadata.
@@ -148,4 +199,18 @@ pub struct PeerNetworkInfo {
 
     /// Whether or not the peer is a static peer.
     pub static_node: bool,
+}
+
+/// Empty consensus configuration for proof-of-work networks.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EthashConfig {}
+
+/// Consensus configuration for Clique.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CliqueConfig {
+    /// Number of seconds between blocks to enforce.
+    pub period: u64,
+
+    /// Epoch length to reset votes and checkpoints.
+    pub epoch: u64,
 }

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -8,8 +8,8 @@ use std::net::{IpAddr, SocketAddr};
 /// details.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NodeInfo {
-    /// TODO: docs - what kind of key is this?
-    pub id: String,
+    /// The node's secp256k1 public key.
+    pub id: H256,
 
     /// The client user agent, containing a client name, version, OS, and other metadata.
     pub name: String,
@@ -84,95 +84,73 @@ pub struct SnapProtocolInfo {}
 
 /// Represents a node's chain configuration.
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
-#[serde(default)]
+#[serde(default, rename_all = "camelCase")]
 pub struct ChainConfig {
     /// The network's chain ID.
-    #[serde(rename = "chainId")]
     pub chain_id: u64,
 
     /// The homestead switch block (None = no fork, 0 = already homestead).
-    #[serde(rename = "homesteadBlock")]
     pub homestead_block: Option<u64>,
 
     /// The DAO fork switch block (None = no fork).
-    #[serde(rename = "daoForkBlock")]
     pub dao_fork_block: Option<u64>,
 
     /// Whether or not the node supports the DAO hard-fork.
-    #[serde(rename = "daoForkSupport")]
     pub dao_fork_support: bool,
 
     /// The EIP-150 hard fork block (None = no fork).
-    #[serde(rename = "eip150Block")]
     pub eip150_block: Option<u64>,
 
     /// The EIP-150 hard fork hash.
-    #[serde(rename = "eip150Hash")]
     pub eip150_hash: Option<H256>,
 
     /// The EIP-155 hard fork block.
-    #[serde(rename = "eip155Block")]
     pub eip155_block: Option<u64>,
 
     /// The EIP-158 hard fork block.
-    #[serde(rename = "eip158Block")]
     pub eip158_block: Option<u64>,
 
     /// The Byzantium hard fork block.
-    #[serde(rename = "byzantiumBlock")]
     pub byzantium_block: Option<u64>,
 
     /// The Constantinople hard fork block.
-    #[serde(rename = "constantinopleBlock")]
     pub constantinople_block: Option<u64>,
 
     /// The Petersburg hard fork block.
-    #[serde(rename = "petersburgBlock")]
     pub petersburg_block: Option<u64>,
 
     /// The Istanbul hard fork block.
-    #[serde(rename = "istanbulBlock")]
     pub istanbul_block: Option<u64>,
 
     /// The Muir Glacier hard fork block.
-    #[serde(rename = "muirGlacierBlock")]
     pub muir_glacier_block: Option<u64>,
 
     /// The Berlin hard fork block.
-    #[serde(rename = "berlinBlock")]
     pub berlin_block: Option<u64>,
 
     /// The London hard fork block.
-    #[serde(rename = "londonBlock")]
     pub london_block: Option<u64>,
 
     /// The Arrow Glacier hard fork block.
-    #[serde(rename = "arrowGlacierBlock")]
     pub arrow_glacier_block: Option<u64>,
 
     /// The Gray Glacier hard fork block.
-    #[serde(rename = "grayGlacierBlock")]
     pub gray_glacier_block: Option<u64>,
 
     /// Virtual fork after the merge to use as a network splitter.
-    #[serde(rename = "mergeNetsplitBlock")]
     pub merge_netsplit_block: Option<u64>,
 
     /// The Shanghai hard fork block.
-    #[serde(rename = "shanghaiBlock")]
     pub shanghai_block: Option<u64>,
 
     /// The Cancun hard fork block.
-    #[serde(rename = "cancunBlock")]
     pub cancun_block: Option<u64>,
 
     /// Total difficulty reached that triggers the merge consensus upgrade.
-    #[serde(rename = "terminalTotalDifficulty")]
     pub terminal_total_difficulty: Option<U256>,
 
     /// A flag specifying that the network already passed the terminal total difficulty. Its
     /// purpose is to disable legacy sync without having seen the TTD locally.
-    #[serde(rename = "terminalTotalDifficultyPassed")]
     pub terminal_total_difficulty_passed: bool,
 
     /// Ethash parameters.
@@ -186,6 +164,7 @@ pub struct ChainConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PeerInfo {
     /// The peer's ENR.
+    #[serde(default)]
     pub enr: Option<Enr<SigningKey>>,
 
     /// The peer's enode URL.
@@ -210,6 +189,7 @@ pub struct PeerInfo {
 /// Represents networking related information about the peer, including details about whether or
 /// not it is inbound, trusted, or static.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PeerNetworkInfo {
     /// The local endpoint of the TCP connection.
     pub local_address: SocketAddr,

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -1,6 +1,6 @@
 use crate::{H256, U256};
 use enr::{k256::ecdsa::SigningKey, Enr};
-use ethers_core::utils::from_int_or_hex;
+use ethers_core::utils::{from_int_or_hex, ChainConfig};
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, SocketAddr};
 
@@ -82,88 +82,6 @@ pub struct EthProtocolInfo {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SnapProtocolInfo {}
 
-/// Represents a node's chain configuration.
-///
-/// See [geth's `ChainConfig`
-/// struct](https://github.com/ethereum/go-ethereum/blob/64dccf7aa411c5c7cd36090c3d9b9892945ae813/params/config.go#L349)
-/// for the source of each field.
-#[derive(Clone, Debug, Deserialize, Serialize, Default)]
-#[serde(default, rename_all = "camelCase")]
-pub struct ChainConfig {
-    /// The network's chain ID.
-    pub chain_id: u64,
-
-    /// The homestead switch block (None = no fork, 0 = already homestead).
-    pub homestead_block: Option<u64>,
-
-    /// The DAO fork switch block (None = no fork).
-    pub dao_fork_block: Option<u64>,
-
-    /// Whether or not the node supports the DAO hard-fork.
-    pub dao_fork_support: bool,
-
-    /// The EIP-150 hard fork block (None = no fork).
-    pub eip150_block: Option<u64>,
-
-    /// The EIP-150 hard fork hash.
-    pub eip150_hash: Option<H256>,
-
-    /// The EIP-155 hard fork block.
-    pub eip155_block: Option<u64>,
-
-    /// The EIP-158 hard fork block.
-    pub eip158_block: Option<u64>,
-
-    /// The Byzantium hard fork block.
-    pub byzantium_block: Option<u64>,
-
-    /// The Constantinople hard fork block.
-    pub constantinople_block: Option<u64>,
-
-    /// The Petersburg hard fork block.
-    pub petersburg_block: Option<u64>,
-
-    /// The Istanbul hard fork block.
-    pub istanbul_block: Option<u64>,
-
-    /// The Muir Glacier hard fork block.
-    pub muir_glacier_block: Option<u64>,
-
-    /// The Berlin hard fork block.
-    pub berlin_block: Option<u64>,
-
-    /// The London hard fork block.
-    pub london_block: Option<u64>,
-
-    /// The Arrow Glacier hard fork block.
-    pub arrow_glacier_block: Option<u64>,
-
-    /// The Gray Glacier hard fork block.
-    pub gray_glacier_block: Option<u64>,
-
-    /// Virtual fork after the merge to use as a network splitter.
-    pub merge_netsplit_block: Option<u64>,
-
-    /// The Shanghai hard fork block.
-    pub shanghai_block: Option<u64>,
-
-    /// The Cancun hard fork block.
-    pub cancun_block: Option<u64>,
-
-    /// Total difficulty reached that triggers the merge consensus upgrade.
-    pub terminal_total_difficulty: Option<U256>,
-
-    /// A flag specifying that the network already passed the terminal total difficulty. Its
-    /// purpose is to disable legacy sync without having seen the TTD locally.
-    pub terminal_total_difficulty_passed: bool,
-
-    /// Ethash parameters.
-    pub ethash: Option<EthashConfig>,
-
-    /// Clique parameters.
-    pub clique: Option<CliqueConfig>,
-}
-
 /// Represents a short summary of information known about a connected peer.
 ///
 /// See [geth's `PeerInfo` struct](https://github.com/ethereum/go-ethereum/blob/64dccf7aa411c5c7cd36090c3d9b9892945ae813/p2p/peer.go#L484) for the source of each field.
@@ -211,18 +129,4 @@ pub struct PeerNetworkInfo {
 
     /// Whether or not the peer is a static peer.
     pub static_node: bool,
-}
-
-/// Empty consensus configuration for proof-of-work networks.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct EthashConfig {}
-
-/// Consensus configuration for Clique.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct CliqueConfig {
-    /// Number of seconds between blocks to enforce.
-    pub period: u64,
-
-    /// Epoch length to reset votes and checkpoints.
-    pub epoch: u64,
 }

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -240,3 +240,33 @@ pub struct CliqueConfig {
     /// Epoch length to reset votes and checkpoints.
     pub epoch: u64,
 }
+
+/// An event emitted by geth when a peer is added or removed, or when a message is sent or
+/// received.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PeerEvent {
+    /// The type of event.
+    #[serde(rename = "type")]
+    pub event_type: String,
+
+    /// The peer's enode ID.
+    pub peer: String,
+
+    /// The error associated with the event.
+    pub error: Option<String>,
+
+    /// The protocol associated with the event.
+    pub protocol: Option<String>,
+
+    /// The message code.
+    pub msg_code: Option<u64>,
+
+    /// The message size.
+    pub msg_size: Option<u64>,
+
+    /// The local address of the peer.
+    pub local_address: Option<SocketAddr>,
+
+    /// The remote address of the peer.
+    pub remote_address: Option<SocketAddr>,
+}

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -165,6 +165,8 @@ pub struct ChainConfig {
 }
 
 /// Represents a short summary of information known about a connected peer.
+///
+/// See [geth's `PeerInfo` struct](https://github.com/ethereum/go-ethereum/blob/64dccf7aa411c5c7cd36090c3d9b9892945ae813/p2p/peer.go#L484) for the source of each field.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PeerInfo {
     /// The peer's ENR.

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -107,7 +107,7 @@ pub struct PeerInfo {
     pub network: PeerNetworkInfo,
 
     /// The protocols that the peer supports, with protocol metadata.
-    pub protocols: Vec<ProtocolInfo>,
+    pub protocols: ProtocolInfo,
 }
 
 /// Represents networking related information about the peer, including details about whether or
@@ -128,5 +128,6 @@ pub struct PeerNetworkInfo {
     pub trusted: bool,
 
     /// Whether or not the peer is a static peer.
+    #[serde(rename = "static")]
     pub static_node: bool,
 }

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -8,8 +8,7 @@ use std::net::{IpAddr, SocketAddr};
 /// details.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NodeInfo {
-    // TODO: double check that this is a public key
-    /// The node's secp256k1 public key.
+    /// The node's private key.
     pub id: H256,
 
     /// The node's user agent, containing a client name, version, OS, and other metadata.
@@ -143,9 +142,8 @@ pub struct PeerInfo {
     /// The peer's enode URL.
     pub enode: String,
 
-    // TODO: unify comment with the one in `NodeInfo`
     /// The peer's enode ID.
-    pub id: H256,
+    pub id: String,
 
     /// The peer's name.
     pub name: String,

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -83,6 +83,10 @@ pub struct EthProtocolInfo {
 pub struct SnapProtocolInfo {}
 
 /// Represents a node's chain configuration.
+///
+/// See [geth's `ChainConfig`
+/// struct](https://github.com/ethereum/go-ethereum/blob/64dccf7aa411c5c7cd36090c3d9b9892945ae813/params/config.go#L349)
+/// for the source of each field.
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 #[serde(default, rename_all = "camelCase")]
 pub struct ChainConfig {

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -220,9 +220,9 @@ mod tests {
         let response = r#"{
             "id":"6e2fe698f3064cd99410926ce16734e35e3cc947d4354461d2594f2d2dd9f7b6",
             "name":"Geth/v1.10.19-stable/darwin-arm64/go1.18.3",
-            "enode":"enode://d7dfaea49c7ef37701e668652bcf1bc63d3abb2ae97593374a949e175e4ff128730a2f35199f3462a56298b981dfc395a5abebd2d6f0284ffe5bdc3d8e258b86@***REMOVED***:30304?discport=0",
+            "enode":"enode://d7dfaea49c7ef37701e668652bcf1bc63d3abb2ae97593374a949e175e4ff128730a2f35199f3462a56298b981dfc395a5abebd2d6f0284ffe5bdc3d8e258b86@127.0.0.1:30304?discport=0",
             "enr":"enr:-Jy4QIvS0dKBLjTTV_RojS8hjriwWsJNHRVyOh4Pk4aUXc5SZjKRVIOeYc7BqzEmbCjLdIY4Ln7x5ZPf-2SsBAc2_zqGAYSwY1zog2V0aMfGhNegsXuAgmlkgnY0gmlwhBiT_DiJc2VjcDI1NmsxoQLX366knH7zdwHmaGUrzxvGPTq7Kul1kzdKlJ4XXk_xKIRzbmFwwIN0Y3CCdmA",
-            "ip":"***REMOVED***",
+            "ip":"127.0.0.1",
             "ports":{
                 "discovery":0,
                 "listener":30304
@@ -252,9 +252,9 @@ mod tests {
         let response = r#"{
             "id":"6e2fe698f3064cd99410926ce16734e35e3cc947d4354461d2594f2d2dd9f7b6",
             "name":"Geth/v1.10.19-stable/darwin-arm64/go1.18.3",
-            "enode":"enode://d7dfaea49c7ef37701e668652bcf1bc63d3abb2ae97593374a949e175e4ff128730a2f35199f3462a56298b981dfc395a5abebd2d6f0284ffe5bdc3d8e258b86@***REMOVED***:30304?discport=0",
+            "enode":"enode://d7dfaea49c7ef37701e668652bcf1bc63d3abb2ae97593374a949e175e4ff128730a2f35199f3462a56298b981dfc395a5abebd2d6f0284ffe5bdc3d8e258b86@127.0.0.1:30304?discport=0",
             "enr":"enr:-Jy4QIvS0dKBLjTTV_RojS8hjriwWsJNHRVyOh4Pk4aUXc5SZjKRVIOeYc7BqzEmbCjLdIY4Ln7x5ZPf-2SsBAc2_zqGAYSwY1zog2V0aMfGhNegsXuAgmlkgnY0gmlwhBiT_DiJc2VjcDI1NmsxoQLX366knH7zdwHmaGUrzxvGPTq7Kul1kzdKlJ4XXk_xKIRzbmFwwIN0Y3CCdmA",
-            "ip":"***REMOVED***",
+            "ip":"127.0.0.1",
             "ports":{
                 "discovery":0,
                 "listener":30304

--- a/ethers-providers/src/admin.rs
+++ b/ethers-providers/src/admin.rs
@@ -240,33 +240,3 @@ pub struct CliqueConfig {
     /// Epoch length to reset votes and checkpoints.
     pub epoch: u64,
 }
-
-/// An event emitted by geth when a peer is added or removed, or when a message is sent or
-/// received.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct PeerEvent {
-    /// The type of event.
-    #[serde(rename = "type")]
-    pub event_type: String,
-
-    /// The peer's enode ID.
-    pub peer: String,
-
-    /// The error associated with the event.
-    pub error: Option<String>,
-
-    /// The protocol associated with the event.
-    pub protocol: Option<String>,
-
-    /// The message code.
-    pub msg_code: Option<u64>,
-
-    /// The message size.
-    pub msg_size: Option<u64>,
-
-    /// The local address of the peer.
-    pub local_address: Option<SocketAddr>,
-
-    /// The remote address of the peer.
-    pub remote_address: Option<SocketAddr>,
-}

--- a/ethers-providers/src/call_raw.rs
+++ b/ethers-providers/src/call_raw.rs
@@ -564,7 +564,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_state_overrides() {
-        let mut geth = Geth::new().spawn();
+        let geth = Geth::new().spawn();
         let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
 
         let adr1: Address = "0x6fC21092DA55B392b045eD78F4732bff3C580e2c".parse().unwrap();
@@ -573,9 +573,6 @@ mod tests {
 
         // Not enough ether to pay for the transaction
         let tx = TransactionRequest::pay(adr2, pay_amt).from(adr1).into();
-
-        // dump the geth logs TODO REMOVE
-        println!("geth logs: {}", geth.dump_stderr().unwrap());
 
         // assert that overriding the sender's balance works
         let state = spoof::balance(adr1, pay_amt * 2);

--- a/ethers-providers/src/call_raw.rs
+++ b/ethers-providers/src/call_raw.rs
@@ -564,7 +564,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_state_overrides() {
-        let geth = Geth::new().spawn();
+        let mut geth = Geth::new().spawn();
         let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
 
         let adr1: Address = "0x6fC21092DA55B392b045eD78F4732bff3C580e2c".parse().unwrap();
@@ -573,6 +573,9 @@ mod tests {
 
         // Not enough ether to pay for the transaction
         let tx = TransactionRequest::pay(adr2, pay_amt).from(adr1).into();
+
+        // dump the geth logs TODO REMOVE
+        println!("geth logs: {}", geth.dump_stderr().unwrap());
 
         // assert that overriding the sender's balance works
         let state = spoof::balance(adr1, pay_amt * 2);

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -10,6 +10,10 @@ pub use transports::*;
 mod provider;
 pub use provider::{is_local_endpoint, FilterKind, Provider, ProviderError, ProviderExt};
 
+// types for the admin api
+pub mod admin;
+pub use admin::{NodeInfo, PeerInfo};
+
 // ENS support
 pub mod ens;
 
@@ -36,6 +40,7 @@ pub mod erc;
 
 use async_trait::async_trait;
 use auto_impl::auto_impl;
+use enr::{k256::ecdsa::SigningKey, Enr};
 use ethers_core::types::transaction::{eip2718::TypedTransaction, eip2930::AccessListWithGasUsed};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{error::Error, fmt::Debug, future::Future, pin::Pin};
@@ -486,6 +491,32 @@ pub trait Middleware: Sync + Send + Debug {
         block: Option<BlockId>,
     ) -> Result<EIP1186ProofResponse, Self::Error> {
         self.inner().get_proof(from, locations, block).await.map_err(FromErr::from)
+    }
+
+    // Admin namespace
+
+    async fn add_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
+        self.inner().add_peer(node_record).await.map_err(FromErr::from)
+    }
+
+    async fn add_trusted_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
+        self.inner().add_trusted_peer(node_record).await.map_err(FromErr::from)
+    }
+
+    async fn node_info(&self) -> Result<NodeInfo, Self::Error> {
+        self.inner().node_info().await.map_err(FromErr::from)
+    }
+
+    async fn peers(&self) -> Result<Vec<PeerInfo>, Self::Error> {
+        self.inner().peers().await.map_err(FromErr::from)
+    }
+
+    async fn remove_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
+        self.inner().remove_peer(node_record).await.map_err(FromErr::from)
+    }
+
+    async fn remove_trusted_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
+        self.inner().remove_trusted_peer(node_record).await.map_err(FromErr::from)
     }
 
     // Mempool inspection for Geth's API

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -40,7 +40,6 @@ pub mod erc;
 
 use async_trait::async_trait;
 use auto_impl::auto_impl;
-use enr::{k256::ecdsa::SigningKey, Enr};
 use ethers_core::types::transaction::{eip2718::TypedTransaction, eip2930::AccessListWithGasUsed};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{error::Error, fmt::Debug, future::Future, pin::Pin};
@@ -495,12 +494,12 @@ pub trait Middleware: Sync + Send + Debug {
 
     // Admin namespace
 
-    async fn add_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
-        self.inner().add_peer(node_record).await.map_err(FromErr::from)
+    async fn add_peer(&self, enode_url: String) -> Result<bool, Self::Error> {
+        self.inner().add_peer(enode_url).await.map_err(FromErr::from)
     }
 
-    async fn add_trusted_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
-        self.inner().add_trusted_peer(node_record).await.map_err(FromErr::from)
+    async fn add_trusted_peer(&self, enode_url: String) -> Result<bool, Self::Error> {
+        self.inner().add_trusted_peer(enode_url).await.map_err(FromErr::from)
     }
 
     async fn node_info(&self) -> Result<NodeInfo, Self::Error> {
@@ -511,12 +510,12 @@ pub trait Middleware: Sync + Send + Debug {
         self.inner().peers().await.map_err(FromErr::from)
     }
 
-    async fn remove_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
-        self.inner().remove_peer(node_record).await.map_err(FromErr::from)
+    async fn remove_peer(&self, enode_url: String) -> Result<bool, Self::Error> {
+        self.inner().remove_peer(enode_url).await.map_err(FromErr::from)
     }
 
-    async fn remove_trusted_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
-        self.inner().remove_trusted_peer(node_record).await.map_err(FromErr::from)
+    async fn remove_trusted_peer(&self, enode_url: String) -> Result<bool, Self::Error> {
+        self.inner().remove_trusted_peer(enode_url).await.map_err(FromErr::from)
     }
 
     // Mempool inspection for Geth's API

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -2293,11 +2293,11 @@ mod tests {
         // check that the second peer is in the list (it uses an enr so the enr should be Some)
         assert_eq!(peers.len(), 1);
 
-        let first_peer = peers.get(0).unwrap();
-        assert_eq!(first_peer.enr, Some(second_info.enr));
+        let peer = peers.get(0).unwrap();
+        assert_eq!(peer.id, second_info.id);
 
         // remove directories
-        // std::fs::remove_dir_all(dir1).unwrap();
-        // std::fs::remove_dir_all(dir2).unwrap();
+        std::fs::remove_dir_all(dir1).unwrap();
+        std::fs::remove_dir_all(dir2).unwrap();
     }
 }

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -2277,7 +2277,7 @@ mod tests {
         assert_eq!(peers.len(), 1);
 
         let peer = peers.get(0).unwrap();
-        assert_eq!(peer.id, second_info.id);
+        assert_eq!(H256::from_str(&peer.id).unwrap(), second_info.id);
 
         // remove directories
         std::fs::remove_dir_all(dir1).unwrap();

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -33,7 +33,6 @@ use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
 use url::{ParseError, Url};
 
-use enr::{k256::ecdsa::SigningKey, Enr};
 use ethers_core::types::Chain;
 use futures_util::{lock::Mutex, try_join};
 use std::{
@@ -801,38 +800,44 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
 
     // Admin namespace
 
-    /// docs: TODO
-    async fn add_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
-        let node_record = utils::serialize(&node_record);
-        self.request("admin_addPeer", [node_record]).await
+    /// Requests adding the given peer, returning a boolean representing whether or not the peer
+    /// was accepted for tracking.
+    async fn add_peer(&self, enode_url: String) -> Result<bool, Self::Error> {
+        let enode_url = utils::serialize(&enode_url);
+        self.request("admin_addPeer", [enode_url]).await
     }
 
-    /// docs: TODO
-    async fn add_trusted_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
-        let node_record = utils::serialize(&node_record);
-        self.request("admin_addTrustedPeer", [node_record]).await
+    /// Requests adding the given peer as a trusted peer, which the node will always connect to
+    /// even when its peer slots are full.
+    async fn add_trusted_peer(&self, enode_url: String) -> Result<bool, Self::Error> {
+        let enode_url = utils::serialize(&enode_url);
+        self.request("admin_addTrustedPeer", [enode_url]).await
     }
 
-    /// docs: TODO
+    /// Returns general information about the node as well as information about the running p2p
+    /// protocols (e.g. `eth`, `snap`).
     async fn node_info(&self) -> Result<NodeInfo, Self::Error> {
         self.request("admin_nodeInfo", ()).await
     }
 
-    /// docs: TODO
+    /// Returns the list of peers currently connected to the node.
     async fn peers(&self) -> Result<Vec<PeerInfo>, Self::Error> {
         self.request("admin_peers", ()).await
     }
 
-    /// docs: TODO
-    async fn remove_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
-        let node_record = utils::serialize(&node_record);
-        self.request("admin_removePeer", [node_record]).await
+    /// Requests to remove the given peer, returning true if the enode was successfully parsed and
+    /// the peer was removed.
+    async fn remove_peer(&self, enode_url: String) -> Result<bool, Self::Error> {
+        let enode_url = utils::serialize(&enode_url);
+        self.request("admin_removePeer", [enode_url]).await
     }
 
-    /// docs: TODO
-    async fn remove_trusted_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
-        let node_record = utils::serialize(&node_record);
-        self.request("admin_removeTrustedPeer", [node_record]).await
+    /// Requests to remove the given peer, returning a boolean representing whether or not the
+    /// enode url passed was validated. A return value of `true` does not necessarily mean that the
+    /// peer was disconnected.
+    async fn remove_trusted_peer(&self, enode_url: String) -> Result<bool, Self::Error> {
+        let enode_url = utils::serialize(&enode_url);
+        self.request("admin_removeTrustedPeer", [enode_url]).await
     }
 
     ////// Ethereum Naming Service

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -4,7 +4,7 @@ use crate::{
     pubsub::{PubsubClient, SubscriptionStream},
     stream::{FilterWatcher, DEFAULT_LOCAL_POLL_INTERVAL, DEFAULT_POLL_INTERVAL},
     FromErr, Http as HttpProvider, JsonRpcClient, JsonRpcClientWrapper, LogQuery, MockProvider,
-    PendingTransaction, QuorumProvider, RwClient, SyncingStatus,
+    NodeInfo, PeerInfo, PendingTransaction, QuorumProvider, RwClient, SyncingStatus,
 };
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "ws"))]
@@ -33,6 +33,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
 use url::{ParseError, Url};
 
+use enr::{k256::ecdsa::SigningKey, Enr};
 use ethers_core::types::Chain;
 use futures_util::{lock::Mutex, try_join};
 use std::{
@@ -796,6 +797,38 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         let block = utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
 
         self.request("eth_getProof", [from, locations, block]).await
+    }
+
+    // Admin namespace
+
+    /// docs: TODO
+    async fn add_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
+        todo!()
+    }
+
+    /// docs: TODO
+    async fn add_trusted_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
+        todo!()
+    }
+
+    /// docs: TODO
+    async fn node_info(&self) -> Result<NodeInfo, Self::Error> {
+        todo!()
+    }
+
+    /// docs: TODO
+    async fn peers(&self) -> Result<Vec<PeerInfo>, Self::Error> {
+        todo!()
+    }
+
+    /// docs: TODO
+    async fn remove_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
+        todo!()
+    }
+
+    /// docs: TODO
+    async fn remove_trusted_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
+        todo!()
     }
 
     ////// Ethereum Naming Service

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1796,7 +1796,7 @@ mod tests {
         types::{
             transaction::eip2930::AccessList, Eip1559TransactionRequest, TransactionRequest, H256,
         },
-        utils::Anvil,
+        utils::{Anvil, Geth},
     };
     use futures_util::StreamExt;
 
@@ -2160,5 +2160,20 @@ mod tests {
             &err.to_string(),
             "ens name not found: `ox63616e.eth` resolver (0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) is invalid."
         );
+    }
+
+    #[tokio::test]
+    async fn geth_admin_nodeinfo() {
+        // we can't use the test provider because infura does not expose admin endpoints
+        let port = 8545u16;
+        let url = format!("http://localhost:{}", port);
+
+        let geth = Geth::new().port(port).spawn();
+        let provider = Provider::try_from(url).unwrap();
+
+        let info = provider.node_info().await.unwrap();
+        dbg!(&info);
+
+        drop(geth); // this will kill the instance
     }
 }

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -803,32 +803,36 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
 
     /// docs: TODO
     async fn add_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
-        todo!()
+        let node_record = utils::serialize(&node_record);
+        self.request("admin_addPeer", [node_record]).await
     }
 
     /// docs: TODO
     async fn add_trusted_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
-        todo!()
+        let node_record = utils::serialize(&node_record);
+        self.request("admin_addTrustedPeer", [node_record]).await
     }
 
     /// docs: TODO
     async fn node_info(&self) -> Result<NodeInfo, Self::Error> {
-        todo!()
+        self.request("admin_nodeInfo", ()).await
     }
 
     /// docs: TODO
     async fn peers(&self) -> Result<Vec<PeerInfo>, Self::Error> {
-        todo!()
+        self.request("admin_peers", ()).await
     }
 
     /// docs: TODO
     async fn remove_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
-        todo!()
+        let node_record = utils::serialize(&node_record);
+        self.request("admin_removePeer", [node_record]).await
     }
 
     /// docs: TODO
     async fn remove_trusted_peer(&self, node_record: Enr<SigningKey>) -> Result<bool, Self::Error> {
-        todo!()
+        let node_record = utils::serialize(&node_record);
+        self.request("admin_removeTrustedPeer", [node_record]).await
     }
 
     ////// Ethereum Naming Service

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -2235,14 +2235,14 @@ mod tests {
         let first_port = 30304u16;
         let second_port = 30305u16;
 
-        let (mut first_geth, first_peer) = spawn_geth_and_create_provider(
+        let (first_geth, first_peer) = spawn_geth_and_create_provider(
             1337,
             8546,
             first_port,
             Some(dir1.clone()),
             Some(genesis.clone()),
         );
-        let (mut second_geth, second_peer) = spawn_geth_and_create_provider(
+        let (second_geth, second_peer) = spawn_geth_and_create_provider(
             1337,
             8547,
             second_port,
@@ -2254,16 +2254,11 @@ mod tests {
         let first_info = first_peer.node_info().await.unwrap();
         let second_info = second_peer.node_info().await.unwrap();
 
-        println!("first_id: {}", hex::encode(first_info.id.0));
-        println!("first_nodeinfo: {:?}", first_info);
-
         // replace the ip in the enode by putting
         let first_prefix = first_info.enode.split('@').collect::<Vec<&str>>();
-        let second_prefix = second_info.enode.split('@').collect::<Vec<&str>>();
 
         // create enodes for each geth instance using each id and port
         let first_enode = format!("{}@localhost:{}", first_prefix.first().unwrap(), first_port);
-        let second_enode = format!("{}@localhost:{}", second_prefix.first().unwrap(), second_port);
 
         // add the second geth as a peer for the first
         let res = second_peer.add_peer(first_enode).await.unwrap();
@@ -2275,20 +2270,8 @@ mod tests {
         // check that second_geth exists in the first_geth peer list
         let peers = first_peer.peers().await.unwrap();
 
-        let mut first_stderr = first_geth.stderr();
-        let mut second_stderr = second_geth.stderr();
-
         drop(first_geth);
         drop(second_geth);
-
-        // turn the stderrs into a string
-        let mut first_str = String::new();
-        let mut second_str = String::new();
-        first_stderr.read_to_string(&mut first_str).unwrap();
-        second_stderr.read_to_string(&mut second_str).unwrap();
-
-        println!("first stderr: {}", first_str);
-        println!("second stderr: {}", second_str);
 
         // check that the second peer is in the list (it uses an enr so the enr should be Some)
         assert_eq!(peers.len(), 1);

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1795,7 +1795,7 @@ pub mod dev_rpc {
 #[cfg(test)]
 #[cfg(not(target_arch = "wasm32"))]
 mod tests {
-    use std::path::PathBuf;
+    use std::{io::Read, path::PathBuf};
 
     use super::*;
     use crate::Http;

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1795,7 +1795,7 @@ pub mod dev_rpc {
 #[cfg(test)]
 #[cfg(not(target_arch = "wasm32"))]
 mod tests {
-    use std::{io::Read, path::PathBuf};
+    use std::path::PathBuf;
 
     use super::*;
     use crate::Http;

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -2172,17 +2172,18 @@ mod tests {
     #[tokio::test]
     async fn geth_admin_nodeinfo() {
         // we can't use the test provider because infura does not expose admin endpoints
-        let port = 8545u16;
+        let port = 8546u16;
         let p2p_listener_port = 13337u16;
-        let authrpc_port = 8551u16;
+        let authrpc_port = 8552u16;
         let network = 1337u64;
+        let temp_dir = tempfile::tempdir().unwrap().into_path();
 
         let (geth, provider) = spawn_geth_and_create_provider(
             network,
             port,
             p2p_listener_port,
             authrpc_port,
-            None,
+            Some(temp_dir),
             None,
         );
 


### PR DESCRIPTION
## Motivation

Geth includes an `admin` namespace which is especially useful for querying its p2p details and prompting the node to add or remove peers.

## Solution

 - Add `NodeInfo` for the `admin_nodeInfo` return type
 - Add `PeerInfo` for the `admin_peers` return type
 - Add the following `admin` namespace RPCs to `Middleware`, implementing them on `Provider<P>`:
   - `admin_nodeInfo`
   - `admin_peers`
   - `admin_addPeer`
   - `admin_addTrustedPeer`
   - `admin_removePeer`
   - `admin_removeTrustedPeer`

This also modifies the `Geth` and `GethInstance` structs to support custom chain ids and running without the `--dev` flag. `--dev`-specific configuration options, and options that are incompatible with `--dev` are kept mutually exclusive with the `PrivateNetOptions` enum. Unless a dev-incompatible option is set, `--dev` mode will remain the default. An option for disabling discovery is also added.

This also adds a simple test using the new `Geth` options to set a few custom fields that are visible in the `admin_nodeInfo` output.

Misc change:
 - expose `from_int_or_hex` as a general utility so it can be used for `admin_nodeInfo` response deserialization.

TODO:
 - [x] cover other RPCs - test for adding and removing peers, as well as listing peers.
   - the test added does the following:
     - connect two geth peers
     - ensure that the `admin_peers` endpoint deserializes correctly
     - the `id` obtained from the `admin_peers` RPC call matches the `id` from the `admin_nodeInfo` response for that peer
   - more tests should be added for admin endpoints, maybe good for a future PR or issue
   - another thing out of scope for this PR: `genesis.json` deserialization tests
 - [x] simple (de)serialization tests for `NodeInfo` and `PeerInfo`
 - [x] consider other `admin_` endpoints to add - `admin_peerEvents` maybe?
   - `admin_peerEvents` is of scope for this PR, will create an issue

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [x] Updated the changelog
