### PR TITLE
fix: examples pipeline timeout 

### DIFF
--- a/examples/subscribe_events_by_type.rs
+++ b/examples/subscribe_events_by_type.rs
@@ -27,14 +27,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // refine the event filter
     let event = Contract::event_of_type::<AnswerUpdatedFilter>(&client)
         .from_block(16022082)
-        .to_block(16022282)
         .address(ValueOrArray::Array(vec![
             PRICE_FEED_1.parse()?,
             PRICE_FEED_2.parse()?,
             PRICE_FEED_3.parse()?,
         ]));
 
-    let mut stream = event.subscribe_with_meta().await?;
+    let mut stream = event.subscribe_with_meta().await?.take(2);
 
     // Note that `log` has type AnswerUpdatedFilter
     while let Some(Ok((log, meta))) = stream.next().await {

--- a/examples/subscribe_logs.rs
+++ b/examples/subscribe_logs.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
     let erc20_transfer_filter =
         Filter::new().from_block(last_block - 25).event("Transfer(address,address,uint256)");
 
-    let mut stream = client.subscribe_logs(&erc20_transfer_filter).await?;
+    let mut stream = client.subscribe_logs(&erc20_transfer_filter).await?.take(2);
 
     while let Some(log) = stream.next().await {
         println!(


### PR DESCRIPTION
## Motivation
The examples pipeline gets stuck due to  active event subscriptions

## Solution
I limited the subscriptions to take at most 2 items

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
