### PR TITLE
fix: signer test

### DIFF
--- a/ethers-middleware/tests/signer.rs
+++ b/ethers-middleware/tests/signer.rs
@@ -164,7 +164,8 @@ async fn typed_txs() {
         .from(address)
         .to(address)
         .nonce(nonce + 2)
-        .max_fee_per_gas(gas_price);
+        .max_fee_per_gas(gas_price)
+        .max_priority_fee_per_gas(gas_price);
     let tx3 = provider.send_transaction(tx, bn).await.unwrap();
 
     futures_util::join!(check_tx(tx1, 0), check_tx(tx2, 1), check_tx(tx3, 2),);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

https://github.com/gakonst/ethers-rs/actions/runs/3865018418/jobs/6588238571

> err: max priority fee per gas higher than max fee per gas: address 0x212af5Bc0CC34CAAb9E25fb46A8A1E3f91e07f57, maxPriorityFeePerGas: 3000000000, maxFeePerGas: 74084601 (supplied gas 15010499)

For some reason the priority fee gets hardcoded at 3 gwei?

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
