### PR TITLE
feat(core): switch shanghaiBlock to shanghaiTime

### DIFF
--- a/ethers-core/src/utils/genesis.rs
+++ b/ethers-core/src/utils/genesis.rs
@@ -130,11 +130,13 @@ pub struct ChainConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub merge_netsplit_block: Option<u64>,
 
-    /// The Shanghai hard fork block.
+    /// Shanghai switch time.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shanghai_block: Option<u64>,
+    pub shanghai_time: Option<u64>,
 
-    /// The Cancun hard fork block.
+    // TODO: change to cancunTime when <https://github.com/ethereum/go-ethereum/pull/26481> is
+    // merged in geth
+    /// Cancun hard fork block.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cancun_block: Option<u64>,
 


### PR DESCRIPTION
## Motivation

Geth [recently switched to time-based forking](https://github.com/ethereum/go-ethereum/pull/25878), and changed the name of the `shanghaiBlock` field to `shanghaiTime`. We should be compatible, and should change the name as well.

## Solution

This renames the `shanghai_block` field in `ChainConfig` to `shanghai_time` so it is compatible with geth.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [x] Breaking changes
