### PR TITLE
refactor: make contract abstract over Borrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,8 @@
 
 ### Unreleased
 
+- Make `Contract` objects generic over the borrow trait, to allow non-arc mware
+  [#2082](https://github.com/gakonst/ethers-rs/pull/2082)
 - Return pending transaction from `Multicall::send`
   [#2044](https://github.com/gakonst/ethers-rs/pull/2044)
 - Add abigen to default features

--- a/ethers-contract/src/base.rs
+++ b/ethers-contract/src/base.rs
@@ -1,4 +1,4 @@
-use crate::Contract;
+use crate::contract::ContractInternal;
 
 pub use ethers_core::abi::AbiError;
 use ethers_core::{
@@ -8,10 +8,10 @@ use ethers_core::{
 use ethers_providers::Middleware;
 
 use std::{
+    borrow::Borrow,
     collections::{BTreeMap, HashMap},
     fmt::Debug,
     hash::Hash,
-    sync::Arc,
 };
 
 /// A reduced form of `Contract` which just takes the `abi` and produces
@@ -195,12 +195,12 @@ impl BaseContract {
     }
 
     /// Upgrades a `BaseContract` into a full fledged contract with an address and middleware.
-    pub fn into_contract<M: Middleware>(
-        self,
-        address: Address,
-        client: impl Into<Arc<M>>,
-    ) -> Contract<M> {
-        Contract::new(address, self, client.into())
+    pub fn into_contract<B, M>(self, address: Address, client: B) -> ContractInternal<B, M>
+    where
+        B: Borrow<M>,
+        M: Middleware,
+    {
+        ContractInternal::new(address, self, client)
     }
 }
 

--- a/ethers-contract/src/base.rs
+++ b/ethers-contract/src/base.rs
@@ -200,7 +200,7 @@ impl BaseContract {
         address: Address,
         client: impl Into<Arc<M>>,
     ) -> Contract<M> {
-        Contract::new(address, self, client)
+        Contract::new(address, self, client.into())
     }
 }
 

--- a/ethers-contract/src/base.rs
+++ b/ethers-contract/src/base.rs
@@ -1,4 +1,4 @@
-use crate::contract::ContractInternal;
+use crate::contract::ContractInstance;
 
 pub use ethers_core::abi::AbiError;
 use ethers_core::{
@@ -195,12 +195,12 @@ impl BaseContract {
     }
 
     /// Upgrades a `BaseContract` into a full fledged contract with an address and middleware.
-    pub fn into_contract<B, M>(self, address: Address, client: B) -> ContractInternal<B, M>
+    pub fn into_contract<B, M>(self, address: Address, client: B) -> ContractInstance<B, M>
     where
         B: Borrow<M>,
         M: Middleware,
     {
-        ContractInternal::new(address, self, client)
+        ContractInstance::new(address, self, client)
     }
 }
 

--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -255,7 +255,7 @@ where
 impl<B, M, D> IntoFuture for FunctionCall<B, M, D>
 where
     Self: 'static,
-    B: Borrow<M>,
+    B: Borrow<M> + Send + Sync,
     M: Middleware,
     D: Detokenize + Send + Sync,
 {

--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -72,7 +72,7 @@ pub enum ContractError<M: Middleware> {
     ContractNotDeployed,
 }
 
-/// `ContractCall` is a [`FunctionCall`] object with an [`Arc`] middleware.
+/// `ContractCall` is a [`FunctionCall`] object with an [`std::sync::Arc`] middleware.
 /// This type alias exists to preserve backwards compatibility with
 /// less-abstract Contracts.
 ///

--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -72,17 +72,11 @@ pub enum ContractError<M: Middleware> {
     ContractNotDeployed,
 }
 
-/// `ContractCall` is a [`FunctionCall`] object with an `Arc` middleware.
+/// `ContractCall` is a [`FunctionCall`] object with an [`Arc`] middleware.
 /// This type alias exists to preserve backwards compatibility with
-/// non-abstract Contracts.
-///
-/// This type alias is deprecated, and its name may be used for the
-/// [`FunctionCall`] struct in the future. We recommend migrating code to
-/// explicitly use [`FunctionCall`] instead of relying on this type alias.
+/// less-abstract Contracts.
 ///
 /// For full usage docs, see [`FunctionCall`].
-// #[deprecated = "ContractCall has been replaced with FunctionCall. Future versions may remove or
-// repurpose this type alias."]
 pub type ContractCall<M, D> = FunctionCall<std::sync::Arc<M>, M, D>;
 
 #[derive(Debug)]

--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -72,13 +72,23 @@ pub enum ContractError<M: Middleware> {
     ContractNotDeployed,
 }
 
-/// type alias for backwards compatibility
-pub type ContractCall<M, D> = ContractCallInternal<std::sync::Arc<M>, M, D>;
+/// `ContractCall` is a [`FunctionCall`] object with an `Arc` middleware.
+/// This type alias exists to preserve backwards compatibility with
+/// non-abstract Contracts.
+///
+/// This type alias is deprecated, and its name may be used for the
+/// [`FunctionCall`] struct in the future. We recommend migrating code to
+/// explicitly use [`FunctionCall`] instead of relying on this type alias.
+///
+/// For full usage docs, see [`FunctionCall`].
+// #[deprecated = "ContractCall has been replaced with FunctionCall. Future versions may remove or
+// repurpose this type alias."]
+pub type ContractCall<M, D> = FunctionCall<std::sync::Arc<M>, M, D>;
 
 #[derive(Debug)]
 #[must_use = "contract calls do nothing unless you `send` or `call` them"]
 /// Helper for managing a transaction before submitting it to a node
-pub struct ContractCallInternal<B, M, D> {
+pub struct FunctionCall<B, M, D> {
     /// The raw transaction object
     pub tx: TypedTransaction,
     /// The ABI of the function being called
@@ -90,12 +100,12 @@ pub struct ContractCallInternal<B, M, D> {
     pub(crate) _m: PhantomData<M>,
 }
 
-impl<B, M, D> Clone for ContractCallInternal<B, M, D>
+impl<B, M, D> Clone for FunctionCall<B, M, D>
 where
     B: Clone,
 {
     fn clone(&self) -> Self {
-        ContractCallInternal {
+        FunctionCall {
             tx: self.tx.clone(),
             function: self.function.clone(),
             block: self.block,
@@ -106,7 +116,7 @@ where
     }
 }
 
-impl<B, M, D> ContractCallInternal<B, M, D>
+impl<B, M, D> FunctionCall<B, M, D>
 where
     B: Borrow<M>,
     D: Detokenize,
@@ -156,7 +166,7 @@ where
     }
 }
 
-impl<B, M, D> ContractCallInternal<B, M, D>
+impl<B, M, D> FunctionCall<B, M, D>
 where
     B: Borrow<M>,
     M: Middleware,
@@ -240,9 +250,9 @@ where
     }
 }
 
-/// [`ContractCall`] can be turned into [`Future`] automatically with `.await`.
-/// Defaults to calling [`ContractCall::call`].
-impl<B, M, D> IntoFuture for ContractCallInternal<B, M, D>
+/// [`FunctionCall`] can be turned into [`Future`] automatically with `.await`.
+/// Defaults to calling [`FunctionCall::call`].
+impl<B, M, D> IntoFuture for FunctionCall<B, M, D>
 where
     Self: 'static,
     B: Borrow<M>,

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -292,6 +292,7 @@ where
     /// Returns a new contract instance using the provided client
     ///
     /// Clones `self` internally
+    #[must_use]
     pub fn connect<N>(&self, client: Arc<N>) -> ContractInstance<Arc<N>, N>
     where
         N: Middleware,

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -263,8 +263,23 @@ where
     /// Returns a new contract instance using the provided client
     ///
     /// Clones `self` internally
+    pub fn connect<N>(&self, client: Arc<N>) -> Contract<N>
+    where
+        N: Middleware,
+    {
+        ContractInternal {
+            base_contract: self.base_contract.clone(),
+            client,
+            address: self.address,
+            _m: PhantomData,
+        }
+    }
+
+    /// Returns a new contract instance using the provided client
+    ///
+    /// Clones `self` internally
     #[must_use]
-    pub fn connect<C, N>(&self, client: C) -> ContractInternal<C, N>
+    pub fn connect_with<C, N>(&self, client: C) -> ContractInternal<C, N>
     where
         C: Borrow<N>,
     {

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -5,6 +5,9 @@
 mod contract;
 pub use contract::Contract;
 
+// pub mod call2;
+// pub mod contract2;
+
 mod base;
 pub use base::{decode_function_data, encode_function_data, AbiError, BaseContract};
 

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -5,9 +5,6 @@
 mod contract;
 pub use contract::Contract;
 
-// pub mod call2;
-// pub mod contract2;
-
 mod base;
 pub use base::{decode_function_data, encode_function_data, AbiError, BaseContract};
 

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -9,7 +9,7 @@ mod base;
 pub use base::{decode_function_data, encode_function_data, AbiError, BaseContract};
 
 mod call;
-pub use call::{ContractError, EthCall};
+pub use call::{ContractCall, ContractCallInternal, ContractError, EthCall};
 
 mod error;
 pub use error::EthError;

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -3,13 +3,13 @@
 #![deny(unsafe_code)]
 
 mod contract;
-pub use contract::{Contract, ContractInternal};
+pub use contract::{Contract, ContractInstance};
 
 mod base;
 pub use base::{decode_function_data, encode_function_data, AbiError, BaseContract};
 
 mod call;
-pub use call::{ContractCall, ContractCallInternal, ContractError, EthCall};
+pub use call::{ContractCall, ContractError, EthCall, FunctionCall};
 
 mod error;
 pub use error::EthError;

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(unsafe_code)]
 
 mod contract;
-pub use contract::Contract;
+pub use contract::{Contract, ContractInternal};
 
 mod base;
 pub use base::{decode_function_data, encode_function_data, AbiError, BaseContract};

--- a/ethers-contract/tests/it/contract.rs
+++ b/ethers-contract/tests/it/contract.rs
@@ -23,7 +23,7 @@ mod eth_tests {
     }
 
     #[derive(Debug)]
-    struct MwErr<M: Middleware>(M::Error);
+    pub struct MwErr<M: Middleware>(M::Error);
     impl<M> ethers_providers::FromErr<M::Error> for MwErr<M>
     where
         M: Middleware,
@@ -73,7 +73,7 @@ mod eth_tests {
 
         // Works (B == &M, M: Clone)
         let c: ContractInternal<Provider<Http>, Provider<Http>> =
-            ContractInternal::new(H160::default(), abi, client.clone());
+            ContractInternal::new(H160::default(), abi.clone(), client.clone());
 
         let _ = c.method::<(), ()>("notARealMethod", ());
 

--- a/ethers-contract/tests/it/contract.rs
+++ b/ethers-contract/tests/it/contract.rs
@@ -265,7 +265,7 @@ mod eth_tests {
 
         // Also set up a subscription for the same thing
         let ws = Provider::connect(anvil.ws_endpoint()).await.unwrap();
-        let contract2 = ethers_contract::Contract::new(contract.address(), abi, ws);
+        let contract2 = ethers_contract::Contract::new(contract.address(), abi, ws.into());
         let event2 = contract2.event::<ValueChanged>();
         let mut subscription = event2.subscribe().await.unwrap();
 

--- a/ethers-contract/tests/it/contract.rs
+++ b/ethers-contract/tests/it/contract.rs
@@ -6,7 +6,7 @@ use ethers_core::types::{Filter, ValueOrArray, H256};
 #[cfg(not(feature = "celo"))]
 mod eth_tests {
     use super::*;
-    use ethers_contract::{ContractInternal, EthEvent, LogMeta, Multicall, MulticallVersion};
+    use ethers_contract::{ContractInstance, EthEvent, LogMeta, Multicall, MulticallVersion};
     use ethers_core::{
         abi::{encode, Detokenize, Token, Tokenizable},
         types::{transaction::eip712::Eip712, Address, BlockId, Bytes, H160, I256, U256},
@@ -66,22 +66,22 @@ mod eth_tests {
             .interval(Duration::from_millis(10u64));
 
         // Works (B == M, M: Clone)
-        let c: ContractInternal<&Provider<Http>, Provider<Http>> =
-            ContractInternal::new(H160::default(), abi.clone(), &client);
+        let c: ContractInstance<&Provider<Http>, Provider<Http>> =
+            ContractInstance::new(H160::default(), abi.clone(), &client);
 
         let _ = c.method::<(), ()>("notARealMethod", ());
 
         // Works (B == &M, M: Clone)
-        let c: ContractInternal<Provider<Http>, Provider<Http>> =
-            ContractInternal::new(H160::default(), abi.clone(), client.clone());
+        let c: ContractInstance<Provider<Http>, Provider<Http>> =
+            ContractInstance::new(H160::default(), abi.clone(), client.clone());
 
         let _ = c.method::<(), ()>("notARealMethod", ());
 
         let non_clone_mware = NonClone { m: client };
 
         // Works (B == &M, M: !Clone)
-        let c: ContractInternal<&NonClone<Provider<Http>>, NonClone<Provider<Http>>> =
-            ContractInternal::new(H160::default(), abi, &non_clone_mware);
+        let c: ContractInstance<&NonClone<Provider<Http>>, NonClone<Provider<Http>>> =
+            ContractInstance::new(H160::default(), abi, &non_clone_mware);
 
         let _ = c.method::<(), ()>("notARealMethod", ());
 


### PR DESCRIPTION
## Motivation

Contracts currently hold `Arc<M>` and have bound `where M: Middleware` . This requires managing arcs across a codebase, which imposes unpleasant requirements on binaries

## Solution

- Modify the contract object to be abstract over `B: Borrow<M>` instead of holding an `Arc<M>`. This allows contracts to be used directly with Cows, non-ARCed middleware, Boxes, other smart pointers, and anything else that uses the `Borrow`  trait.
- rename the modified object `ContractInternal` and create a type alias under the old name, for backwards compatibility

Example use case: 
- you can now use a contract directly with a `Lazy<Provider<Http>>` without having to have an arc in the lazy first

## Inference Limitation

While `FunctionCall` and `ContractInstance` may be used with any type is `Borrow<M>`, there are sometimes multiple choices of borrowed type that satisfy the `M: Middleware` constraint. 

because `Middleware` has an `auto_impl(&, Box, Arc)`, references, boxes, and arcs have multiple `Borrow` options that satisfy the constraint. 
E.g. `Arc<M>` has these impls:
- `impl Borrow<Arc<M>> for Arc<M>`
- `impl Borrow<M> for Arc<M>`
- `impl Borrow<&M> for Arc<M>`

as a result, type inference fails when calling `ContractInstance::new(address, arc_mware)` users must instead specify `ContractInstance::<_, ConcreteMiddlewareType>(address, arc_mware)`

Removing the `auto_impl` will solve this. However, we don't know the extent of reliance on that auto_impl. As a result, using the backwards-compatibility aliases `Contract` and `ContractCall` is still recommended. the Followup work section describes a migration route to fix inference and deprecate the backwards-compatibility aliases

## Followup work

- Change the abigen derived Contract objects to use the generic `ContractInternal` 
- in 2.0.0, eliminate the type alias, and have the  generic version use the `Contract` name

Lib-wide refactoring plan:
1. list further abstraction targets
    - EthEvent
    - ContractDeployer
    - ContractFactory
    - Middlewares (should the stack be `MyMiddleware { inner: Borrow<M> } ` ?)
    - ProviderOracle
    - abigen! output code
3. refactor to use borrow
4. provide backwards compatible type aliases like `type Contract = ContractInstance<Arc<M>, M>`
5. remove `auto_impl(&, Box, Arc)` on `Middleware`
6. write migration guide
7. deprecate backwards-compatibility aliases
8. remove aliases

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [x] Updated the changelog
-   [x] Breaking changes
