### PR TITLE
feat(solc): support emitting bytecode as extra files

### DIFF
--- a/ethers-solc/src/artifacts/output_selection.rs
+++ b/ethers-solc/src/artifacts/output_selection.rs
@@ -407,7 +407,7 @@ impl FromStr for BytecodeOutputSelection {
         match s {
             "evm.bytecode" => Ok(BytecodeOutputSelection::All),
             "evm.bytecode.functionDebugData" => Ok(BytecodeOutputSelection::FunctionDebugData),
-            "evm.bytecode.object" => Ok(BytecodeOutputSelection::Object),
+            "code" | "bin" | "evm.bytecode.object" => Ok(BytecodeOutputSelection::Object),
             "evm.bytecode.opcodes" => Ok(BytecodeOutputSelection::Opcodes),
             "evm.bytecode.sourceMap" => Ok(BytecodeOutputSelection::SourceMap),
             "evm.bytecode.linkReferences" => Ok(BytecodeOutputSelection::LinkReferences),
@@ -482,6 +482,10 @@ impl FromStr for DeployedBytecodeOutputSelection {
             "evm.deployedBytecode.functionDebugData" => {
                 Ok(DeployedBytecodeOutputSelection::FunctionDebugData)
             }
+            "deployed-code" |
+            "deployed-bin" |
+            "runtime-code" |
+            "runtime-bin" |
             "evm.deployedBytecode.object" => Ok(DeployedBytecodeOutputSelection::Object),
             "evm.deployedBytecode.opcodes" => Ok(DeployedBytecodeOutputSelection::Opcodes),
             "evm.deployedBytecode.sourceMap" => Ok(DeployedBytecodeOutputSelection::SourceMap),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes https://github.com/foundry-rs/foundry/issues/4114

adds `bytecode` and `deployed-bytecode` as additional optional to emit code as separate file
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
uses the existing selection variants, but adds additional matching for `code` `bin`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
