### PR TITLE
Instantiate an event builder without a contract instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+-   An `Event` builder can be instantiated specifying the event filter type, without the need to instantiate a contract.
 -   Add comment about safety of u8 -> u64 cast in `ethers_core::types::Signature`
 -   Stop defaulting to the `"latest"` block in `eth_estimateGas` params [#1657](https://github.com/gakonst/ethers-rs/pull/1657)
 -   Fix geth trace types for debug_traceTransaction rpc

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -192,6 +192,19 @@ impl<M> Contract<M> {
 }
 
 impl<M: Middleware> Contract<M> {
+    /// Returns an [`Event`](crate::builders::Event) builder for the provided event.
+    /// This function operates in a static context, then it does not require a `self`
+    /// to reference to instantiate an [`Event`](crate::builders::Event) builder.
+    pub fn event_of_type<'a, D: EthEvent>(client: &'a Arc<M>) -> Event<'a, M, D> {
+        Event {
+            provider: client,
+            filter: Filter::new().event(&D::abi_signature()),
+            datatype: PhantomData,
+        }
+    }
+}
+
+impl<M: Middleware> Contract<M> {
     /// Creates a new contract from the provided client, abi and address
     pub fn new(
         address: impl Into<Address>,

--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -3,7 +3,7 @@
 use crate::{log::LogMeta, stream::EventStream, ContractError, EthLogDecode};
 use ethers_core::{
     abi::{Detokenize, RawLog},
-    types::{BlockNumber, Filter, Log, Topic, H256},
+    types::{BlockNumber, Filter, Log, Topic, H256, ValueOrArray, H160},
 };
 use ethers_providers::{FilterWatcher, Middleware, PubsubClient, SubscriptionStream};
 use std::{borrow::Cow, marker::PhantomData};
@@ -106,6 +106,12 @@ impl<M, D: EthLogDecode> Event<'_, M, D> {
     /// Sets the filter's 3rd topic
     pub fn topic3<T: Into<Topic>>(mut self, topic: T) -> Self {
         self.filter.topics[3] = Some(topic.into());
+        self
+    }
+
+    /// Sets the filter's address.
+    pub fn address(mut self, address: ValueOrArray<H160>) -> Self {
+        self.filter.address = Some(address);
         self
     }
 }

--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -3,7 +3,7 @@
 use crate::{log::LogMeta, stream::EventStream, ContractError, EthLogDecode};
 use ethers_core::{
     abi::{Detokenize, RawLog},
-    types::{BlockNumber, Filter, Log, Topic, H256, ValueOrArray, H160},
+    types::{BlockNumber, Filter, Log, Topic, ValueOrArray, H160, H256},
 };
 use ethers_providers::{FilterWatcher, Middleware, PubsubClient, SubscriptionStream};
 use std::{borrow::Cow, marker::PhantomData};

--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -111,7 +111,7 @@ impl<M, D: EthLogDecode> Event<'_, M, D> {
 
     /// Sets the filter's address.
     pub fn address(mut self, address: ValueOrArray<H160>) -> Self {
-        self.filter.address = Some(address);
+        self.filter = self.filter.address(address);
         self
     }
 }

--- a/ethers-contract/tests/it/contract.rs
+++ b/ethers-contract/tests/it/contract.rs
@@ -6,7 +6,7 @@ use ethers_core::types::{Filter, ValueOrArray, H256};
 #[cfg(not(feature = "celo"))]
 mod eth_tests {
     use super::*;
-    use ethers_contract::{LogMeta, Multicall, MulticallVersion};
+    use ethers_contract::{LogMeta, Multicall, MulticallVersion, EthEvent};
     use ethers_core::{
         abi::{encode, Detokenize, Token, Tokenizable},
         types::{transaction::eip712::Eip712, Address, BlockId, Bytes, I256, U256},
@@ -322,6 +322,22 @@ mod eth_tests {
         let log_2 = stream.next().await.unwrap();
         assert_eq!(log_1.address, contract_1.address());
         assert_eq!(log_2.address, contract_2.address());
+    }
+
+
+    #[tokio::test]
+    async fn build_event_of_type() {
+        abigen!(
+            AggregatorInterface,
+            r#"[
+                event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt)
+            ]"#,
+        );
+
+        let anvil = Anvil::new().spawn();
+        let client = connect(&anvil, 0);
+        let event = ethers_contract::Contract::event_of_type::<AnswerUpdatedFilter>(&client);
+        assert_eq!(event.filter, Filter::new().event(&AnswerUpdatedFilter::abi_signature()));
     }
 
     #[tokio::test]

