### PR TITLE
fix: failing can_autodetect_dirs solc test (#1895)

### DIFF
--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -911,13 +911,13 @@ mod tests {
 
         let root = root.path();
         assert_eq!(ProjectPathsConfig::find_source_dir(root), src,);
-        std::fs::File::create(&contracts).unwrap();
+        std::fs::create_dir_all(&contracts).unwrap();
         assert_eq!(ProjectPathsConfig::find_source_dir(root), contracts,);
         assert_eq!(
             ProjectPathsConfig::builder().build_with_root(root).sources,
             utils::canonicalized(contracts),
         );
-        std::fs::File::create(&src).unwrap();
+        std::fs::create_dir_all(&src).unwrap();
         assert_eq!(ProjectPathsConfig::find_source_dir(root), src,);
         assert_eq!(
             ProjectPathsConfig::builder().build_with_root(root).sources,
@@ -925,18 +925,19 @@ mod tests {
         );
 
         assert_eq!(ProjectPathsConfig::find_artifacts_dir(root), out,);
-        std::fs::File::create(&artifacts).unwrap();
+        std::fs::create_dir_all(&artifacts).unwrap();
         assert_eq!(ProjectPathsConfig::find_artifacts_dir(root), artifacts,);
         assert_eq!(
             ProjectPathsConfig::builder().build_with_root(root).artifacts,
             utils::canonicalized(artifacts),
         );
+        std::fs::create_dir_all(&build_infos).unwrap();
         assert_eq!(
             ProjectPathsConfig::builder().build_with_root(root).build_infos,
             utils::canonicalized(build_infos)
         );
 
-        std::fs::File::create(&out).unwrap();
+        std::fs::create_dir_all(&out).unwrap();
         assert_eq!(ProjectPathsConfig::find_artifacts_dir(root), out,);
         assert_eq!(
             ProjectPathsConfig::builder().build_with_root(root).artifacts,
@@ -944,13 +945,13 @@ mod tests {
         );
 
         assert_eq!(ProjectPathsConfig::find_libs(root), vec![lib.clone()],);
-        std::fs::File::create(&node_modules).unwrap();
+        std::fs::create_dir_all(&node_modules).unwrap();
         assert_eq!(ProjectPathsConfig::find_libs(root), vec![node_modules.clone()],);
         assert_eq!(
             ProjectPathsConfig::builder().build_with_root(root).libraries,
             vec![utils::canonicalized(node_modules)],
         );
-        std::fs::File::create(&lib).unwrap();
+        std::fs::create_dir_all(&lib).unwrap();
         assert_eq!(ProjectPathsConfig::find_libs(root), vec![lib.clone()],);
         assert_eq!(
             ProjectPathsConfig::builder().build_with_root(root).libraries,


### PR DESCRIPTION
## Motivation

Fix `can_autodetect_dirs` solc test failing on MacOS (#1895).

## Solution

The test was failing for two reasons on macOS:

1. The build info directory was not created during the test.
2. Temporary directories are created with symbolic links on macOS and the path canonicalization returns the given path if it doesn't exist.

This lead to a mismatch between the project root's canonical path (which did exist and thus was a real path after canonicalization) and the build info directory's canonical path (which did not exist and was a symbolic link after canonicalization).

The fix is to create the build info directory to make sure its canonical path matches the project root's canonical path.

## PR Checklist

-   [ ] Added Tests **(n/a)**
-   [ ] Added Documentation **(n/a)**
-   [ ] Updated the changelog **(n/a)**
-   [ ] Breaking changes **(n/a)**
