### PR TITLE
fix(core): set `GethInstance` p2p_port in spawn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,7 @@ dependencies = [
  "libc",
  "log",
  "matches",
- "nix",
+ "nix 0.13.1",
  "serde",
  "thiserror",
  "wasm-bindgen",
@@ -834,7 +834,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
- "memoffset",
+ "memoffset 0.6.5",
  "scopeguard",
 ]
 
@@ -1414,6 +1414,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "k256",
+ "nix 0.26.1",
  "once_cell",
  "open-fastrlp",
  "proc-macro2",
@@ -2461,6 +2462,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,6 +2538,20 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "void",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,6 +1425,7 @@ dependencies = [
  "serde_json",
  "strum",
  "syn",
+ "tempfile",
  "thiserror",
  "tiny-keccak",
  "unicode-xid",

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -35,9 +35,6 @@ once_cell = { version = "1.16.0", optional = true }
 unicode-xid = "0.2.4"
 strum = { version = "0.24", features = ["derive"] }
 
-# for sending sigint to geth
-nix = "0.26.1"
-
 # macros feature enabled dependencies
 cargo_metadata = { version = "0.15.2", optional = true }
 

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -35,6 +35,9 @@ once_cell = { version = "1.16.0", optional = true }
 unicode-xid = "0.2.4"
 strum = { version = "0.24", features = ["derive"] }
 
+# for sending sigint to geth
+nix = "0.26.1"
+
 # macros feature enabled dependencies
 cargo_metadata = { version = "0.15.2", optional = true }
 

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -47,6 +47,7 @@ syn = { version = "1.0.105", optional = true }
 proc-macro2 = { version = "1.0.47", optional = true }
 
 [dev-dependencies]
+tempfile = { version = "3.3.0", default-features = false }
 serde_json = { version = "1.0.64", default-features = false }
 bincode = { version = "1.3.3", default-features = false }
 once_cell = { version = "1.16.0" }

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -1,3 +1,8 @@
+use nix::{
+    sys::signal::{kill, Signal},
+    unistd::Pid,
+};
+
 use super::{unused_port, Genesis};
 use crate::types::H256;
 use std::{
@@ -99,7 +104,8 @@ impl GethInstance {
 
 impl Drop for GethInstance {
     fn drop(&mut self) {
-        self.pid.kill().expect("could not kill geth");
+        let pid = Pid::from_raw(self.pid.id() as i32);
+        kill(pid, Signal::SIGTERM).expect("could not kill geth");
     }
 }
 

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -411,29 +411,54 @@ impl Geth {
     }
 }
 
+// These tests should use a different datadir for each `Geth` spawned
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn p2p_port() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir_path = temp_dir.path().to_path_buf();
+
         // disabling discovery should put the geth instance into non-dev mode, and it should have a
         // p2p port.
-        let geth = Geth::new().disable_discovery().spawn();
-        assert!(geth.p2p_port().is_some());
+        let geth = Geth::new().disable_discovery().data_dir(temp_dir_path).spawn();
+        let p2p_port = geth.p2p_port();
+
+        drop(geth);
+        temp_dir.close().unwrap();
+
+        assert!(p2p_port.is_some());
     }
 
     #[test]
     fn explicit_p2p_port() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir_path = temp_dir.path().to_path_buf();
+
         // if a p2p port is explicitly set, it should be used
-        let geth = Geth::new().p2p_port(1234).spawn();
-        assert_eq!(geth.p2p_port(), Some(1234));
+        let geth = Geth::new().p2p_port(1234).data_dir(temp_dir_path).spawn();
+        let p2p_port = geth.p2p_port();
+
+        drop(geth);
+        temp_dir.close().unwrap();
+
+        assert_eq!(p2p_port, Some(1234));
     }
 
     #[test]
     fn dev_mode() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir_path = temp_dir.path().to_path_buf();
+
         // dev mode should not have a p2p port, and dev should be the default
-        let geth = Geth::new().spawn();
-        assert!(geth.p2p_port().is_none());
+        let geth = Geth::new().data_dir(temp_dir_path).spawn();
+        let p2p_port = geth.p2p_port();
+
+        drop(geth);
+        temp_dir.close().unwrap();
+
+        assert!(p2p_port.is_none());
     }
 }

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -105,7 +105,7 @@ impl GethInstance {
 impl Drop for GethInstance {
     fn drop(&mut self) {
         let pid = Pid::from_raw(self.pid.id() as i32);
-        kill(pid, Signal::SIGTERM).expect("could not kill geth");
+        kill(pid, Signal::SIGINT).expect("could not kill geth");
     }
 }
 

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -1,8 +1,3 @@
-use nix::{
-    sys::signal::{kill, Signal},
-    unistd::Pid,
-};
-
 use super::{unused_port, Genesis};
 use crate::types::H256;
 use std::{
@@ -104,8 +99,7 @@ impl GethInstance {
 
 impl Drop for GethInstance {
     fn drop(&mut self) {
-        let pid = Pid::from_raw(self.pid.id() as i32);
-        kill(pid, Signal::SIGINT).expect("could not kill geth");
+        self.pid.kill().expect("could not kill geth");
     }
 }
 

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -430,11 +430,4 @@ mod tests {
         let geth = Geth::new().spawn();
         assert!(geth.p2p_port().is_none());
     }
-
-    #[test]
-    fn test_rpc_port_exists() {
-        // if a rpc port is explicitly set, it should be available
-        let geth = Geth::new().port(1234u16).spawn();
-        assert_eq!(geth.port(), 1234);
-    }
 }


### PR DESCRIPTION
## Motivation

Previously, spawning Geth with disabled discovery would not actually set the p2p port in the returned GethInstance. This is because it would only pass the port to the geth command. If the value started as None, it would remain to be None in the GethInstance even though a port was passed to the command.

## Solution

Return the p2p port by the `match` statement that handles setting the p2p port if `Geth` is in `PrivateNetMode`. This port is then set and returned in the `GethInstance`.

 * adds tests for the existence of ports in GethInstance

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
