### PR TITLE
nonce_manager: remove current nonce load when initialized

### DIFF
--- a/ethers-middleware/src/nonce_manager.rs
+++ b/ethers-middleware/src/nonce_manager.rs
@@ -43,9 +43,11 @@ where
                 .map_err(FromErr::from)?;
             self.nonce.store(nonce.as_u64(), Ordering::SeqCst);
             self.initialized.store(true, Ordering::SeqCst);
+            Ok(nonce)
+        } else {
+            // return current nonce
+            Ok(self.nonce.load(Ordering::SeqCst).into())
         }
-        // return current nonce
-        Ok(self.nonce.load(Ordering::SeqCst).into())
     }
 
     async fn get_transaction_count_with_manager(


### PR DESCRIPTION

## Motivation

If nonce was just initialized, no need for store and load. Just return the stored value without load.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
