### PR TITLE
Prestwich/event no lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@
 
 ### Unreleased
 
+- Abigen now generates events with new `<B, M>` generic pattern [#2103](https://github.com/gakonst/ethers-rs/pull/2103)
 - Fix Cargo.toml generation issue that could cause dependency conflicts [#1852](https://github.com/gakonst/ethers-rs/pull/1852)
 - Use corresponding rust structs for event fields if they're solidity structs [#1674](https://github.com/gakonst/ethers-rs/pull/1674)
 - Add `ContractFilter` to filter contracts in `MultiAbigen` [#1564](https://github.com/gakonst/ethers-rs/pull/1564)
@@ -300,6 +301,8 @@
 
 ### Unreleased
 
+- (Breaking) Make `Event` objects generic over borrow & remove lifetime
+  [#2105](https://github.com/gakonst/ethers-rs/pull/2105)
 - Make `Factory` objects generic over the borrow trait, to allow non-arc mware
   [#2103](https://github.com/gakonst/ethers-rs/pull/2103)
 - Make `Contract` objects generic over the borrow trait, to allow non-arc mware

--- a/ethers-contract/ethers-contract-abigen/src/contract/events.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/events.rs
@@ -127,7 +127,7 @@ impl Context {
 
             quote! {
                 /// Returns an [`Event`](#ethers_contract::builders::Event) builder for all events of this contract
-                pub fn events(&self) -> #ethers_contract::builders::Event<M, #ty> {
+                pub fn events(&self) -> #ethers_contract::builders::Event<Arc<M>, M, #ty> {
                     self.0.event_with_filter(Default::default())
                 }
             }
@@ -235,7 +235,7 @@ impl Context {
 
         quote! {
             #[doc = #doc_str]
-            pub fn #function_name(&self) -> #ethers_contract::builders::Event<M, #struct_name> {
+            pub fn #function_name(&self) -> #ethers_contract::builders::Event<Arc<M>, M, #struct_name> {
                 self.0.event()
             }
         }
@@ -406,7 +406,7 @@ mod tests {
             #[doc = "Gets the contract's `Transfer` event"]
             pub fn transfer_event_filter(
                 &self
-            ) -> ::ethers_contract::builders::Event<M, TransferEventFilter> {
+            ) -> ::ethers_contract::builders::Event<Arc<M>, M, TransferEventFilter> {
                 self.0.event()
             }
         });
@@ -425,7 +425,9 @@ mod tests {
         let cx = test_context();
         assert_quote!(cx.expand_filter(&event), {
             #[doc = "Gets the contract's `Transfer` event"]
-            pub fn transfer_filter(&self) -> ::ethers_contract::builders::Event<M, TransferFilter> {
+            pub fn transfer_filter(
+                &self,
+            ) -> ::ethers_contract::builders::Event<Arc<M>, M, TransferFilter> {
                 self.0.event()
             }
         });

--- a/ethers-contract/tests/it/contract.rs
+++ b/ethers-contract/tests/it/contract.rs
@@ -410,7 +410,7 @@ mod eth_tests {
 
         let anvil = Anvil::new().spawn();
         let client = connect(&anvil, 0);
-        let event = ethers_contract::Contract::event_of_type::<AnswerUpdatedFilter>(&client);
+        let event = ethers_contract::Contract::event_of_type::<AnswerUpdatedFilter>(client);
         assert_eq!(event.filter, Filter::new().event(&AnswerUpdatedFilter::abi_signature()));
     }
 

--- a/ethers-middleware/src/transformer/ds_proxy/factory.rs
+++ b/ethers-middleware/src/transformer/ds_proxy/factory.rs
@@ -98,13 +98,13 @@ mod dsproxyfactory_mod {
                 .expect("method not found (this should never happen)")
         }
         ///Gets the contract's `Created` event
-        pub fn created_filter(&self) -> Event<M, CreatedFilter> {
+        pub fn created_filter(&self) -> Event<Arc<M>, M, CreatedFilter> {
             self.0.event()
         }
 
         /// Returns an [`Event`](ethers_contract::builders::Event) builder for all events of this
         /// contract
-        pub fn events(&self) -> Event<M, CreatedFilter> {
+        pub fn events(&self) -> Event<Arc<M>, M, CreatedFilter> {
             self.0.event_with_filter(Default::default())
         }
     }

--- a/examples/subscriptions/examples/subscribe_events_by_type.rs
+++ b/examples/subscriptions/examples/subscribe_events_by_type.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Build an Event by type. We are not tied to a contract instance. We use builder functions to
     // refine the event filter
-    let event = Contract::event_of_type::<AnswerUpdatedFilter>(&client)
+    let event = Contract::event_of_type::<AnswerUpdatedFilter>(client)
         .from_block(16022082)
         .address(ValueOrArray::Array(vec![
             PRICE_FEED_1.parse()?,


### PR DESCRIPTION
Depends on #2082 

## Motivation

`FunctionCall` and `Event` both are created by `Contract` types via similar APIs. However, `Event` had a lifetime and borrowed the client, while `FunctionCall` cloned the client.

## Solution

 This PR updates `Event` to work as `FunctionCall` does.

Old Style:
- `Event<'a, M, D>`

New Style:
- `Event<B, M, D>`

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [x] Breaking changes
