### PR TITLE
feat(core): expose genesis and private key in Geth

### DIFF
--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -619,4 +619,19 @@ mod tests {
 
         assert!(geth.genesis().is_some());
     }
+
+    #[test]
+    fn clique_p2p_configured() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_dir_path = temp_dir.path().to_path_buf();
+
+        let private_key = SigningKey::random(&mut rand::thread_rng());
+        let geth = Geth::new()
+            .set_clique_private_key(private_key)
+            .chain_id(1337u64)
+            .data_dir(temp_dir_path)
+            .spawn();
+
+        assert!(geth.p2p_port().is_some());
+    }
 }

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -602,7 +602,12 @@ mod tests {
             .data_dir(temp_dir_path)
             .spawn();
 
-        assert!(geth.clique_private_key().is_some());
+        let clique_private_key = geth.clique_private_key().clone();
+
+        drop(geth);
+        temp_dir.close().unwrap();
+
+        assert!(clique_private_key.is_some());
     }
 
     #[test]
@@ -617,7 +622,12 @@ mod tests {
             .data_dir(temp_dir_path)
             .spawn();
 
-        assert!(geth.genesis().is_some());
+        let genesis = geth.genesis().clone();
+
+        drop(geth);
+        temp_dir.close().unwrap();
+
+        assert!(genesis.is_some());
     }
 
     #[test]
@@ -632,6 +642,11 @@ mod tests {
             .data_dir(temp_dir_path)
             .spawn();
 
-        assert!(geth.p2p_port().is_some());
+        let p2p_port = geth.p2p_port();
+
+        drop(geth);
+        temp_dir.close().unwrap();
+
+        assert!(p2p_port.is_some());
     }
 }


### PR DESCRIPTION
## Motivation

While the `genesis` and `clique_private_key` fields are exposed in `Geth`, they can't be accessed once the `GethInstance` is spawned.

## Solution

This exposes the `genesis` and `clique_private_key` fields in `GethInstance`.

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
