### PR TITLE
fix(core): always set p2p port in non-dev mode

### DIFF
--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -339,9 +339,9 @@ impl Geth {
                 }
             }
             GethMode::NonDev(PrivateNetOptions { p2p_port, discovery }) => {
-                if let Some(p2p_port) = p2p_port {
-                    cmd.arg("--port").arg(p2p_port.to_string());
-                }
+                // automatically enable and set the p2p port if we are in non-dev mode
+                let port = if let Some(port) = p2p_port { port } else { unused_port() };
+                cmd.arg("--port").arg(port.to_string());
 
                 // disable discovery if the flag is set
                 if !discovery {


### PR DESCRIPTION
## Motivation

If another process is already using the default p2p port, disabling discovery will cause the geth instance to crash because it will start with p2p enabled. Even if it doesn't crash, the p2p port will not be visible from the `GethInstance` created when geth is spawned. Instead, it would be `None`.

## Solution

Always set the p2p port if geth is in non-dev mode, using `unused_port` if the p2p port is not explicitly set.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
