### PR TITLE
fix(provider): Add Send bound to return type of JsonRpcClient::request

### DIFF
--- a/ethers-contract/tests/it/abigen.rs
+++ b/ethers-contract/tests/it/abigen.rs
@@ -752,6 +752,7 @@ fn can_handle_overloaded_function_with_array() {
 }
 
 #[test]
+#[allow(clippy::disallowed_names)]
 fn convert_uses_correct_abi() {
     abigen!(
         Foo, r#"[function foo()]"#;

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -76,7 +76,7 @@ pub trait JsonRpcClient: Debug + Send + Sync {
     async fn request<T, R>(&self, method: &str, params: T) -> Result<R, Self::Error>
     where
         T: Debug + Serialize + Send + Sync,
-        R: DeserializeOwned;
+        R: DeserializeOwned + Send;
 }
 
 pub trait FromErr<T> {

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -199,7 +199,7 @@ impl<P: JsonRpcClient> Provider<P> {
     pub async fn request<T, R>(&self, method: &str, params: T) -> Result<R, ProviderError>
     where
         T: Debug + Serialize + Send + Sync,
-        R: Serialize + DeserializeOwned + Debug,
+        R: Serialize + DeserializeOwned + Debug + Send,
     {
         let span =
             tracing::trace_span!("rpc", method = method, params = ?serde_json::to_string(&params)?);
@@ -215,7 +215,7 @@ impl<P: JsonRpcClient> Provider<P> {
         Ok(res)
     }
 
-    async fn get_block_gen<Tx: Default + Serialize + DeserializeOwned + Debug>(
+    async fn get_block_gen<Tx: Default + Serialize + DeserializeOwned + Debug + Send>(
         &self,
         id: BlockId,
         include_txs: bool,

--- a/ethers-providers/src/transports/retry.rs
+++ b/ethers-providers/src/transports/retry.rs
@@ -238,7 +238,7 @@ where
     async fn request<A, R>(&self, method: &str, params: A) -> Result<R, Self::Error>
     where
         A: Debug + Serialize + Send + Sync,
-        R: DeserializeOwned,
+        R: DeserializeOwned + Send,
     {
         // Helper type that caches the `params` value across several retries
         // This is necessary because the wrapper provider is supposed to skip he `params` if it's of

--- a/ethers-providers/src/transports/rw.rs
+++ b/ethers-providers/src/transports/rw.rs
@@ -105,14 +105,10 @@ where
 
     /// Sends a POST request with the provided method and the params serialized as JSON
     /// over HTTP
-    async fn request<T: Serialize + Send + Sync, R: DeserializeOwned>(
-        &self,
-        method: &str,
-        params: T,
-    ) -> Result<R, Self::Error>
+    async fn request<T, R>(&self, method: &str, params: T) -> Result<R, Self::Error>
     where
         T: std::fmt::Debug + Serialize + Send + Sync,
-        R: DeserializeOwned,
+        R: DeserializeOwned + Send,
     {
         match method {
             "eth_sendTransaction" | "eth_sendRawTransaction" => {


### PR DESCRIPTION
## Motivation

`#[async_trait]` implementations require return types to be `Send`. So except for trivial cases the `JsonRpcClient::request` demanded implementors to be impossibly generic.

## Solution

Add `Send` bound to the method and follow-up on its callers inside the monorepo.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
