### PR TITLE
fix: ensure urls have trailing /

### DIFF
--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -446,7 +446,7 @@ fn ensure_url(url: impl IntoUrl) -> std::result::Result<Url, reqwest::Error> {
     let url_str = url.as_str();
 
     // ensure URL ends with `/`
-     if url_str.ends_with('/') {
+    if url_str.ends_with('/') {
         url.into_url()
     } else {
         into_url(format!("{url_str}/"))
@@ -462,7 +462,7 @@ fn into_url(url: impl IntoUrl) -> std::result::Result<Url, reqwest::Error> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ Client, EtherscanError};
+    use crate::{Client, EtherscanError};
     use ethers_core::types::{Address, Chain, H256};
     use std::{
         future::Future,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
linked to https://github.com/foundry-rs/foundry/issues/4150

ensures all etherscan URLs have trailing: `/`
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
