### PR TITLE
Add Geth js tracer option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Add support for Geth javascript custom tracer request into `debug_traceCall` [#2088](https://github.com/gakonst/ethers-rs/pull/2088)
 - Add a `Send` bound to the `IntoFuture` implementation of `ContractCall` [#2083](https://github.com/gakonst/ethers-rs/pull/2083)
 - Bump [`svm-rs`](https://github.com/roynalnaruto/svm-rs) dependency to fix conflicts with Rust Crytpo packages [#2051](https://github.com/gakonst/ethers-rs/pull/2051)
 - Avoid unnecessary allocations in `utils` [#2046](https://github.com/gakonst/ethers-rs/pull/2046)

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -595,12 +595,15 @@ pub trait Middleware: Sync + Send + Debug {
     }
 
     /// Executes the given call and returns a number of possible traces for it
-    async fn debug_trace_call<T: Into<TypedTransaction> + Send + Sync>(
+    async fn debug_trace_call<
+        T: Into<TypedTransaction> + Send + Sync,
+        R: Serialize + DeserializeOwned + Debug + Send,
+    >(
         &self,
         req: T,
         block: Option<BlockId>,
         trace_options: GethDebugTracingCallOptions,
-    ) -> Result<GethTrace, ProviderError> {
+    ) -> Result<R, ProviderError> {
         self.inner().debug_trace_call(req, block, trace_options).await.map_err(FromErr::from)
     }
 

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -1121,12 +1121,15 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
     }
 
     /// Executes the given call and returns a number of possible traces for it
-    async fn debug_trace_call<T: Into<TypedTransaction> + Send + Sync>(
+    async fn debug_trace_call<
+        T: Into<TypedTransaction> + Send + Sync,
+        R: Serialize + DeserializeOwned + Debug + Send,
+    >(
         &self,
         req: T,
         block: Option<BlockId>,
         trace_options: GethDebugTracingCallOptions,
-    ) -> Result<GethTrace, ProviderError> {
+    ) -> Result<R, ProviderError> {
         let req = req.into();
         let req = utils::serialize(&req);
         let block = utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));

--- a/examples/geth_trace_call.rs
+++ b/examples/geth_trace_call.rs
@@ -1,15 +1,44 @@
 use ethers::prelude::*;
 use eyre::Result;
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 /// use `debug_traceCall` to fetch traces
 /// requires, a valid endpoint in `RPC_URL` env var that supports `debug_traceCall`
+/// Currently, Geth support several builtin tracers. For details, please read
+/// https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers.
+///
+/// However, currently ethers-rs only support 3 types of tracers.
+/// 1. Struct/opcode logger tracer (This is the default one when no tracer is configured)
+/// 2. callTracer -> https://geth.ethereum.org/docs/developers/evm-tracing/built-in-tracers#call-tracer
+/// 3. javascript tracer -> https://geth.ethereum.org/docs/developers/evm-tracing/custom-tracer#custom-javascript-tracing
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct CustomJSTracerResult {
+    result: String,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     if let Ok(url) = std::env::var("RPC_URL") {
         let client = Provider::<Http>::try_from(url)?;
         let tx = TransactionRequest::new().from(Address::from_str("0xdeadbeef29292929192939494959594933929292").unwrap()).to(Address::from_str("0xde929f939d939d393f939393f93939f393929023").unwrap()).gas("0x7a120").data(Bytes::from_str("0xf00d4b5d00000000000000000000000001291230982139282304923482304912923823920000000000000000000000001293123098123928310239129839291010293810").unwrap());
         let block = BlockId::from(16213100);
+
+        // 1. default Struct/opcode logger tracer
+        let options: GethDebugTracingCallOptions = GethDebugTracingCallOptions {
+            tracing_options: GethDebugTracingOptions {
+                disable_storage: Some(true),
+                enable_memory: Some(false),
+                tracer: None,
+                ..Default::default()
+            },
+        };
+        let traces: GethTrace =
+            client.debug_trace_call(tx.clone(), Some(block.clone()), options).await?;
+        println!("1. {traces:?}");
+
+        // 2. callTracer
         let options: GethDebugTracingCallOptions = GethDebugTracingCallOptions {
             tracing_options: GethDebugTracingOptions {
                 disable_storage: Some(true),
@@ -18,9 +47,24 @@ async fn main() -> Result<()> {
                 ..Default::default()
             },
         };
-        let traces = client.debug_trace_call(tx, Some(block), options).await?;
-        println!("{traces:?}");
-    }
+        let traces: CallTrace =
+            client.debug_trace_call(tx.clone(), Some(block.clone()), options).await?;
+        println!("2. {traces:?}");
 
+        // 3. javascript tracer
+        let options: GethDebugTracingCallOptions = GethDebugTracingCallOptions {
+            tracing_options: GethDebugTracingOptions {
+                disable_storage: Some(true),
+                enable_memory: Some(false),
+                tracer: Some(GethDebugTracerType::JSTracer(
+                    "{data: [], fault: function(log) {},step: function(log) { if(log.op.toString() == \"CALL\") this.data.push(log.stack.peek(0));},result: function() { return {\"result\":\"HelloWorld\"};}}".to_string()
+                )),
+                ..Default::default()
+            },
+        };
+        let traces: CustomJSTracerResult =
+            client.debug_trace_call(tx, Some(block), options).await?;
+        println!("3. {traces:?}");
+    }
     Ok(())
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
In [aa-bundler](https://github.com/Vid201/aa-bundler), we need `debug_traceCall` javascript tracer option. So we add this js tracer config in making the request.

And the `CallTracer` return data is not correct which needs to be fixed, too.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add additional options.

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [x] Updated the changelog
-   [ ] Breaking changes