--- a/ethers-contract/tests/it/contract.rs
+++ b/ethers-contract/tests/it/contract.rs
@@ -6,7 +6,7 @@ use ethers_core::types::{Filter, ValueOrArray, H256};
 #[cfg(not(feature = "celo"))]
 mod eth_tests {
     use super::*;
-    use ethers_contract::{LogMeta, Multicall, MulticallVersion, EthEvent};
+    use ethers_contract::{EthEvent, LogMeta, Multicall, MulticallVersion};
     use ethers_core::{
         abi::{encode, Detokenize, Token, Tokenizable},
         types::{transaction::eip712::Eip712, Address, BlockId, Bytes, I256, U256},
@@ -323,7 +323,6 @@ mod eth_tests {
         assert_eq!(log_1.address, contract_1.address());
         assert_eq!(log_2.address, contract_2.address());
     }
-
 
     #[tokio::test]
     async fn build_event_of_type() {

--- a/examples/subscribe_events_by_type.rs
+++ b/examples/subscribe_events_by_type.rs
@@ -1,0 +1,52 @@
+use ethers::{prelude::*};
+use std::{error::Error, sync::Arc};
+use ethers::contract::Contract;
+abigen!(
+    AggregatorInterface,
+    r#"[
+        event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt)
+    ]"#,
+);
+
+const PRICE_FEED_1: &str = "0x7de93682b9b5d80d45cd371f7a14f74d49b0914c";
+const PRICE_FEED_2: &str = "0x0f00392fcb466c0e4e4310d81b941e07b4d5a079";
+const PRICE_FEED_3: &str = "0xebf67ab8cff336d3f609127e8bbf8bd6dd93cd81";
+
+/// Subscribe to a typed event stream without requiring a `Contract` instance.
+/// In this example we subscribe Chainlink price feeds and filter out them
+/// by address.
+/// -------------------------------------------------------------------------------
+/// In order to run this example you need to include Ws and TLS features
+/// Run this example with
+/// `cargo run -p ethers --example subscribe_events_by_type --features="ws","rustls"`
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let client = get_client().await;
+    let client = Arc::new(client);
+
+    // Build an Event by type. We are not tied to a contract instance. We use builder functions to refine the event filter
+    let event = Contract::event_of_type::<AnswerUpdatedFilter>(&client)
+        .from_block(16022082)
+        .to_block(16022282)
+        .address(ValueOrArray::Array( vec![
+            PRICE_FEED_1.parse()?,
+            PRICE_FEED_2.parse()?,
+            PRICE_FEED_3.parse()?,
+        ]));
+
+    let mut stream = event.subscribe_with_meta().await?;
+
+    // Note that `log` has type AnswerUpdatedFilter
+    while let Some(Ok((log, meta))) = stream.next().await {
+        println!("{:?}", log);
+        println!("{:?}", meta)
+    }
+
+    Ok(())
+}
+
+
+async fn get_client() -> Provider<Ws> {
+    Provider::<Ws>::connect("wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27")
+    .await.unwrap()
+}

--- a/examples/subscribe_events_by_type.rs
+++ b/examples/subscribe_events_by_type.rs
@@ -1,6 +1,5 @@
-use ethers::{prelude::*};
+use ethers::{contract::Contract, prelude::*};
 use std::{error::Error, sync::Arc};
-use ethers::contract::Contract;
 abigen!(
     AggregatorInterface,
     r#"[
@@ -24,11 +23,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let client = get_client().await;
     let client = Arc::new(client);
 
-    // Build an Event by type. We are not tied to a contract instance. We use builder functions to refine the event filter
+    // Build an Event by type. We are not tied to a contract instance. We use builder functions to
+    // refine the event filter
     let event = Contract::event_of_type::<AnswerUpdatedFilter>(&client)
         .from_block(16022082)
         .to_block(16022282)
-        .address(ValueOrArray::Array( vec![
+        .address(ValueOrArray::Array(vec![
             PRICE_FEED_1.parse()?,
             PRICE_FEED_2.parse()?,
             PRICE_FEED_3.parse()?,
@@ -45,8 +45,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-
 async fn get_client() -> Provider<Ws> {
     Provider::<Ws>::connect("wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27")
-    .await.unwrap()
+        .await
+        .unwrap()
 }


### PR DESCRIPTION
## Motivation
The `Event` builder system requires to instantiate a new `Contract` to create a typed event builder ([as implemented here](https://github.com/gakonst/ethers-rs/blob/master/ethers-contract/src/contract.rs#L205)).
```rust
  /// Returns an [`Event`](crate::builders::Event) builder for the provided event.
  pub fn event<D: EthEvent>(&self) -> Event<M, D> {
        self.event_with_filter(Filter::new().event(&D::abi_signature()))
  }
```
To stream the same event from many different contracts, developers tend to subscribe to a `Log` stream, needing to map the `Log` struct into a typed event struct.

[](https://github.com/gakonst/ethers-rs/blob/master/ethers-contract/src/contract.rs#L205)

```rust
    let filter = Filter::new()
                     .event("Transfer(address,address,uint256)")
                     .address(ValueOrArray::Array(vec![
                        "0x..".parse()?,
                        "0x..".parse()?,
                        "0x..".parse()?,
                      ]));

    let mut stream = client.subscribe_logs(&filter).await?;

    while let Some(log) = stream.next().await {
         // Developers need to map 'Log' into the 'Transfer' event struct 😭😭😭😭😭
    }
```
## Solution
The proposed solution allows to create an event builder from an event type. The returned builder can be combined with all the existing builder functions. 

I did the following:
1. Added the static `event_of_type` function to the `Contract` struct.
2. Added the `address` function to the `Event` struct in order to extend the filter with required addresses
3. Added unit tests
4. Added a new example

Usage is like this:
```rust
    abigen!(
        ERC20,
        r#"[
            event Transfer(address indexed from, address indexed to, uint256 value)
        ]"#,
    );

    let event = Contract::event_of_type::<Transfer>(&client)
                       .address(ValueOrArray::Array(vec![
                           "0x..".parse()?,
                           "0x..".parse()?,
                           "0x..".parse()?,
                       ]));

    let mut stream = event.subscribe().await?;

    while let Some(Ok(log)) = stream.next().await {
         // 'Log' has the 'Transfer' type. No mapping is required 🥳🥳🥳🥳🥳
    }
```

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
