### PR TITLE
feat(providers): add mining related apis

### DIFF
--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -16,7 +16,7 @@ const GETH_STARTUP_TIMEOUT_MILLIS: u64 = 10_000;
 const GETH_DIAL_LOOP_TIMEOUT: Duration = Duration::new(20, 0);
 
 /// The exposed APIs
-const API: &str = "eth,net,web3,txpool,admin";
+const API: &str = "eth,net,web3,txpool,admin,miner";
 
 /// The geth command
 const GETH: &str = "geth";

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -528,6 +528,16 @@ pub trait Middleware: Sync + Send + Debug {
         self.inner().remove_trusted_peer(enode_url).await.map_err(FromErr::from)
     }
 
+    // Miner namespace
+
+    /// Starts the miner with the given number of threads. If threads is nil, the number of workers
+    /// started is equal to the number of logical CPUs that are usable by this process. If mining
+    /// is already running, this method adjust the number of threads allowed to use and updates the
+    /// minimum price required by the transaction pool.
+    async fn start_mining(&self, threads: Option<usize>) -> Result<bool, Self::Error> {
+        self.inner().start_mining(threads).await.map_err(FromErr::from)
+    }
+
     // Mempool inspection for Geth's API
 
     async fn txpool_content(&self) -> Result<TxpoolContent, Self::Error> {

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -502,6 +502,11 @@ pub trait Middleware: Sync + Send + Debug {
         self.inner().get_proof(from, locations, block).await.map_err(FromErr::from)
     }
 
+    /// Returns an indication if this node is currently mining.
+    async fn mining(&self) -> Result<bool, Self::Error> {
+        self.inner().mining().await.map_err(FromErr::from)
+    }
+
     // Admin namespace
 
     async fn add_peer(&self, enode_url: String) -> Result<bool, Self::Error> {
@@ -534,8 +539,14 @@ pub trait Middleware: Sync + Send + Debug {
     /// started is equal to the number of logical CPUs that are usable by this process. If mining
     /// is already running, this method adjust the number of threads allowed to use and updates the
     /// minimum price required by the transaction pool.
-    async fn start_mining(&self, threads: Option<usize>) -> Result<bool, Self::Error> {
+    async fn start_mining(&self, threads: Option<usize>) -> Result<(), Self::Error> {
         self.inner().start_mining(threads).await.map_err(FromErr::from)
+    }
+
+    /// Stop terminates the miner, both at the consensus engine level as well as at
+    /// the block creation level.
+    async fn stop_mining(&self) -> Result<(), Self::Error> {
+        self.inner().stop_mining().await.map_err(FromErr::from)
     }
 
     // Mempool inspection for Geth's API

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -855,6 +855,17 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.request("admin_removeTrustedPeer", [enode_url]).await
     }
 
+    // miner namespace (just used for starting mining)
+
+    /// Starts the miner with the given number of threads. If threads is nil, the number of workers
+    /// started is equal to the number of logical CPUs that are usable by this process. If mining
+    /// is already running, this method adjust the number of threads allowed to use and updates the
+    /// minimum price required by the transaction pool.
+    async fn start_mining(&self, threads: Option<usize>) -> Result<bool, Self::Error> {
+        let threads = utils::serialize(&threads);
+        self.request("miner_start", [threads]).await
+    }
+
     ////// Ethereum Naming Service
     // The Ethereum Naming Service (ENS) allows easy to remember and use names to
     // be assigned to Ethereum addresses. Any provider operation which takes an address

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -813,6 +813,11 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.request("eth_getProof", [from, locations, block]).await
     }
 
+    /// Returns an indication if this node is currently mining.
+    async fn mining(&self) -> Result<bool, Self::Error> {
+        self.request("eth_mining", ()).await
+    }
+
     // Admin namespace
 
     /// Requests adding the given peer, returning a boolean representing whether or not the peer
@@ -855,15 +860,21 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.request("admin_removeTrustedPeer", [enode_url]).await
     }
 
-    // miner namespace (just used for starting mining)
+    // Miner namespace
 
     /// Starts the miner with the given number of threads. If threads is nil, the number of workers
     /// started is equal to the number of logical CPUs that are usable by this process. If mining
     /// is already running, this method adjust the number of threads allowed to use and updates the
     /// minimum price required by the transaction pool.
-    async fn start_mining(&self, threads: Option<usize>) -> Result<bool, Self::Error> {
+    async fn start_mining(&self, threads: Option<usize>) -> Result<(), Self::Error> {
         let threads = utils::serialize(&threads);
         self.request("miner_start", [threads]).await
+    }
+
+    /// Stop terminates the miner, both at the consensus engine level as well as at the block
+    /// creation level.
+    async fn stop_mining(&self) -> Result<(), Self::Error> {
+        self.request("miner_stop", ()).await
     }
 
     ////// Ethereum Naming Service


### PR DESCRIPTION
## Motivation

In reth, we will be using a clique geth instance to produce blocks, which we will then peer with and test IBD / sync. To get geth to produce blocks after importing a clique signing key, we need to enable the miner.

## Solution

Add support for the following APIs:
 - `eth_mining`
 - `miner_start`
 - `miner_stop`
 
The `miner` namespace is also enabled in `Geth`.

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
