### PR TITLE
fix(core): decode to correctly in Transaction

### DIFF
--- a/ethers-core/src/types/transaction/eip1559.rs
+++ b/ethers-core/src/types/transaction/eip1559.rs
@@ -208,7 +208,7 @@ impl Eip1559TransactionRequest {
         *offset += 1;
         tx.gas = Some(rlp.val_at(*offset)?);
         *offset += 1;
-        tx.to = decode_to(rlp, offset)?;
+        tx.to = decode_to(rlp, offset)?.map(NameOrAddress::Address);
         tx.value = Some(rlp.val_at(*offset)?);
         *offset += 1;
         let data = rlp::Rlp::new(rlp.at(*offset)?.as_raw()).data()?;

--- a/ethers-core/src/types/transaction/mod.rs
+++ b/ethers-core/src/types/transaction/mod.rs
@@ -75,7 +75,7 @@ fn decode_signature(
 fn decode_to(
     rlp: &rlp::Rlp,
     offset: &mut usize,
-) -> Result<Option<super::NameOrAddress>, rlp::DecoderError> {
+) -> Result<Option<super::Address>, rlp::DecoderError> {
     let to = {
         let to = rlp.at(*offset)?;
         if to.is_empty() {

--- a/ethers-core/src/types/transaction/request.rs
+++ b/ethers-core/src/types/transaction/request.rs
@@ -233,7 +233,7 @@ impl TransactionRequest {
             *offset += 1;
         }
 
-        txn.to = decode_to(rlp, offset)?;
+        txn.to = decode_to(rlp, offset)?.map(NameOrAddress::Address);
         txn.value = Some(rlp.at(*offset)?.as_val()?);
         *offset += 1;
 


### PR DESCRIPTION
## Motivation

Currently `Transaction`s do not decode correctly if they are contract creation transactions. This is when the `to` field is `None`, which is encoded in RLP as `0x80`. 

## Solution

Refactor the `decode_to` method to instead return `Result<Option<Address>, DecodeError>`, and use it when decoding `Transaction`s, not just transaction requests.

Add a test from #1393 that passes with the changes.

Fixes #1939

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
