### PR TITLE
fix: doc typo regarding Multicall::call_array

### DIFF
--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -661,7 +661,7 @@ impl<M: Middleware> Multicall<M> {
     /// #
     /// # let multicall = Multicall::new(client, None).await?;
     /// // If the all Solidity function calls `returns (uint256)`:
-    /// let result: Vec<U256> = multicall.call().await?;
+    /// let result: Vec<U256> = multicall.call_array().await?;
     /// # Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
## Motivation

Fixes https://github.com/gakonst/ethers-rs/issues/1984 regarding `Multicall::call_array`

## Solution

Change `.call` to `call_array` which is the function the docs are referencing.

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
