### PR TITLE
fix: add serde(default) to v,r,s in `Transaction`

### DIFF
--- a/ethers-core/src/types/transaction/response.rs
+++ b/ethers-core/src/types/transaction/response.rs
@@ -57,12 +57,15 @@ pub struct Transaction {
     pub input: Bytes,
 
     /// ECDSA recovery id
+    #[serde(default)]
     pub v: U64,
 
     /// ECDSA signature r
+    #[serde(default)]
     pub r: U256,
 
     /// ECDSA signature s
+    #[serde(default)]
     pub s: U256,
 
     /////////////////  Celo-specific transaction fields /////////////////


### PR DESCRIPTION
ref: https://github.com/foundry-rs/foundry/issues/4094

I am not sure if this is a really good change, but also think that the other ways to do it (eg with an Option) are too annoying.

cc @mattsse 