### PR TITLE
Feat middleware stack builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## ethers-core
 
 ### Unreleased
--   New builder struct to instantiate `Provider` as `Middleware` layers.
+-   New builder struct to instantiate a `Provider` as `Middleware` layers.
 -   An `Event` builder can be instantiated specifying the event filter type, without the need to instantiate a contract.
 -   Add 'ethers_core::types::OpCode' and use in 'ethers_core::types::VMOperation' [1857](https://github.com/gakonst/ethers-rs/issues/1857)
 -   Remove rust_decimals dependency for ethers-core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## ethers-core
 
 ### Unreleased
--   New builder struct to instantiate a `Provider` as `Middleware` layers.
+-   `MiddlewareBuilder` trait to instantiate a `Provider` as `Middleware` layers.
 -   An `Event` builder can be instantiated specifying the event filter type, without the need to instantiate a contract.
 -   Add 'ethers_core::types::OpCode' and use in 'ethers_core::types::VMOperation' [1857](https://github.com/gakonst/ethers-rs/issues/1857)
 -   Remove rust_decimals dependency for ethers-core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## ethers-core
 
 ### Unreleased
-
+-   New builder struct to instantiate `Provider` as `Middleware` layers.
 -   An `Event` builder can be instantiated specifying the event filter type, without the need to instantiate a contract.
 -   Add 'ethers_core::types::OpCode' and use in 'ethers_core::types::VMOperation' [1857](https://github.com/gakonst/ethers-rs/issues/1857)
 -   Remove rust_decimals dependency for ethers-core

--- a/ethers-middleware/README.md
+++ b/ethers-middleware/README.md
@@ -55,7 +55,7 @@ let provider = NonceManagerMiddleware::new(provider, address);
 ```
 ## Example of a middleware stack using a builder
 
-Ethers provides a builder utility to compose a [`Middleware`](crate::Middleware) stack. As usual the composition acts in a wrapping fashion. Adding a new layer results in wrapping its predecessor.
+Ethers provides a builder utility to compose a [`Middleware`](ethers_providers::Middleware) stack. As usual the composition acts in a wrapping fashion. Adding a new layer results in wrapping its predecessor.
 Builder can be used as follows:
 ```rust
 use ethers_providers::{Middleware, Provider, Http};

--- a/ethers-middleware/README.md
+++ b/ethers-middleware/README.md
@@ -4,22 +4,22 @@ middleware functionalities that you need.
 
 ## Available Middleware
 
--   [`Signer`](./signer/struct.SignerMiddleware.html): Signs transactions locally,
-    with a private key or a hardware wallet
--   [`Nonce Manager`](./nonce_manager/struct.NonceManagerMiddleware.html): Manages
-    nonces locally, allowing the rapid broadcast of transactions without having to
-    wait for them to be submitted
--   [`Gas Escalator`](./gas_escalator/struct.GasEscalatorMiddleware.html): Bumps
-    transaction gas prices in the background
--   [`Gas Oracle`](./gas_oracle/struct.GasOracleMiddleware.html): Allows getting
-    your gas price estimates from places other than `eth_gasPrice`.
--   [`Transformer`](./transformer/trait.Transformer.html): Allows intercepting and
-    transforming a transaction to be broadcasted via a proxy wallet, e.g.
-    [`DSProxy`](./transformer/struct.DsProxy.html).
+- [`Signer`](./signer/struct.SignerMiddleware.html): Signs transactions locally,
+  with a private key or a hardware wallet
+- [`Nonce Manager`](./nonce_manager/struct.NonceManagerMiddleware.html): Manages
+  nonces locally, allowing the rapid broadcast of transactions without having to
+  wait for them to be submitted
+- [`Gas Escalator`](./gas_escalator/struct.GasEscalatorMiddleware.html): Bumps
+  transaction gas prices in the background
+- [`Gas Oracle`](./gas_oracle/struct.GasOracleMiddleware.html): Allows getting
+  your gas price estimates from places other than `eth_gasPrice`.
+- [`Transformer`](./transformer/trait.Transformer.html): Allows intercepting and
+  transforming a transaction to be broadcasted via a proxy wallet, e.g.
+  [`DSProxy`](./transformer/struct.DsProxy.html).
 
 ## Example of a middleware stack
 
-```no_run
+```rust no_run
 use ethers_providers::{Provider, Http};
 use ethers_signers::{LocalWallet, Signer};
 use ethers_middleware::{
@@ -53,3 +53,29 @@ let provider = NonceManagerMiddleware::new(provider, address);
 
 // ... do something with the provider
 ```
+## Example of a middleware stack using a builder
+
+Ethers provides a builder utility to compose a [`Middleware`](crate::Middleware) stack. [`Middleware`](crate::Middleware) as usual the composition acts in a wrapping fashion. Adding a new layer results wrapping its predecessor.
+Builder can be used as follows:
+```rust
+use ethers_providers::{Middleware, Provider, Http};
+use std::sync::Arc;
+use std::convert::TryFrom;
+use ethers_signers::{LocalWallet, Signer};
+use ethers_middleware::{*,gas_escalator::*,gas_oracle::*};
+
+fn example() {
+    let key = "fdb33e2105f08abe41a8ee3b758726a31abdd57b7a443f470f23efce853af169";
+    let signer = key.parse::<LocalWallet>().unwrap();
+    let address = signer.address();
+    let escalator = GeometricGasPrice::new(1.125, 60_u64, None::<u64>);
+ 
+    let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
+ 
+    ProviderBuilder::from(provider)
+        .wrap_into(|p| GasEscalatorMiddleware::new(p, escalator, Frequency::PerBlock))
+        .wrap_into(|p| SignerMiddleware::new(p, signer))
+        .wrap_into(|p| GasOracleMiddleware::new(p, EthGasStation::new(None)))
+        .wrap_into(|p| NonceManagerMiddleware::new(p, address)) // Outermost layer
+        .build();
+}

--- a/ethers-middleware/README.md
+++ b/ethers-middleware/README.md
@@ -55,7 +55,7 @@ let provider = NonceManagerMiddleware::new(provider, address);
 ```
 ## Example of a middleware stack using a builder
 
-Ethers provides a builder utility to compose a [`Middleware`](crate::Middleware) stack. [`Middleware`](crate::Middleware) as usual the composition acts in a wrapping fashion. Adding a new layer results wrapping its predecessor.
+Ethers provides a builder utility to compose a [`Middleware`](crate::Middleware) stack. As usual the composition acts in a wrapping fashion. Adding a new layer results in wrapping its predecessor.
 Builder can be used as follows:
 ```rust
 use ethers_providers::{Middleware, Provider, Http};

--- a/ethers-middleware/src/builder.rs
+++ b/ethers-middleware/src/builder.rs
@@ -1,8 +1,9 @@
 use ethers_providers::Middleware;
 
-/// A builder struct useful to compose different [`Middleware`](crate::Middleware) layers and then
-/// build a composed [`Provider`](crate::Provider) architecture. [`Middleware`](crate::Middleware)
-/// composition acts in a wrapping fashion. Adding a new layer results in wrapping its predecessor.
+/// A builder struct useful to compose different [`Middleware`](ethers_providers::Middleware) layers
+/// and then build a composed [`Provider`](ethers_providers::Provider) architecture.
+/// [`Middleware`](ethers_providers::Middleware) composition acts in a wrapping fashion. Adding a
+/// new layer results in wrapping its predecessor.
 ///
 /// Builder can be used as follows:
 ///

--- a/ethers-middleware/src/builder.rs
+++ b/ethers-middleware/src/builder.rs
@@ -27,7 +27,7 @@ use crate::{
 ///     let address = signer.address();
 ///     let escalator = GeometricGasPrice::new(1.125, 60_u64, None::<u64>);
 ///     let gas_oracle = EthGasStation::new(None);
-/// 
+///
 ///     let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
 ///
 ///     let provider = ProviderBuilder::from(provider)
@@ -37,7 +37,7 @@ use crate::{
 ///         .nonce_manager(address)
 ///         .build();
 /// }
-/// 
+///
 /// fn builder_example_raw_wrap() {
 ///     let key = "fdb33e2105f08abe41a8ee3b758726a31abdd57b7a443f470f23efce853af169";
 ///     let signer = key.parse::<LocalWallet>().unwrap();

--- a/ethers-middleware/src/builder.rs
+++ b/ethers-middleware/src/builder.rs
@@ -1,4 +1,7 @@
 use ethers_providers::Middleware;
+use ethers_signers::Signer;
+
+use crate::SignerMiddleware;
 
 /// A builder struct useful to compose different [`Middleware`](ethers_providers::Middleware) layers
 /// and then build a composed [`Provider`](ethers_providers::Provider) architecture.
@@ -38,6 +41,14 @@ impl<M> ProviderBuilder<M>
 where
     M: Middleware,
 {
+    pub fn with_signer<S>(self, signer: S) -> ProviderBuilder<SignerMiddleware<M, S>> 
+    where
+        S: Signer
+    {
+        let provider = SignerMiddleware::new(self.inner, signer);
+        ProviderBuilder::from(provider)
+    }
+
     /// Wraps a new [`Middleware`](ethers_providers::Middleware) around the current one.
     ///
     /// `builder_fn` This closure takes the current [`Middleware`](ethers_providers::Middleware) as

--- a/ethers-middleware/src/builder.rs
+++ b/ethers-middleware/src/builder.rs
@@ -1,10 +1,10 @@
-use ethers_core::types::Address;
-use ethers_providers::Middleware;
-use ethers_signers::Signer;
 use crate::{
     gas_oracle::{GasOracle, GasOracleMiddleware},
     NonceManagerMiddleware, SignerMiddleware,
 };
+use ethers_core::types::Address;
+use ethers_providers::Middleware;
+use ethers_signers::Signer;
 
 /// A builder trait to compose different [`Middleware`](ethers_providers::Middleware) layers
 /// and then build a composed [`Provider`](ethers_providers::Provider) architecture.
@@ -50,8 +50,8 @@ use crate::{
 pub trait MiddlewareBuilder: Middleware + Sized + 'static {
     /// Wraps `self` inside a new [`Middleware`](ethers_providers::Middleware).
     ///
-    /// `f` Consumes `self`, must be used to return a new [`Middleware`](ethers_providers::Middleware)
-    /// around `self`.
+    /// `f` Consumes `self`, must be used to return a new
+    /// [`Middleware`](ethers_providers::Middleware) around `self`.
     fn wrap_into<F, T>(self, f: F) -> T
     where
         F: FnOnce(Self) -> T,

--- a/ethers-middleware/src/builder.rs
+++ b/ethers-middleware/src/builder.rs
@@ -1,8 +1,8 @@
 use ethers_providers::Middleware;
 
-/// A builder struct useful to compose different [`Middleware`](crate::Middleware) layers and then build
-/// a composed [`Provider`](crate::Provider) architecture. [`Middleware`](crate::Middleware) composition acts
-/// in a wrapping fashion. Adding a new layer results in wrapping its predecessor.
+/// A builder struct useful to compose different [`Middleware`](crate::Middleware) layers and then
+/// build a composed [`Provider`](crate::Provider) architecture. [`Middleware`](crate::Middleware)
+/// composition acts in a wrapping fashion. Adding a new layer results in wrapping its predecessor.
 ///
 /// Builder can be used as follows:
 ///
@@ -18,9 +18,9 @@ use ethers_providers::Middleware;
 ///     let signer = key.parse::<LocalWallet>().unwrap();
 ///     let address = signer.address();
 ///     let escalator = GeometricGasPrice::new(1.125, 60_u64, None::<u64>);
-/// 
+///
 ///     let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
-/// 
+///
 ///     ProviderBuilder::from(provider)
 ///         .wrap_into(|p| GasEscalatorMiddleware::new(p, escalator, Frequency::PerBlock))
 ///         .wrap_into(|p| SignerMiddleware::new(p, signer))
@@ -39,9 +39,9 @@ where
 {
     /// Wraps a new [`Middleware`](ethers_providers::Middleware) around the current one.
     ///
-    /// `builder_fn` This closure takes the current [`Middleware`](ethers_providers::Middleware) as an argument.
-    /// Use this to build a new [`Middleware`](ethers_providers::Middleware) layer wrapping out the current.
-    ///
+    /// `builder_fn` This closure takes the current [`Middleware`](ethers_providers::Middleware) as
+    /// an argument. Use this to build a new [`Middleware`](ethers_providers::Middleware) layer
+    /// wrapping out the current.
     pub fn wrap_into<F, R>(&mut self, builder_fn: F) -> ProviderBuilder<R>
     where
         F: FnOnce(M) -> R,
@@ -52,12 +52,12 @@ where
         ProviderBuilder::from(provider)
     }
 
-    /// Returns the overall[`Middleware`](ethers_providers::Middleware) as a reference to the outermost layer
+    /// Returns the overall[`Middleware`](ethers_providers::Middleware) as a reference to the
+    /// outermost layer
     pub fn build(&mut self) -> M {
         self.inner.take().unwrap()
     }
 }
-
 
 impl<M: Middleware> From<M> for ProviderBuilder<M> {
     fn from(provider: M) -> Self {

--- a/ethers-middleware/src/builder.rs
+++ b/ethers-middleware/src/builder.rs
@@ -31,7 +31,7 @@ use ethers_providers::Middleware;
 /// }
 /// ```
 pub struct ProviderBuilder<M> {
-    inner: Option<M>,
+    inner: M,
 }
 
 impl<M> ProviderBuilder<M>
@@ -43,25 +43,24 @@ where
     /// `builder_fn` This closure takes the current [`Middleware`](ethers_providers::Middleware) as
     /// an argument. Use this to build a new [`Middleware`](ethers_providers::Middleware) layer
     /// wrapping out the current.
-    pub fn wrap_into<F, R>(&mut self, builder_fn: F) -> ProviderBuilder<R>
+    pub fn wrap_into<F, R>(self, builder_fn: F) -> ProviderBuilder<R>
     where
         F: FnOnce(M) -> R,
         R: Middleware,
     {
-        let provider = self.inner.take();
-        let provider = builder_fn(provider.unwrap());
+        let provider: R = builder_fn(self.inner);
         ProviderBuilder::from(provider)
     }
 
     /// Returns the overall[`Middleware`](ethers_providers::Middleware) as a reference to the
     /// outermost layer
-    pub fn build(&mut self) -> M {
-        self.inner.take().unwrap()
+    pub fn build(self) -> M {
+        self.inner
     }
 }
 
 impl<M: Middleware> From<M> for ProviderBuilder<M> {
     fn from(provider: M) -> Self {
-        Self { inner: Some(provider) }
+        Self { inner: provider }
     }
 }

--- a/ethers-middleware/src/builder.rs
+++ b/ethers-middleware/src/builder.rs
@@ -21,7 +21,24 @@ use crate::{
 /// use ethers_signers::{LocalWallet, Signer};
 /// use ethers_middleware::{*,gas_escalator::*,gas_oracle::*};
 ///
-/// fn example() {
+/// fn builder_example() {
+///     let key = "fdb33e2105f08abe41a8ee3b758726a31abdd57b7a443f470f23efce853af169";
+///     let signer = key.parse::<LocalWallet>().unwrap();
+///     let address = signer.address();
+///     let escalator = GeometricGasPrice::new(1.125, 60_u64, None::<u64>);
+///     let gas_oracle = EthGasStation::new(None);
+/// 
+///     let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
+///
+///     let provider = ProviderBuilder::from(provider)
+///         .wrap_into(|p| GasEscalatorMiddleware::new(p, escalator, Frequency::PerBlock))
+///         .gas_oracle(gas_oracle)
+///         .with_signer(signer)
+///         .nonce_manager(address)
+///         .build();
+/// }
+/// 
+/// fn builder_example_raw_wrap() {
 ///     let key = "fdb33e2105f08abe41a8ee3b758726a31abdd57b7a443f470f23efce853af169";
 ///     let signer = key.parse::<LocalWallet>().unwrap();
 ///     let address = signer.address();

--- a/ethers-middleware/src/lib.rs
+++ b/ethers-middleware/src/lib.rs
@@ -37,7 +37,7 @@ pub use policy::PolicyMiddleware;
 pub mod timelag;
 pub use timelag::TimeLag;
 
-/// The [ProviderBuilder](crate::ProviderBuilder) provides a way to compose many
+/// The [MiddlewareBuilder](crate::MiddlewareBuilder) provides a way to compose many
 /// [`Middleware`](ethers_providers::Middleware) in a concise way
 pub mod builder;
-pub use builder::ProviderBuilder;
+pub use builder::MiddlewareBuilder;

--- a/ethers-middleware/src/lib.rs
+++ b/ethers-middleware/src/lib.rs
@@ -37,7 +37,7 @@ pub use policy::PolicyMiddleware;
 pub mod timelag;
 pub use timelag::TimeLag;
 
-/// The [ProviderBuilder](crate::ProviderBuilder) provides a way to compose many [`Middleware`](ethers_providers::Middleware)
-/// in a concise way
+/// The [ProviderBuilder](crate::ProviderBuilder) provides a way to compose many
+/// [`Middleware`](ethers_providers::Middleware) in a concise way
 pub mod builder;
 pub use builder::ProviderBuilder;

--- a/ethers-middleware/src/lib.rs
+++ b/ethers-middleware/src/lib.rs
@@ -39,5 +39,5 @@ pub use timelag::TimeLag;
 
 /// The [ProviderBuilder](crate::ProviderBuilder) provides a way to compose many [`Middleware`](ethers_providers::Middleware)
 /// in a concise way
-pub mod provider_builder;
-pub use provider_builder::*;
+pub mod builder;
+pub use builder::ProviderBuilder;

--- a/ethers-middleware/src/lib.rs
+++ b/ethers-middleware/src/lib.rs
@@ -36,3 +36,8 @@ pub use policy::PolicyMiddleware;
 /// before the chain tip
 pub mod timelag;
 pub use timelag::TimeLag;
+
+/// The [ProviderBuilder](crate::ProviderBuilder) provides a way to compose many [`Middleware`](ethers_providers::Middleware)
+/// in a concise way
+pub mod provider_builder;
+pub use provider_builder::*;

--- a/ethers-middleware/src/provider_builder.rs
+++ b/ethers-middleware/src/provider_builder.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 /// A builder struct useful to compose different [`Middleware`](crate::Middleware) layers and then build
 /// a composed [`Provider`](crate::Provider) architecture. [`Middleware`](crate::Middleware) composition acts
-/// in a wrapping fashion. Adding a new layer results wrapping its predecessor.
+/// in a wrapping fashion. Adding a new layer results in wrapping its predecessor.
 ///
 /// Builder can be used as follows:
 ///

--- a/ethers-middleware/src/provider_builder.rs
+++ b/ethers-middleware/src/provider_builder.rs
@@ -1,0 +1,67 @@
+use ethers_providers::Middleware;
+use std::sync::Arc;
+
+/// A builder struct useful to compose different [`Middleware`](crate::Middleware) layers and then build
+/// a composed [`Provider`](crate::Provider) architecture. [`Middleware`](crate::Middleware) composition acts
+/// in a wrapping fashion. Adding a new layer results wrapping its predecessor.
+///
+/// Builder can be used as follows:
+///
+/// ```rust
+/// use ethers_providers::{Middleware, Provider, Http};
+/// use std::sync::Arc;
+/// use std::convert::TryFrom;
+/// use ethers_signers::{LocalWallet, Signer};
+/// use ethers_middleware::{*,gas_escalator::*,gas_oracle::*};
+///
+/// fn example() {
+///     let key = "fdb33e2105f08abe41a8ee3b758726a31abdd57b7a443f470f23efce853af169";
+///     let signer = key.parse::<LocalWallet>().unwrap();
+///     let address = signer.address();
+///     let escalator = GeometricGasPrice::new(1.125, 60_u64, None::<u64>);
+/// 
+///     let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
+/// 
+///     ProviderBuilder::from(provider)
+///         .wrap_into(|p| GasEscalatorMiddleware::new(p, escalator, Frequency::PerBlock))
+///         .wrap_into(|p| SignerMiddleware::new(p, signer))
+///         .wrap_into(|p| GasOracleMiddleware::new(p, EthGasStation::new(None)))
+///         .wrap_into(|p| NonceManagerMiddleware::new(p, address)) // Outermost layer
+///         .build();
+/// }
+/// ```
+pub struct ProviderBuilder<M> {
+    inner: Arc<M>,
+}
+
+impl<M> ProviderBuilder<M>
+where
+    M: Middleware,
+{
+    /// Wraps a new [`Middleware`](ethers_providers::Middleware) layer by nesting the current one.
+    ///
+    /// `builder_fn` This closure takes the current [`Middleware`](ethers_providers::Middleware) as an argument.
+    /// Use this to build a new [`Middleware`](ethers_providers::Middleware) layer wrapping out the current.
+    ///
+    pub fn wrap_into<F, R>(&mut self, builder_fn: F) -> ProviderBuilder<R>
+    where
+        F: FnOnce(Arc<M>) -> R,
+        R: Middleware,
+    {
+        let provider = self.inner.clone();
+        let provider = builder_fn(provider);
+        ProviderBuilder::from(provider)
+    }
+
+    /// Returns the overall[`Middleware`](ethers_providers::Middleware) as a reference to the outermost layer
+    pub fn build(&self) -> Arc<M> {
+        self.inner.clone()
+    }
+}
+
+
+impl<M: Middleware> From<M> for ProviderBuilder<M> {
+    fn from(provider: M) -> Self {
+        Self { inner: Arc::new(provider) }
+    }
+}

--- a/ethers-middleware/tests/builder.rs
+++ b/ethers-middleware/tests/builder.rs
@@ -13,7 +13,7 @@ mod tests {
     use ethers_signers::{LocalWallet, Signer};
 
     #[tokio::test]
-    async fn build_middleware_stack() {
+    async fn build_raw_middleware_stack() {
         let (provider, mock) = Provider::mocked();
 
         let signer = LocalWallet::new(&mut thread_rng());
@@ -25,6 +25,35 @@ mod tests {
             .wrap_into(|p| GasOracleMiddleware::new(p, EthGasStation::new(None)))
             .wrap_into(|p| SignerMiddleware::new(p, signer))
             .wrap_into(|p| NonceManagerMiddleware::new(p, address))
+            .build();
+
+        // push a response
+        mock.push(U64::from(12u64)).unwrap();
+        let block: U64 = provider.get_block_number().await.unwrap();
+        assert_eq!(block.as_u64(), 12);
+
+        provider.get_block_number().await.unwrap_err();
+
+        // 2 calls were made
+        mock.assert_request("eth_blockNumber", ()).unwrap();
+        mock.assert_request("eth_blockNumber", ()).unwrap();
+        mock.assert_request("eth_blockNumber", ()).unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn build_declarative_middleware_stack() {
+        let (provider, mock) = Provider::mocked();
+
+        let signer = LocalWallet::new(&mut thread_rng());
+        let address = signer.address();
+        let escalator = GeometricGasPrice::new(1.125, 60u64, None::<u64>);
+        let gas_oracle = EthGasStation::new(None);
+
+        let provider = ProviderBuilder::from(provider)
+            .wrap_into(|p| GasEscalatorMiddleware::new(p, escalator, Frequency::PerBlock))
+            .gas_oracle(gas_oracle)
+            .with_signer(signer)
+            .nonce_manager(address)
             .build();
 
         // push a response

--- a/ethers-middleware/tests/builder.rs
+++ b/ethers-middleware/tests/builder.rs
@@ -6,7 +6,8 @@ mod tests {
         gas_escalator::{Frequency, GasEscalatorMiddleware, GeometricGasPrice},
         gas_oracle::{EthGasStation, GasOracleMiddleware},
         nonce_manager::NonceManagerMiddleware,
-        signer::SignerMiddleware, ProviderBuilder,
+        signer::SignerMiddleware,
+        ProviderBuilder,
     };
     use ethers_providers::{Middleware, Provider};
     use ethers_signers::{LocalWallet, Signer};

--- a/ethers-middleware/tests/builder.rs
+++ b/ethers-middleware/tests/builder.rs
@@ -1,0 +1,41 @@
+#![cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "celo"))]
+mod tests {
+    use ethers_core::{rand::thread_rng, types::U64};
+    use ethers_middleware::{
+        gas_escalator::{Frequency, GasEscalatorMiddleware, GeometricGasPrice},
+        gas_oracle::{EthGasStation, GasOracleMiddleware},
+        nonce_manager::NonceManagerMiddleware,
+        signer::SignerMiddleware, ProviderBuilder,
+    };
+    use ethers_providers::{Middleware, Provider};
+    use ethers_signers::{LocalWallet, Signer};
+
+    #[tokio::test]
+    async fn build_middleware_stack() {
+        let (provider, mock) = Provider::mocked();
+
+        let signer = LocalWallet::new(&mut thread_rng());
+        let address = signer.address();
+        let escalator = GeometricGasPrice::new(1.125, 60u64, None::<u64>);
+
+        let provider = ProviderBuilder::from(provider)
+            .wrap_into(|p| GasEscalatorMiddleware::new(p, escalator, Frequency::PerBlock))
+            .wrap_into(|p| GasOracleMiddleware::new(p, EthGasStation::new(None)))
+            .wrap_into(|p| SignerMiddleware::new(p, signer))
+            .wrap_into(|p| NonceManagerMiddleware::new(p, address))
+            .build();
+
+        // push a response
+        mock.push(U64::from(12u64)).unwrap();
+        let block: U64 = provider.get_block_number().await.unwrap();
+        assert_eq!(block.as_u64(), 12);
+
+        provider.get_block_number().await.unwrap_err();
+
+        // 2 calls were made
+        mock.assert_request("eth_blockNumber", ()).unwrap();
+        mock.assert_request("eth_blockNumber", ()).unwrap();
+        mock.assert_request("eth_blockNumber", ()).unwrap_err();
+    }
+}

--- a/ethers-middleware/tests/builder.rs
+++ b/ethers-middleware/tests/builder.rs
@@ -3,11 +3,11 @@
 mod tests {
     use ethers_core::{rand::thread_rng, types::U64};
     use ethers_middleware::{
+        builder::MiddlewareBuilder,
         gas_escalator::{Frequency, GasEscalatorMiddleware, GeometricGasPrice},
         gas_oracle::{EthGasStation, GasOracleMiddleware},
         nonce_manager::NonceManagerMiddleware,
         signer::SignerMiddleware,
-        ProviderBuilder,
     };
     use ethers_providers::{Middleware, Provider};
     use ethers_signers::{LocalWallet, Signer};
@@ -20,12 +20,11 @@ mod tests {
         let address = signer.address();
         let escalator = GeometricGasPrice::new(1.125, 60u64, None::<u64>);
 
-        let provider = ProviderBuilder::from(provider)
+        let provider = provider
             .wrap_into(|p| GasEscalatorMiddleware::new(p, escalator, Frequency::PerBlock))
             .wrap_into(|p| GasOracleMiddleware::new(p, EthGasStation::new(None)))
             .wrap_into(|p| SignerMiddleware::new(p, signer))
-            .wrap_into(|p| NonceManagerMiddleware::new(p, address))
-            .build();
+            .wrap_into(|p| NonceManagerMiddleware::new(p, address));
 
         // push a response
         mock.push(U64::from(12u64)).unwrap();
@@ -49,12 +48,11 @@ mod tests {
         let escalator = GeometricGasPrice::new(1.125, 60u64, None::<u64>);
         let gas_oracle = EthGasStation::new(None);
 
-        let provider = ProviderBuilder::from(provider)
+        let provider = provider
             .wrap_into(|p| GasEscalatorMiddleware::new(p, escalator, Frequency::PerBlock))
             .gas_oracle(gas_oracle)
             .with_signer(signer)
-            .nonce_manager(address)
-            .build();
+            .nonce_manager(address);
 
         // push a response
         mock.push(U64::from(12u64)).unwrap();


### PR DESCRIPTION
## Motivation
The ability to stack different `Middleware`s  is a powerful feature of this library, since it promotes "Single Responsibility", "Open Closed Principle" and other good stuff. 
I think that readability and composability can be further improved. For such reason I propose another approach to build stacked `Middleware`s using a builder struct.

## Solution
I provided
- A `ProviderBuilder` module under  the `ethers-middleware` lib
- Extensive documentation
- Unit tests

It works as follows 
```rust
fn example() {
    let key = "fdb33e2105f08abe41a8ee3b758726a31abdd57b7a443f470f23efce853af169";
    let signer = key.parse::<LocalWallet>().unwrap();
    let address = signer.address();
    let escalator = GeometricGasPrice::new(1.125, 60_u64, None::<u64>);
 
    let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
 
    ProviderBuilder::from(provider)
        .wrap_into(|p| GasEscalatorMiddleware::new(p, escalator, Frequency::PerBlock))
        .wrap_into(|p| SignerMiddleware::new(p, signer))
        .wrap_into(|p| GasOracleMiddleware::new(p, EthGasStation::new(None)))
        .wrap_into(|p| NonceManagerMiddleware::new(p, address)) // Outermost layer
        .build();
}
```

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Updated the changelog
