### PR TITLE
feat(solc): create compilation unit for files that share solc version/ settings

### DIFF
--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -284,7 +284,7 @@ impl From<CompilerInput> for StandardJsonCompilerInput {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
     /// Stop compilation after the given stage.
@@ -513,6 +513,17 @@ impl Hash for Settings {
             (revert_strings.unwrap_or_default() as u8).hash(state);
             debug_info.hash(state);
         }
+    }
+}
+
+impl PartialEq for Settings {
+    fn eq(&self, other: &Self) -> bool {
+        self.optimizer == other.optimizer &&
+            self.metadata == other.metadata &&
+            self.output_selection == other.output_selection &&
+            self.evm_version == other.evm_version &&
+            self.via_ir == other.via_ir &&
+            self.debug == other.debug
     }
 }
 

--- a/ethers-solc/src/artifacts/output_selection.rs
+++ b/ethers-solc/src/artifacts/output_selection.rs
@@ -68,7 +68,7 @@ pub type FileOutputSelection = BTreeMap<String, Vec<String>>;
 ///    }
 ///  }
 /// ```
-#[derive(Debug, Clone, Eq, PartialEq, Default, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Default, Deserialize, Hash)]
 #[serde(transparent)]
 pub struct OutputSelection(pub BTreeMap<String, FileOutputSelection>);
 

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -41,7 +41,7 @@ impl CompilationUnitId {
         version.hash(&mut hasher);
         solc_config.hash(&mut hasher);
         let result = hasher.finish();
-        Self(format!("{:x}", result))
+        Self(format!("{result:x}"))
     }
 }
 
@@ -676,11 +676,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
         } else {
             self.cache.compilation_units.insert(
                 id,
-                CompilationUnit {
-                    solc_config,
-                    version,
-                    source_units: HashSet::from([file.to_path_buf()]),
-                },
+                CompilationUnit { solc_config, version, source_units: HashSet::from([file]) },
             );
         }
     }

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -32,7 +32,7 @@ const ETHERS_FORMAT_VERSION: &str = "ethers-rs-sol-cache-4";
 pub const SOLIDITY_FILES_CACHE_FILENAME: &str = "solidity-files-cache.json";
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
-pub struct CompilationUnitId(String);
+pub struct CompilationUnitId(u64);
 
 impl CompilationUnitId {
     /// Create a unique id for each compilation unit based on compiler version and settings
@@ -40,8 +40,13 @@ impl CompilationUnitId {
         let mut hasher = hash_map::DefaultHasher::new();
         version.hash(&mut hasher);
         solc_config.hash(&mut hasher);
-        let result = hasher.finish();
-        Self(format!("{result:x}"))
+        Self(hasher.finish())
+    }
+}
+
+impl std::fmt::Display for CompilationUnitId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:x}", self.0)
     }
 }
 

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -31,6 +31,7 @@ const ETHERS_FORMAT_VERSION: &str = "ethers-rs-sol-cache-4";
 /// The file name of the default cache file
 pub const SOLIDITY_FILES_CACHE_FILENAME: &str = "solidity-files-cache.json";
 
+/// A unique identifier for source files that were compiled together
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct CompilationUnitId(u64);
 

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -789,10 +789,8 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
                     tracing::trace!("changed content hash for source file \"{}\"", file.display());
                     return true
                 }
