### PR TITLE
fix: Add `openssl` and `rustls` feature flags in ethers-middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,6 +341,8 @@
 
 ### Unreleased
 
+- Added `openssl` and `rustls` feature flags
+  [#1961](https://github.com/gakonst/ethers-rs/pull/1961)
 - Relax Clone requirements when Arc<Middleware> is used
   [#1183](https://github.com/gakonst/ethers-rs/pull/1183)
 - Ensure a consistent chain ID between a Signer and Provider in SignerMiddleware

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,12 +63,14 @@ eip712 = ["ethers-contract/eip712", "ethers-core/eip712"]
 ws = ["ethers-providers/ws"]
 ipc = ["ethers-providers/ipc"]
 rustls = [
+    "ethers-middleware/rustls",
     "ethers-providers/rustls",
     "ethers-etherscan/rustls",
     "ethers-contract/rustls",
     "ethers-solc/rustls",
 ]
 openssl = [
+    "ethers-middleware/openssl",
     "ethers-providers/openssl",
     "ethers-etherscan/openssl",
     "ethers-contract/openssl",

--- a/ethers-contract/ethers-contract-derive/Cargo.toml
+++ b/ethers-contract/ethers-contract-derive/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 
 [dependencies]
 ethers-core = { version = "^1.0.0", path = "../../ethers-core" }
-ethers-contract-abigen = { version = "^1.0.0", path = "../ethers-contract-abigen" }
+ethers-contract-abigen = { version = "^1.0.0", path = "../ethers-contract-abigen", default-features = false }
 
 serde_json = "1.0.53"
 hex = { version = "0.4.3", default-features = false, features = ["std"] }

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -31,7 +31,7 @@ tracing = { version = "0.1.37", default-features = false }
 tracing-futures = { version = "0.2.5", default-features = false }
 
 # for gas oracles
-reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.11.13", default-features = false, features = ["json"] }
 url = { version = "2.3.1", default-features = false }
 
 serde_json = { version = "1.0.64", default-features = false }
@@ -50,9 +50,13 @@ ethers-providers = { version = "^1.0.0", path = "../ethers-providers", default-f
 once_cell = "1.16.0"
 ethers-solc = { version = "^1.0.0", path = "../ethers-solc" }
 serial_test = "0.9.0"
+reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1.18", default-features = false, features = ["rt", "macros", "time"] }
 
 [features]
+default = ["rustls"]
 celo = ["ethers-core/celo", "ethers-providers/celo", "ethers-signers/celo", "ethers-contract/celo"]
+openssl = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls-tls"]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I was working on a project with requirement to use OpenSSL, so I added this:

```
ethers = { version = "1.0.2", default-features = false, features = ["ws", "openssl"] }
```

But I noticed that `rustls` was still building.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The problem was that `ethers-middleware` was explicitly using `reqwest` with `rustls-tls` enabled, so I added `rustls` and `openssl` feature flags to it.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [x] Updated the changelog
-   [ ] Breaking changes
