### PR TITLE
Keystore Generation & Decryption

### DIFF
--- a/examples/wallets/examples/keystores.rs
+++ b/examples/wallets/examples/keystores.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()>{
     //generates a brand new keystore with key
     //name your keystore file, set the path, set the password
     //*NOTE* -- pls don't store your passwords in a plain text file, this is just an example 
-    let key_store = LocalWallet::new_keystore(encryption_path, &mut thread_rng(), &password, Some("my_encrypted_keys"))
+    let (signing_key, _) = LocalWallet::new_keystore(encryption_path, &mut thread_rng(), &password, Some("my_encrypted_keys"))
         .expect("key store fail");
     
     let (your_signing_key, _) = key_store; 

--- a/examples/wallets/examples/keystores.rs
+++ b/examples/wallets/examples/keystores.rs
@@ -1,22 +1,12 @@
 use ethers::prelude::*;
 use ethers::core::rand::thread_rng;
 use ethers::signers::{LocalWallet};
-use dotenv::dotenv;
-
 use eyre::Result;
-
 
 #[tokio::main]
 async fn main() -> Result<()>{
 
-    dotenv().ok();
-
-    let api_key = std::env::var("API_KEY").expect("expected environmental variable");
-    let encryption_path = std::env::var("ENCRYPTION_PATH").expect("expected environmental variable");
-    let decryption_path = std::env::var("DECRYPTION_PATH").expect("expected environmental variable");
-    let password = std::env::var("PASSWORD").expect("expected environmental variable");
-
-    let ws = Ws::connect(api_key)
+    let ws = Ws::connect("your_api_key")
         .await
         .expect("no connection");
 
@@ -25,14 +15,14 @@ async fn main() -> Result<()>{
     //generates a brand new keystore with key
     //name your keystore file, set the path, set the password
     //*NOTE* -- pls don't store your passwords in a plain text file, this is just an example 
-    let (signing_key, _) = LocalWallet::new_keystore(encryption_path, &mut thread_rng(), &password, Some("my_encrypted_keys"))
+    let (signing_key, _) = LocalWallet::new_keystore("C:/encryption_path", &mut thread_rng(), "PASSWORD", Some("my_encrypted_keys"))
         .expect("key store fail");
     
     println!("your signing key is: {:?}", signing_key);
 
 
     //decrypt your keystore given the filepath with the password you encrypted it with originally
-    let decrypt_key_store = LocalWallet::decrypt_keystore(decryption_path, &password)
+    let decrypt_key_store = LocalWallet::decrypt_keystore("C:/decryption_path/file_name", "PASSWORD")
         .expect("decryption failed");
 
     println!("your signing key is: {:?}", decrypt_key_store);

--- a/examples/wallets/examples/keystores.rs
+++ b/examples/wallets/examples/keystores.rs
@@ -1,0 +1,43 @@
+use ethers::prelude::*;
+use ethers::core::rand::thread_rng;
+use ethers::signers::{LocalWallet};
+use dotenv::dotenv;
+
+use eyre::Result;
+
+
+#[tokio::main]
+async fn main() -> Result<()>{
+
+    dotenv().ok();
+
+    let api_key = std::env::var("API_KEY").expect("expected environmental variable");
+    let encryption_path = std::env::var("ENCYPTION_PATH").expect("expected environmental variable");
+    let decryption_path = std::env::var("DECRYPTION_PATH").expect("expected environmental variable");
+    let password = std::env::var("PASSWORD").expect("expected environmental variable");
+
+    let ws = Ws::connect(api_key)
+        .await
+        .expect("no connection");
+
+    println!("Is Connected: {}", ws.ready());
+
+    //generates a brand new keystore with key
+    //name your keystore file, set the path, set the password
+    //*NOTE* -- pls don't store your passwords in a plain text file, this is just an example 
+    let key_store = LocalWallet::new_keystore(encryption_path, &mut thread_rng(), &password, Some("my_encrypted_keys"))
+        .expect("key store fail");
+    
+    let (your_signing_key, _) = key_store; 
+
+    println!("your signing key is: {:?}", your_signing_key);
+
+
+    //decrypt your keystore given the filepath with the password you encrypted it with originally
+    let decrypt_key_store = LocalWallet::decrypt_keystore(decryption_path, &password)
+        .expect("decryption failed");
+
+    println!("your signing key is: {:?}", decrypt_key_store);
+
+    Ok(())
+}

--- a/examples/wallets/examples/keystores.rs
+++ b/examples/wallets/examples/keystores.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<()>{
     dotenv().ok();
 
     let api_key = std::env::var("API_KEY").expect("expected environmental variable");
-    let encryption_path = std::env::var("ENCYPTION_PATH").expect("expected environmental variable");
+    let encryption_path = std::env::var("ENCRYPTION_PATH").expect("expected environmental variable");
     let decryption_path = std::env::var("DECRYPTION_PATH").expect("expected environmental variable");
     let password = std::env::var("PASSWORD").expect("expected environmental variable");
 

--- a/examples/wallets/examples/keystores.rs
+++ b/examples/wallets/examples/keystores.rs
@@ -28,9 +28,7 @@ async fn main() -> Result<()>{
     let (signing_key, _) = LocalWallet::new_keystore(encryption_path, &mut thread_rng(), &password, Some("my_encrypted_keys"))
         .expect("key store fail");
     
-    let (your_signing_key, _) = key_store; 
-
-    println!("your signing key is: {:?}", your_signing_key);
+    println!("your signing key is: {:?}", signing_key);
 
 
     //decrypt your keystore given the filepath with the password you encrypted it with originally


### PR DESCRIPTION
## Motivation

This is a functioning example of generating + encrypting a new keystore and decrypting a keystore using ethers-rs. This could particularly be helpful for applications that rely on local encrypted keys client side or server side. 