### PR TITLE
fix: txpool_inspect unable to parse contract creations

### DIFF
--- a/ethers-core/src/types/txpool.rs
+++ b/ethers-core/src/types/txpool.rs
@@ -65,9 +65,9 @@ impl<'de> Visitor<'de> for TxpoolInspectSummaryVisitor {
                 Some(Address::from_str(&addr.to_string().split_off(2)).map_err(de::Error::custom)?)
             }
         };
-        let value = U256::from(u64::from_str(value_split[0]).map_err(de::Error::custom)?);
-        let gas = U256::from(u64::from_str(gas_split[0]).map_err(de::Error::custom)?);
-        let gas_price = U256::from(u64::from_str(gas_price_split[0]).map_err(de::Error::custom)?);
+        let value = U256::from(u128::from_str(value_split[0]).map_err(de::Error::custom)?);
+        let gas = U256::from(u128::from_str(gas_split[0]).map_err(de::Error::custom)?);
+        let gas_price = U256::from(u128::from_str(gas_price_split[0]).map_err(de::Error::custom)?);
 
         Ok(TxpoolInspectSummary { to: addr, value, gas, gas_price })
     }
@@ -386,9 +386,9 @@ mod tests {
             "124930".to_string(),
             TxpoolInspectSummary {
                 to: Some(Address::from_str("000000000000000000000000000000000000007E").unwrap()),
-                value: U256::from(0u64),
-                gas: U256::from(100187u64),
-                gas_price: U256::from(20000000000u64),
+                value: U256::from(0u128),
+                gas: U256::from(100187u128),
+                gas_price: U256::from(20000000000u128),
             },
         );
         pending_map.insert(
@@ -400,36 +400,36 @@ mod tests {
             "252350".to_string(),
             TxpoolInspectSummary {
                 to: Some(Address::from_str("d10e3Be2bc8f959Bc8C41CF65F60dE721cF89ADF").unwrap()),
-                value: U256::from(0u64),
-                gas: U256::from(65792u64),
-                gas_price: U256::from(2000000000u64),
+                value: U256::from(0u128),
+                gas: U256::from(65792u128),
+                gas_price: U256::from(2000000000u128),
             },
         );
         pending_map_inner.insert(
             "252351".to_string(),
             TxpoolInspectSummary {
                 to: Some(Address::from_str("d10e3Be2bc8f959Bc8C41CF65F60dE721cF89ADF").unwrap()),
-                value: U256::from(0u64),
-                gas: U256::from(65792u64),
-                gas_price: U256::from(2000000000u64),
+                value: U256::from(0u128),
+                gas: U256::from(65792u128),
+                gas_price: U256::from(2000000000u128),
             },
         );
         pending_map_inner.insert(
             "252352".to_string(),
             TxpoolInspectSummary {
                 to: Some(Address::from_str("d10e3Be2bc8f959Bc8C41CF65F60dE721cF89ADF").unwrap()),
-                value: U256::from(0u64),
-                gas: U256::from(65780u64),
-                gas_price: U256::from(2000000000u64),
+                value: U256::from(0u128),
+                gas: U256::from(65780u128),
+                gas_price: U256::from(2000000000u128),
             },
         );
         pending_map_inner.insert(
             "252353".to_string(),
             TxpoolInspectSummary {
                 to: Some(Address::from_str("d10e3Be2bc8f959Bc8C41CF65F60dE721cF89ADF").unwrap()),
-                value: U256::from(0u64),
-                gas: U256::from(65780u64),
-                gas_price: U256::from(2000000000u64),
+                value: U256::from(0u128),
+                gas: U256::from(65780u128),
+                gas_price: U256::from(2000000000u128),
             },
         );
         pending_map.insert(
@@ -441,9 +441,9 @@ mod tests {
             "40".to_string(),
             TxpoolInspectSummary {
                 to: None,
-                value: U256::from(0u64),
-                gas: U256::from(612412),
-                gas_price: U256::from(6000000000u64),
+                value: U256::from(0u128),
+                gas: U256::from(612412u128),
+                gas_price: U256::from(6000000000u128),
             },
         );
         pending_map.insert(
@@ -456,18 +456,18 @@ mod tests {
             "7".to_string(),
             TxpoolInspectSummary {
                 to: Some(Address::from_str("3479BE69e07E838D9738a301Bb0c89e8EA2Bef4a").unwrap()),
-                value: U256::from(1000000000000000u64),
-                gas: U256::from(21000u64),
-                gas_price: U256::from(10000000000u64),
+                value: U256::from(1000000000000000u128),
+                gas: U256::from(21000u128),
+                gas_price: U256::from(10000000000u128),
             },
         );
         queued_map_inner.insert(
             "8".to_string(),
             TxpoolInspectSummary {
                 to: Some(Address::from_str("73Aaf691bc33fe38f86260338EF88f9897eCaa4F").unwrap()),
-                value: U256::from(1000000000000000u64),
-                gas: U256::from(21000u64),
-                gas_price: U256::from(10000000000u64),
+                value: U256::from(1000000000000000u128),
+                gas: U256::from(21000u128),
+                gas_price: U256::from(10000000000u128),
             },
         );
         queued_map.insert(
@@ -479,9 +479,9 @@ mod tests {
             "3".to_string(),
             TxpoolInspectSummary {
                 to: Some(Address::from_str("73Aaf691bc33fe38f86260338EF88f9897eCaa4F").unwrap()),
-                value: U256::from(10000000000000000u64),
-                gas: U256::from(21000u64),
-                gas_price: U256::from(10000000000u64),
+                value: U256::from(10000000000000000u128),
+                gas: U256::from(21000u128),
+                gas_price: U256::from(10000000000u128),
             },
         );
         queued_map.insert(

--- a/ethers-core/src/types/txpool.rs
+++ b/ethers-core/src/types/txpool.rs
@@ -62,12 +62,12 @@ impl<'de> Visitor<'de> for TxpoolInspectSummaryVisitor {
             "0x" => None,
             "contract creation" => None,
             addr => {
-                Some(Address::from_str(&addr.to_string().split_off(2)).map_err(de::Error::custom)?)
+                Some(Address::from_str(addr.trim_start_matches("0x")).map_err(de::Error::custom)?)
             }
         };
-        let value = U256::from(u128::from_str(value_split[0]).map_err(de::Error::custom)?);
-        let gas = U256::from(u128::from_str(gas_split[0]).map_err(de::Error::custom)?);
-        let gas_price = U256::from(u128::from_str(gas_price_split[0]).map_err(de::Error::custom)?);
+        let value = U256::from_dec_str(value_split[0]).map_err(de::Error::custom)?;
+        let gas = U256::from_dec_str(gas_split[0]).map_err(de::Error::custom)?;
+        let gas_price = U256::from_dec_str(gas_price_split[0]).map_err(de::Error::custom)?;
 
         Ok(TxpoolInspectSummary { to: addr, value, gas, gas_price })
     }

--- a/ethers-core/src/types/txpool.rs
+++ b/ethers-core/src/types/txpool.rs
@@ -90,9 +90,10 @@ impl Serialize for TxpoolInspectSummary {
     where
         S: serde::Serializer,
     {
-        let formatted_to = match self.to {
-            Some(to) => format!("{:?}", to),
-            None => "contract creation".to_string(),
+        let formatted_to = if let Some(to) = self.to {
+            format!("{:?}", to)
+        } else {
+            "contract creation".to_string()
         };
         let formatted = format!(
             "{}: {} wei + {} gas × {} wei",

--- a/ethers-core/src/types/txpool.rs
+++ b/ethers-core/src/types/txpool.rs
@@ -60,6 +60,7 @@ impl<'de> Visitor<'de> for TxpoolInspectSummaryVisitor {
         let addr = match addr_split[0] {
             "" => None,
             "0x" => None,
+            "contract creation" => None,
             addr => {
                 Some(Address::from_str(&addr.to_string().split_off(2)).map_err(de::Error::custom)?)
             }
@@ -89,12 +90,13 @@ impl Serialize for TxpoolInspectSummary {
     where
         S: serde::Serializer,
     {
+        let formatted_to = match self.to {
+            Some(to) => format!("{:?}", to),
+            None => "contract creation".to_string(),
+        };
         let formatted = format!(
-            "{:?}: {} wei + {} gas × {} wei",
-            self.to.unwrap_or_default(),
-            self.value,
-            self.gas,
-            self.gas_price
+            "{}: {} wei + {} gas × {} wei",
+            formatted_to, self.value, self.gas, self.gas_price
         );
         serializer.serialize_str(&formatted)
     }
@@ -341,6 +343,9 @@ mod tests {
       "252351": "0xd10e3Be2bc8f959Bc8C41CF65F60dE721cF89ADF: 0 wei + 65792 gas × 2000000000 wei",
       "252352": "0xd10e3Be2bc8f959Bc8C41CF65F60dE721cF89ADF: 0 wei + 65780 gas × 2000000000 wei",
       "252353": "0xd10e3Be2bc8f959Bc8C41CF65F60dE721cF89ADF: 0 wei + 65780 gas × 2000000000 wei"
+    },
+    "0x00000000863B56a3C1f0F1be8BC4F8b7BD78F57a": {
+      "40": "contract creation: 0 wei + 612412 gas × 6000000000 wei"
     }
   },
   "queued": {
@@ -428,6 +433,20 @@ mod tests {
         );
         pending_map.insert(
             Address::from_str("201354729f8d0f8b64e9a0c353c672c6a66b3857").unwrap(),
+            pending_map_inner.clone(),
+        );
+        pending_map_inner.clear();
+        pending_map_inner.insert(
+            "40".to_string(),
+            TxpoolInspectSummary {
+                to: None,
+                value: U256::from(0u64),
+                gas: U256::from(612412),
+                gas_price: U256::from(6000000000u64),
+            },
+        );
+        pending_map.insert(
+            Address::from_str("00000000863B56a3C1f0F1be8BC4F8b7BD78F57a").unwrap(),
             pending_map_inner,
         );
         let mut queued_map = BTreeMap::new();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes #1899 

## Description of problem

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The error occurs due to `TxpoolInspectSummary`'s deserialize method not having a way to parse the following response

```
"0x00000000863B56a3C1f0F1be8BC4F8b7BD78F57a": {
  "40": "contract creation: 0 wei + 612412 gas × 6000000000 wei"
}

```
## Solution
- Add a new match arm to map "contract creation" into None (as specified [here](https://github.com/gakonst/ethers-rs/blob/79e64a8378891df5afc6b83f75059c5afc587ae1/ethers-core/src/types/txpool.rs#L11)) when deserializing  `TxpoolInspectSummary`'s `to` field

- Rewrite tests to account for deserializing and serializing logs that include a contract creation

- `TxpoolInspectSummary`'s serialize method should serialize a `to` field equal to **None** into "contract creation" or "0x" instead of the default value for address type ("0x0000000000000000000000000000000000000000" - treated as a valid address)

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
