### PR TITLE
feat(core/geth): enable Clique mode 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,6 +1320,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ ethers-contract = { version = "^1.0.0", default-features = false, path = "./ethe
 ethers-providers = { version = "^1.0.0", default-features = false, path = "./ethers-providers", features = [
     "ws",
 ] }
+tempfile = "3.3.0"
 
 [target.'cfg(target_family = "unix")'.dev-dependencies]
 ethers-providers = { version = "^1.0.0", default-features = false, path = "./ethers-providers", features = [

--- a/examples/geth_clique.rs
+++ b/examples/geth_clique.rs
@@ -1,0 +1,30 @@
+use ethers::{
+    core::{rand::thread_rng, utils::Geth},
+    signers::LocalWallet,
+};
+use eyre::Result;
+
+#[tokio::main]
+/// Shows how to instantiate a Geth with Clique enabled.
+async fn main() -> Result<()> {
+    // Generate a random clique signer and set it on Geth.
+    let data_dir = tempfile::tempdir().expect("should be able to create temp geth datadir");
+    let dir_path = data_dir.into_path();
+    println!("Using {}", dir_path.display());
+
+    // Create a random signer
+    let key = LocalWallet::new(&mut thread_rng());
+
+    let clique_key = key.signer().clone();
+    let _geth = Geth::new()
+        // set the signer
+        .set_clique_private_key(clique_key)
+        // must always set the chain id here
+        .chain_id(199u64)
+        // set the datadir to a temp dir
+        .data_dir(dir_path)
+        // spawn it
+        .spawn();
+
+    Ok(())
+}


### PR DESCRIPTION
Allows instantiating Geth in Clique mode when provided with a `SigningKey`.

Extracts the logic from https://github.com/paradigmxyz/reth/pull/623/files#diff-99e7bcdfb85c75ffe5fb2ccfbc5fd8234fced6704c34b622fbf24289b8522515R210

cc @Rjected 