### PR TITLE
chore: generate selector as hex in docs

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract/errors.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/errors.rs
@@ -60,10 +60,10 @@ impl Context {
         };
 
         let doc = format!(
-            "Custom Error type `{}` with signature `{}` and selector `{:?}`",
+            "Custom Error type `{}` with signature `{}` and selector `0x{}`",
             error.name,
             abi_signature,
-            error.selector()
+            hex::encode(&error.selector()[..])
         );
         let abi_signature_doc = util::expand_doc(&doc);
         let ethers_contract = ethers_contract_crate();

--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -125,10 +125,10 @@ impl Context {
         let function_name = &function.name;
         let abi_signature = function.abi_signature();
         let doc = format!(
-            "Container type for all input parameters for the `{}` function with signature `{}` and selector `{:?}`",
+            "Container type for all input parameters for the `{}` function with signature `{}` and selector `0x{}`",
             function.name,
             abi_signature,
-            function.selector()
+            hex::encode(&function.selector()[..])
         );
         let abi_signature_doc = util::expand_doc(&doc);
         let ethers_contract = ethers_contract_crate();
@@ -177,10 +177,10 @@ impl Context {
         };
         let abi_signature = function.abi_signature();
         let doc = format!(
-            "Container type for all return fields from the `{}` function with signature `{}` and selector `{:?}`",
+            "Container type for all return fields from the `{}` function with signature `{}` and selector `0x{}`",
             function.name,
             abi_signature,
-            function.selector()
+            hex::encode(&function.selector()[..])
         );
         let abi_signature_doc = util::expand_doc(&doc);
         let ethers_contract = ethers_contract_crate();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
instead of byte array, generate selector as hex for docs.

all clippy stuff fixed here https://github.com/gakonst/ethers-rs/pull/1923
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
