### PR TITLE
fix(core): fix geth --init temp dir race condition

### DIFF
--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -34,6 +34,7 @@ hex = { version = "0.4.3", default-features = false, features = ["std"] }
 once_cell = { version = "1.17.0", optional = true }
 unicode-xid = "0.2.4"
 strum = { version = "0.24", features = ["derive"] }
+tempfile = { version = "3.3.0", default-features = false }
 
 # macros feature enabled dependencies
 cargo_metadata = { version = "0.15.2", optional = true }
@@ -45,7 +46,6 @@ proc-macro2 = { version = "1.0.50", optional = true }
 num_enum = "0.5.7"
 
 [dev-dependencies]
-tempfile = { version = "3.3.0", default-features = false }
 serde_json = { version = "1.0.64", default-features = false }
 bincode = { version = "1.3.3", default-features = false }
 once_cell = { version = "1.17.0" }

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -34,7 +34,6 @@ hex = { version = "0.4.3", default-features = false, features = ["std"] }
 once_cell = { version = "1.17.0", optional = true }
 unicode-xid = "0.2.4"
 strum = { version = "0.24", features = ["derive"] }
-tempfile = { version = "3.3.0", default-features = false }
 
 # macros feature enabled dependencies
 cargo_metadata = { version = "0.15.2", optional = true }
@@ -44,6 +43,9 @@ convert_case = { version = "0.6.0", optional = true }
 syn = { version = "1.0.107", optional = true }
 proc-macro2 = { version = "1.0.50", optional = true }
 num_enum = "0.5.7"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tempfile = { version = "3.3.0", default-features = false }
 
 [dev-dependencies]
 serde_json = { version = "1.0.64", default-features = false }


### PR DESCRIPTION
## Motivation

Previously, if multiple instances of geth were spawned concurrently, only one directory would be used to populate geth's `genesis.json`. This can lead to a race condition where the `genesis.json` would be re-written by a second instance, before the first instance reads the `genesis.json` for populating its db and genesis block with the `geth --init` command. this was possible because directory returned by `std::env::temp_dir()` is often shared.

## Solution

This fixes the race condition by using `tempfile::tempdir()`, which creates a unique directory per call to `tempdir()`.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