-                if let Some(compilation_unit) = self
-                    .cache
-                    .compilation_units
-                    .get(&CompilationUnitId::new(version.clone(), self.project.solc_config.clone()))
+                if let Some(compilation_unit) =
+                    self.cache.compilation_units.get(&entry.compilation_unit)
                 {
                     if self.project.solc_config != compilation_unit.solc_config {
                         tracing::trace!(

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -690,11 +690,10 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
     /// If there is already an entry available for the file the given version is added to the set
     fn insert_new_cache_entry(&mut self, file: &Path, source: &Source, version: Version) {
         if let Some((_, versions)) = self.dirty_source_files.get_mut(file) {
-            versions.insert(version.clone());
+            versions.insert(version);
         } else {
             let entry = self.create_cache_entry(file, source, version.clone());
-            self.dirty_source_files
-                .insert(file.to_path_buf(), (entry.clone(), HashSet::from([version.clone()])));
+            self.dirty_source_files.insert(file.to_path_buf(), (entry, HashSet::from([version])));
         }
     }
 

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -32,7 +32,7 @@ const ETHERS_FORMAT_VERSION: &str = "ethers-rs-sol-cache-4";
 pub const SOLIDITY_FILES_CACHE_FILENAME: &str = "solidity-files-cache.json";
 
 /// A unique identifier for source files that were compiled together
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
 pub struct CompilationUnitId(u64);
 
 impl CompilationUnitId {
@@ -57,7 +57,7 @@ impl std::fmt::Display for CompilationUnitId {
 pub struct CompilationUnit {
     pub solc_config: SolcConfig,
     pub version: Version,
-    pub source_units: HashSet<PathBuf>,
+    pub source_units: BTreeSet<PathBuf>,
 }
 
 /// A multi version cache file
@@ -69,7 +69,7 @@ pub struct SolFilesCache {
     pub paths: ProjectPaths,
     pub files: BTreeMap<PathBuf, CacheEntry>,
     #[serde(rename = "compilationUnits")]
-    pub compilation_units: HashMap<CompilationUnitId, CompilationUnit>,
+    pub compilation_units: BTreeMap<CompilationUnitId, CompilationUnit>,
 }
 
 impl SolFilesCache {
@@ -77,7 +77,7 @@ impl SolFilesCache {
     pub fn new(
         files: BTreeMap<PathBuf, CacheEntry>,
         paths: ProjectPaths,
-        compilation_units: HashMap<CompilationUnitId, CompilationUnit>,
+        compilation_units: BTreeMap<CompilationUnitId, CompilationUnit>,
     ) -> Self {
         Self { format: ETHERS_FORMAT_VERSION.to_string(), files, paths, compilation_units }
     }
@@ -682,7 +682,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
         } else {
             self.cache.compilation_units.insert(
                 id,
-                CompilationUnit { solc_config, version, source_units: HashSet::from([file]) },
+                CompilationUnit { solc_config, version, source_units: BTreeSet::from([file]) },
             );
         }
     }

--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -37,7 +37,7 @@ pub struct CompilationUnitId(u64);
 
 impl CompilationUnitId {
     /// Create a unique id for each compilation unit based on compiler version and settings
-    pub fn new(version: Version, solc_config: SolcConfig) -> Self {
+    pub fn new(version: &Version, solc_config: &SolcConfig) -> Self {
         let mut hasher = hash_map::DefaultHasher::new();
         version.hash(&mut hasher);
         solc_config.hash(&mut hasher);
@@ -654,7 +654,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
                 .unwrap_or_default(),
             content_hash: source.content_hash(),
             source_name: utils::source_name(file, self.project.root()).into(),
-            compilation_unit: CompilationUnitId::new(version, self.project.solc_config.clone()),
+            compilation_unit: CompilationUnitId::new(&version, &self.project.solc_config),
             imports,
             version_requirement: self.edges.version_requirement(file).map(|v| v.to_string()),
             // artifacts remain empty until we received the compiler output
@@ -674,7 +674,7 @@ impl<'a, T: ArtifactOutput> ArtifactsCacheInner<'a, T> {
         solc_config: SolcConfig,
         version: Version,
     ) {
-        let id = CompilationUnitId::new(version.clone(), solc_config.clone());
+        let id = CompilationUnitId::new(&version, &solc_config);
         if let Some(CompilationUnit { source_units, .. }) =
             self.cache.compilation_units.get_mut(&id)
         {

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -720,7 +720,7 @@ impl ProjectPathsConfigBuilder {
 }
 
 /// The config to use when compiling the contracts
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Serialize, Deserialize)]
 pub struct SolcConfig {
     /// How the file was compiled
     pub settings: Settings,
@@ -749,6 +749,12 @@ impl From<SolcConfig> for Settings {
 impl Hash for SolcConfig {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.settings.hash(state);
+    }
+}
+
+impl PartialEq for SolcConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.settings == other.settings
     }
 }
 

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -11,7 +11,6 @@ use std::{
     collections::{BTreeSet, HashSet},
     fmt::{self, Formatter},
     fs,
-    hash::{Hash, Hasher},
     ops::{Deref, DerefMut},
     path::{Component, Path, PathBuf},
 };
@@ -720,7 +719,7 @@ impl ProjectPathsConfigBuilder {
 }
 
 /// The config to use when compiling the contracts
-#[derive(Clone, Debug, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct SolcConfig {
     /// How the file was compiled
     pub settings: Settings,
@@ -743,18 +742,6 @@ impl SolcConfig {
 impl From<SolcConfig> for Settings {
     fn from(config: SolcConfig) -> Self {
         config.settings
-    }
-}
-
-impl Hash for SolcConfig {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.settings.hash(state);
-    }
-}
-
-impl PartialEq for SolcConfig {
-    fn eq(&self, other: &Self) -> bool {
-        self.settings == other.settings
     }
 }
 

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -11,6 +11,7 @@ use std::{
     collections::{BTreeSet, HashSet},
     fmt::{self, Formatter},
     fs,
+    hash::{Hash, Hasher},
     ops::{Deref, DerefMut},
     path::{Component, Path, PathBuf},
 };
@@ -742,6 +743,12 @@ impl SolcConfig {
 impl From<SolcConfig> for Settings {
     fn from(config: SolcConfig) -> Self {
         config.settings
+    }
+}
+
+impl Hash for SolcConfig {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.settings.hash(state);
     }
 }
 

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -44,7 +44,7 @@ const JS_LIB_DIR: &str = "node_modules";
 /// contracts-ethereum-package ./MyContract.sol
 ///
 /// [Source](https://ethereum.stackexchange.com/questions/74448/what-are-remappings-and-how-do-they-work-in-solidity)
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct Remapping {
     pub name: String,
     pub path: String,

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -375,7 +375,7 @@ fn can_compile_dapp_only_recompile_dirty_sources() {
     // Changing source content should not invalidate compilation unit id
     assert_eq!(updated_b.compilation_unit, original_b.compilation_unit);
     // B.sol should be recompiled
-    assert_ne!(updated_b.last_modification_date, original_b.last_modification_date);
+    assert!(updated_b.last_modification_date > original_b.last_modification_date);
 
     project.artifacts_snapshot().unwrap().assert_artifacts_essentials_present();
 }

--- a/ethers-solc/tests/project.rs
+++ b/ethers-solc/tests/project.rs
@@ -339,13 +339,15 @@ fn can_compile_dapp_only_recompile_dirty_sources() {
         .unwrap();
 
     let compiled = project.compile().unwrap();
-
     assert!(!compiled.has_compiler_errors());
+
     let cache = SolFilesCache::read(project.cache_path()).unwrap();
     // A.sol and B.sol are compatible and should be compiled into one unit
     assert_eq!(cache.compilation_units.len(), 1);
-    let original_a = cache.entry(Path::new("src/A.sol")).unwrap();
-    let original_b = cache.entry(Path::new("src/B.sol")).unwrap();
+    let path_a = Path::new("src/A.sol");
+    let path_b = Path::new("src/B.sol");
+    let original_a = cache.entry(path_a).unwrap();
+    let original_b = cache.entry(path_b).unwrap();
 
     // modify B.sol
     project
@@ -365,11 +367,11 @@ fn can_compile_dapp_only_recompile_dirty_sources() {
     let updated_cache = SolFilesCache::read(project.cache_path()).unwrap();
     assert_eq!(updated_cache.compilation_units.len(), 1);
 
-    let cahced_a = updated_cache.entry(Path::new("src/A.sol")).unwrap();
+    let cached_a = updated_cache.entry(path_a).unwrap();
     // A.sol should not be recompiled
-    assert_eq!(original_a.last_modification_date, cahced_a.last_modification_date);
+    assert_eq!(original_a.last_modification_date, cached_a.last_modification_date);
 
-    let updated_b = updated_cache.entry(Path::new("src/B.sol")).unwrap();
+    let updated_b = updated_cache.entry(path_b).unwrap();
     // Changing source content should not invalidate compilation unit id
     assert_eq!(updated_b.compilation_unit, original_b.compilation_unit);
     // B.sol should be recompiled


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Currently, the cache file stores the compiler version and its settings individually for each file, and it can be ambiguous what compilation artifacts are a "unit"; that is, they were determined to be compatible and/or necessary e.g. imports and then compiled with the same solc version and compiler settings. This is mainly a concern when multiple compiler versions are used and the artifacts can then contain duplicate id's in the source mappings (see https://github.com/crytic/slither/issues/1213). 

Ref https://github.com/foundry-rs/foundry/issues/3450
## Solution
This PR changes the data model of the artifacts to instead store a unique identifier representing that the source files were compiled together (`CompilationUnitId`). This identifier maps back to a `CompilationUnit` which stores the version, configuration, and source files' paths. Rather than redundantly store the `SolcConfig` for each `CacheEntry`, it is now looked up by its `CompilationUnitId`.  Now, the each compilation unit can be parsed individually and lookup where the artifact is in the cache entry's `files`. This [diff](https://github.com/0xalpharush/foundry/commit/61f054038329e7a2eae175993487bdf4c3ab6ef2) in Foundry is pretty small fwiw.

I'm new to Rust and also may have overlooked some design decision that my changes are incompatible with so I'm very open to feedback!
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [x] Added Tests
-   [X] Added Documentation
-   [ ] Updated the changelog
-   [X] Breaking changes
