### PR TITLE
fix(abigen): ensure correct ABI in `From` impl

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -150,7 +150,7 @@ impl Context {
                     /// client at the given `Address`. The contract derefs to a `ethers::Contract`
                     /// object
                     pub fn new<T: Into<#ethers_core::types::Address>>(address: T, client: ::std::sync::Arc<M>) -> Self {
-                        #ethers_contract::Contract::new(address.into(), #abi_name.clone(), client).into()
+                        Self(#ethers_contract::Contract::new(address.into(), #abi_name.clone(), client))
                     }
 
                     #deployment_methods
@@ -163,7 +163,7 @@ impl Context {
 
                 impl<M : #ethers_providers::Middleware> From<#ethers_contract::Contract<M>> for #name<M> {
                     fn from(contract: #ethers_contract::Contract<M>) -> Self {
-                       Self(contract)
+                       Self::new(contract.address(), contract.client())
                     }
                 }
         };

--- a/ethers-contract/tests/it/abigen.rs
+++ b/ethers-contract/tests/it/abigen.rs
@@ -751,8 +751,8 @@ fn can_handle_overloaded_function_with_array() {
     );
 }
 
-#[tokio::test]
-async fn convert_uses_correct_abi() {
+#[test]
+fn convert_uses_correct_abi() {
     abigen!(
         Foo, r#"[function foo()]"#;
         Bar, r#"[function bar()]"#;

--- a/ethers-contract/tests/it/abigen.rs
+++ b/ethers-contract/tests/it/abigen.rs
@@ -750,3 +750,21 @@ fn can_handle_overloaded_function_with_array() {
     ]"#,
     );
 }
+
+#[tokio::test]
+async fn convert_uses_correct_abi() {
+    abigen!(
+        Foo, r#"[function foo()]"#;
+        Bar, r#"[function bar()]"#;
+    );
+
+    let provider = Arc::new(Provider::new(MockProvider::new()));
+    let foo = Foo::new(Address::default(), Arc::clone(&provider));
+
+    let contract: &ethers_contract::Contract<_> = &foo;
+    let bar: Bar<Provider<MockProvider>> = contract.clone().into();
+
+    // Ensure that `bar` is using the `Bar` ABI internally (this method lookup will panic if `bar`
+    // is incorrectly using the `Foo` ABI internally).
+    bar.bar().call();
+}


### PR DESCRIPTION
## Motivation

The `new` methods generated by `abigen!` create an underlying `Contract` with the correct ABI, but the generated `From` impls simply wraps a source `Contract`, which could have a completely different ABI. In effect this was an unsafe cast, and indeed was observed to trigger a "method not found (this should never happen)" panic for subsequent method lookups.

## Solution

Implementing `From` in terms of `new` fixes this, at the cost of an extra `Arc::clone()` (which I can't see how to eliminate without piercing the `ethers::contract::Contract` public API).

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes