### PR TITLE
fix(core): format_units overflow

### DIFF
--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -159,7 +159,6 @@ where
     K: TryInto<Units, Error = ConversionError>,
 {
     let units: usize = units.try_into()?.into();
-    dbg!(&units);
     // 2**256 ~= 10**77
     if units > 77 {
         return Err(ConversionError::ParseOverflow)

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -159,6 +159,7 @@ where
     K: TryInto<Units, Error = ConversionError>,
 {
     let units: usize = units.try_into()?.into();
+    dbg!(&units);
     // 2**256 ~= 10**77
     if units > 77 {
         return Err(ConversionError::ParseOverflow)
@@ -166,16 +167,16 @@ where
     let exp10 = U256::exp10(units);
     match amount.into() {
         ParseUnits::U256(amount) => {
-            let amount_integer = amount / exp10;
-            let amount_decimals = amount % exp10;
-            Ok(format!("{amount_integer}.{amount_decimals:0units$}"))
+            let integer = amount / exp10;
+            let decimals = (amount % exp10).to_string();
+            Ok(format!("{integer}.{decimals:0>units$}"))
         }
         ParseUnits::I256(amount) => {
             let exp10 = I256::from_raw(exp10);
             let sign = if amount.is_negative() { "-" } else { "" };
-            let amount_integer = (amount / exp10).twos_complement();
-            let amount_decimals = (amount % exp10).twos_complement();
-            Ok(format!("{sign}{amount_integer}.{amount_decimals:0units$}",))
+            let integer = (amount / exp10).twos_complement();
+            let decimals = ((amount % exp10).twos_complement()).to_string();
+            Ok(format!("{sign}{integer}.{decimals:0>units$}"))
         }
     }
 }

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -544,7 +544,7 @@ mod tests {
             format_units(U256::from_dec_str("1005633240123456789").unwrap(), "ether").unwrap();
         assert_eq!(eth, "1.005633240123456789");
 
-        let eth = format_units(255u8, 4).unwrap();
+        let eth = format_units(u8::MAX, 4).unwrap();
         assert_eq!(eth, "0.0255");
 
         let eth = format_units(u16::MAX, "ether").unwrap();
@@ -560,6 +560,15 @@ mod tests {
 
         let eth = format_units(u128::MAX, 36).unwrap();
         assert_eq!(eth, "340.282366920938463463374607431768211455");
+
+        let eth = format_units(U256::MAX, 77).unwrap();
+        assert_eq!(
+            eth,
+            "1.15792089237316195423570985008687907853269984665640564039457584007913129639935"
+        );
+
+        let err = format_units(U256::MAX, 78).unwrap_err();
+        assert!(matches!(err, ConversionError::ParseOverflow));
     }
 
     #[test]
@@ -597,6 +606,15 @@ mod tests {
 
         let eth = format_units(i128::MIN, 36).unwrap();
         assert_eq!(eth, "-170.141183460469231731687303715884105728");
+
+        let eth = format_units(I256::MIN, 77).unwrap();
+        assert_eq!(
+            eth,
+            "-3.10519776906709511441072537478280230366825038335898589901356039980217175900160"
+        );
+
+        let err = format_units(I256::MIN, 78).unwrap_err();
+        assert!(matches!(err, ConversionError::ParseOverflow));
     }
 
     #[test]

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -159,11 +159,14 @@ where
     K: TryInto<Units, Error = ConversionError>,
 {
     let units: usize = units.try_into()?.into();
+
     // 2**256 ~= 10**77
     if units > 77 {
         return Err(ConversionError::ParseOverflow)
     }
     let exp10 = U256::exp10(units);
+
+    // `decimals` are formatted twice because U256 does not support alignment (`:0>width`).
     match amount.into() {
         ParseUnits::U256(amount) => {
             let integer = amount / exp10;

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -41,6 +41,11 @@ use std::{
 };
 use thiserror::Error;
 
+/// I256 overflows for numbers wider than 77 units.
+const OVERFLOW_I256_UNITS: usize = 77;
+/// U256 overflows for numbers wider than 78 units.
+const OVERFLOW_U256_UNITS: usize = 78;
+
 /// Re-export of serde-json
 #[doc(hidden)]
 pub mod __serde_json {
@@ -161,12 +166,15 @@ where
     let units: usize = units.try_into()?.into();
     let amount = amount.into();
 
-    // 78 overflows U256, 77 overflows I256
     match amount {
         // 2**256 ~= 1.16e77
-        ParseUnits::U256(_) if units >= 78 => return Err(ConversionError::ParseOverflow),
+        ParseUnits::U256(_) if units >= OVERFLOW_U256_UNITS => {
+            return Err(ConversionError::ParseOverflow)
+        }
         // 2**255 ~= 5.79e76
-        ParseUnits::I256(_) if units >= 77 => return Err(ConversionError::ParseOverflow),
+        ParseUnits::I256(_) if units >= OVERFLOW_I256_UNITS => {
+            return Err(ConversionError::ParseOverflow)
+        }
         _ => {}
     };
     let exp10 = U256::exp10(units);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

U256::from(u128...);
U256::exp10(x) with x > 77;
also lots of unnecessary calculations and casts

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
