### PR TITLE
added `from_bytes` for `Wallet` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,7 @@
 
 - `eth-keystore-rs` crate updated. Allow an optional name for the to-be-generated
   keystore file [#910](https://github.com/gakonst/ethers-rs/pull/910)
+- [1983](https://github.com/gakonst/ethers-rs/pull/1983) Added a `from_bytes` function for the `Wallet` type.
 
 ### 0.6.0
 

--- a/ethers-signers/src/wallet/private_key.rs
+++ b/ethers-signers/src/wallet/private_key.rs
@@ -90,13 +90,20 @@ impl Wallet<SigningKey> {
         let address = secret_key_to_address(&signer);
         Self { signer, address, chain_id: 1 }
     }
+
+    /// Creates a new Wallet instance from a raw scalar value (big endian).
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, WalletError> {
+        let signer = SigningKey::from_bytes(bytes)?;
+        let address = secret_key_to_address(&signer);
+        Ok(Self { signer, address, chain_id: 1 })
+    }
 }
 
 impl PartialEq for Wallet<SigningKey> {
     fn eq(&self, other: &Self) -> bool {
-        self.signer.to_bytes().eq(&other.signer.to_bytes()) &&
-            self.address == other.address &&
-            self.chain_id == other.chain_id
+        self.signer.to_bytes().eq(&other.signer.to_bytes())
+            && self.address == other.address
+            && self.chain_id == other.chain_id
     }
 }
 

--- a/ethers-signers/src/wallet/private_key.rs
+++ b/ethers-signers/src/wallet/private_key.rs
@@ -101,9 +101,9 @@ impl Wallet<SigningKey> {
 
 impl PartialEq for Wallet<SigningKey> {
     fn eq(&self, other: &Self) -> bool {
-        self.signer.to_bytes().eq(&other.signer.to_bytes())
-            && self.address == other.address
-            && self.chain_id == other.chain_id
+        self.signer.to_bytes().eq(&other.signer.to_bytes()) &&
+            self.address == other.address &&
+            self.chain_id == other.chain_id
     }
 }
 
@@ -311,5 +311,18 @@ mod tests {
             wallet.address,
             Address::from_str("6813Eb9362372EEF6200f3b1dbC3f819671cBA69").expect("Decoding failed")
         );
+    }
+
+    #[test]
+    fn key_from_bytes() {
+        let wallet: Wallet<SigningKey> =
+            "0000000000000000000000000000000000000000000000000000000000000001".parse().unwrap();
+
+        let key_as_bytes = wallet.signer.to_bytes();
+        let wallet_from_bytes = Wallet::from_bytes(&key_as_bytes).unwrap();
+
+        assert_eq!(wallet.address, wallet_from_bytes.address);
+        assert_eq!(wallet.chain_id, wallet_from_bytes.chain_id);
+        assert_eq!(wallet.signer, wallet_from_bytes.signer);
     }
 }


### PR DESCRIPTION
## Motivation
There was no way to initialize a new Wallet from a byte slice.

## Solution
I added a `from_bytes` associated function for the `Wallet` type. The function  initializes a new `SignerKey` from a byte slice and uses the key to create a new wallet.

```rust
impl Wallet<SigningKey> {
    //--snip--
    pub fn from_bytes(bytes: &[u8]) -> Result<Self, WalletError> {
        let signer = SigningKey::from_bytes(bytes)?;
        let address = secret_key_to_address(&signer);
        Ok(Self { signer, address, chain_id: 1 })
    }
 }
 ```

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [x] Updated the changelog
-   [ ] Breaking changes
