### PR TITLE
docs: update MRSV to 1.64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ethers"
 version = "1.0.2"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/ethers-addressbook/Cargo.toml
+++ b/ethers-addressbook/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ethers-addressbook"
 version = "1.0.2"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 license = "MIT OR Apache-2.0"
 description = "Common Ethereum name to address mappings"

--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ethers-contract"
 version = "1.0.2"
 edition = "2018"
-rust-version = "1.62"
+rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 license = "MIT OR Apache-2.0"
 description = "Smart contract bindings for the ethers-rs crate"

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -1324,7 +1324,7 @@ contract Enum {
         name = "ethers-contract"
         version = "1.0.0"
         edition = "2018"
-        rust-version = "1.62"
+        rust-version = "1.64"
         authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
         license = "MIT OR Apache-2.0"
         description = "Smart contract bindings for the ethers-rs crate"
@@ -1370,7 +1370,7 @@ contract Enum {
         name = "ethers-contract"
         version = "1.0.0"
         edition = "2018"
-        rust-version = "1.62"
+        rust-version = "1.64"
         authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
         license = "MIT OR Apache-2.0"
         description = "Smart contract bindings for the ethers-rs crate"
@@ -1417,7 +1417,7 @@ contract Enum {
         name = "ethers-contract"
         version = "1.0.0"
         edition = "2018"
-        rust-version = "1.62"
+        rust-version = "1.64"
         authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
         license = "MIT OR Apache-2.0"
         description = "Smart contract bindings for the ethers-rs crate"
@@ -1464,7 +1464,7 @@ contract Enum {
         name = "ethers-contract"
         version = "1.0.0"
         edition = "2018"
-        rust-version = "1.62"
+        rust-version = "1.64"
         authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
         license = "MIT OR Apache-2.0"
         description = "Smart contract bindings for the ethers-rs crate"

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ethers-core"
 license = "MIT OR Apache-2.0"
 version = "1.0.2"
-rust-version = "1.62"
+rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 edition = "2018"
 description = "Core structures for the ethers-rs crate"

--- a/ethers-etherscan/Cargo.toml
+++ b/ethers-etherscan/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ethers-etherscan"
 version = "1.0.2"
-rust-version = "1.62"
+rust-version = "1.64"
 authors = [
     "Matthias Seitz <matthias.seitz@outlook.de>",
     "Georgios Konstantopoulos <me@gakonst.com>",

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ethers-middleware"
 version = "1.0.2"
 edition = "2018"
-rust-version = "1.62"
+rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 license = "MIT OR Apache-2.0"
 description = "Middleware implementations for the ethers-rs crate"

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ethers-providers"
 version = "1.0.2"
 edition = "2018"
-rust-version = "1.62"
+rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 license = "MIT OR Apache-2.0"
 description = "Provider implementations for the ethers-rs crate"

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ethers-signers"
 version = "1.0.2"
 edition = "2018"
-rust-version = "1.62"
+rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 license = "MIT OR Apache-2.0"
 description = "Signer implementations for the ethers-rs crate"

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ethers-solc"
 version = "1.0.2"
 edition = "2018"
-rust-version = "1.62"
+rust-version = "1.64"
 authors = [
     "Matthias Seitz <matthias.seitz@outlook.de>",
     "Georgios Konstantopoulos <me@gakonst.com>",

--- a/examples/ethers-wasm/Cargo.toml
+++ b/examples/ethers-wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ethers-wasm"
 version = "0.1.0"
 edition = "2018"
-rust-version = "1.62"
+rust-version = "1.64"
 authors = ["Matthias Seitz <matthias.seitz@outlook.de>"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Motivation

IntoFuture was implemented in #1826, which means the MSRV should be 1.64

## Solution

Update `rust-version` in `Cargo.toml`

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
