### PR TITLE
feature: allow signature to recover typed_data payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Add `Signature::recover_typed_data` [#2120](https://github.com/gakonst/ethers-rs/pull/2120)
 - Add `abi::encode_packed` [#2104](https://github.com/gakonst/ethers-rs/pull/2104)
 - Add support for custom JavaScript tracer to `debug_traceCall` and `debug_traceTransaction` [#2064](https://github.com/gakonst/ethers-rs/pull/2064)
 - Add a `Send` bound to the `IntoFuture` implementation of `ContractCall` [#2083](https://github.com/gakonst/ethers-rs/pull/2083)

--- a/ethers-core/src/types/signature.rs
+++ b/ethers-core/src/types/signature.rs
@@ -17,6 +17,8 @@ use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fmt, str::FromStr};
 use thiserror::Error;
 
+use super::transaction::eip712::Eip712;
+
 /// An error involving a signature.
 #[derive(Debug, Error)]
 pub enum SignatureError {
@@ -109,6 +111,19 @@ impl Signature {
         debug_assert_eq!(public_key[0], 0x04);
         let hash = crate::utils::keccak256(&public_key[1..]);
         Ok(Address::from_slice(&hash[12..]))
+    }
+
+    /// Recovers the ethereum address which was used to sign a given EIP712
+    /// typed data payload.
+    ///
+    /// Recovery signature data uses 'Electrum' notation, this means the `v`
+    /// value is expected to be either `27` or `28`.
+    pub fn recover_typed_data<T>(&self, payload: T) -> Result<Address, SignatureError>
+    where
+        T: Eip712,
+    {
+        let encoded = payload.encode_eip712().map_err(|_| SignatureError::RecoveryError)?;
+        self.recover(encoded)
     }
 
     /// Retrieves the recovery signature.

--- a/ethers-core/src/types/signature.rs
+++ b/ethers-core/src/types/signature.rs
@@ -40,8 +40,8 @@ pub enum SignatureError {
 
 /// Recovery message data.
 ///
-/// The message data can either be a binary message rst hashed
-/// according to EIP-191 and then recovered based on the signathat is fiture or a
+/// The message data can either be a binary message that is first hashed
+/// according to EIP-191 and then recovered based on the signature or a
 /// precomputed hash.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RecoveryMessage {


### PR DESCRIPTION

## Motivation

Provide an official API to recover signatures on eip-712 objects.

## Solution

add `Signature::recover_typed_data<T: Eip712>`

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [x] Updated the changelog
-   [ ] Breaking changes
