### PR TITLE
etherscan: fix deserializing contract creation NormalTransaction objects

### DIFF
--- a/ethers-etherscan/src/account.rs
+++ b/ethers-etherscan/src/account.rs
@@ -186,6 +186,7 @@ pub struct NormalTransaction {
     pub transaction_index: Option<u64>,
     #[serde(with = "genesis_string")]
     pub from: GenesisOption<Address>,
+    #[serde(with = "json_string")]
     pub to: Option<Address>,
     #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub value: U256,

--- a/ethers-etherscan/src/account.rs
+++ b/ethers-etherscan/src/account.rs
@@ -798,7 +798,7 @@ mod tests {
 
             let txs = client
                 .get_transactions(
-                    &"0x58eB28A67731c570Ef827C365c89B5751F9E6b0a".parse().unwrap(),
+                    &"0x4F26FfBe5F04ED43630fdC30A87638d53D0b0876".parse().unwrap(),
                     None,
                 )
                 .await;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

The `"to"` field of the response to `get_transactions()` is set to `""` for contract creation transactions. This wasn't handled resulting in a deserialization failure.

## Solution

Added `#[json_string]` macro.
