### PR TITLE
Refactor factories to use `Borrow<M>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,8 @@
 
 ### Unreleased
 
+- Make `Factory` objects generic over the borrow trait, to allow non-arc mware
+  [#2103](https://github.com/gakonst/ethers-rs/pull/2103)
 - Make `Contract` objects generic over the borrow trait, to allow non-arc mware
   [#2082](https://github.com/gakonst/ethers-rs/pull/2082)
 - Return pending transaction from `Multicall::send`

--- a/ethers-contract/src/contract.rs
+++ b/ethers-contract/src/contract.rs
@@ -243,7 +243,7 @@ where
     /// Returns an [`Event`](crate::builders::Event) builder for the provided event.
     /// This function operates in a static context, then it does not require a `self`
     /// to reference to instantiate an [`Event`](crate::builders::Event) builder.
-    pub fn event_of_type<D: EthEvent>(client: &Arc<M>) -> Event<M, D> {
+    pub fn event_of_type<D: EthEvent>(client: &M) -> Event<M, D> {
         Event {
             provider: client,
             filter: Filter::new().event(&D::abi_signature()),

--- a/ethers-contract/src/factory.rs
+++ b/ethers-contract/src/factory.rs
@@ -37,7 +37,7 @@ pub type ContractFactory<M> = DeploymentTxFactory<Arc<M>, M>;
 ///
 /// Currently, we recommend using the [`ContractDeployer`] type alias.
 #[derive(Debug)]
-#[must_use = "Deployer does nothing unless you `send` it"]
+#[must_use = "DeploymentTx does nothing unless you `send` it"]
 pub struct ContractDeploymentTx<B, M, C> {
     /// the actual deployer, exposed for overriding the defaults
     pub deployer: Deployer<B, M>,
@@ -56,15 +56,21 @@ where
     }
 }
 
+impl<B, M, C> From<Deployer<B, M>> for ContractDeploymentTx<B, M, C> {
+    fn from(deployer: Deployer<B, M>) -> Self {
+        Self { deployer, _contract: PhantomData }
+    }
+}
+
 impl<B, M, C> ContractDeploymentTx<B, M, C>
 where
     B: Borrow<M> + Clone,
     M: Middleware,
     C: From<ContractInstance<B, M>>,
 {
-    /// Create a new instance of this [ContractDeployment]
+    /// Create a new instance of this from a deployer.
     pub fn new(deployer: Deployer<B, M>) -> Self {
-        Self { deployer, _contract: Default::default() }
+        Self { deployer, _contract: PhantomData }
     }
 
     /// Sets the number of confirmations to wait for the contract deployment transaction

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -15,7 +15,7 @@ mod error;
 pub use error::EthError;
 
 mod factory;
-pub use factory::{ContractDeployer, ContractFactory};
+pub use factory::{ContractDeployer, ContractDeploymentTx, ContractFactory, DeploymentTxFactory};
 
 mod event;
 pub use event::{EthEvent, Event};


### PR DESCRIPTION
Depends on #2082 

## Motivation

- Continue refactoring types that take `Arc<M>` to take `B: Borrow<M>` instead.
- Provide backwards-compatible aliases

## Solution

- Refactor `ethers_contracts::factory` module to be abstract over B
- provide type aliases 

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [x] Updated the changelog
-   [ ] Breaking changes
