### PR TITLE
feature: bubble up jsonrpc error response via trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,8 @@
 
 ### Unreleased
 
+- Add `MiddlewareError` and `RpcError` traits to support access to deeply nested
+  RPC errors [#2122](https://github.com/gakonst/ethers-rs/pull/2122)
 - Convert provider errors to arbitrary middleware errors
   [#1920](https://github.com/gakonst/ethers-rs/pull/1920)
 - Add a subset of the `admin` namespace

--- a/ethers-contract/tests/it/contract.rs
+++ b/ethers-contract/tests/it/contract.rs
@@ -13,7 +13,9 @@ mod eth_tests {
         utils::{keccak256, Anvil},
     };
     use ethers_derive_eip712::*;
-    use ethers_providers::{Http, Middleware, PendingTransaction, Provider, StreamExt};
+    use ethers_providers::{
+        Http, Middleware, MiddlewareError, PendingTransaction, Provider, StreamExt,
+    };
     use ethers_signers::{LocalWallet, Signer};
     use std::{convert::TryFrom, iter::FromIterator, sync::Arc, time::Duration};
 
@@ -24,12 +26,19 @@ mod eth_tests {
 
     #[derive(Debug)]
     pub struct MwErr<M: Middleware>(M::Error);
-    impl<M> ethers_providers::FromErr<M::Error> for MwErr<M>
+
+    impl<M: Middleware> MiddlewareError for MwErr<M>
     where
         M: Middleware,
     {
-        fn from(src: M::Error) -> Self {
+        type Inner = M::Error;
+
+        fn from_err(src: M::Error) -> Self {
             Self(src)
+        }
+
+        fn as_inner(&self) -> Option<&Self::Inner> {
+            Some(&self.0)
         }
     }
 

--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -2,7 +2,7 @@ use ethers_core::types::{
     transaction::{eip2718::TypedTransaction, eip2930::AccessListWithGasUsed},
     Address, BlockId, Bytes, Chain, Signature, TransactionRequest, U256,
 };
-use ethers_providers::{maybe, FromErr, Middleware, PendingTransaction};
+use ethers_providers::{maybe, Middleware, MiddlewareError, PendingTransaction};
 use ethers_signers::Signer;
 use std::convert::TryFrom;
 
@@ -67,12 +67,6 @@ pub struct SignerMiddleware<M, S> {
     pub(crate) address: Address,
 }
 
-impl<M: Middleware, S: Signer> FromErr<M::Error> for SignerMiddlewareError<M, S> {
-    fn from(src: M::Error) -> SignerMiddlewareError<M, S> {
-        SignerMiddlewareError::MiddlewareError(src)
-    }
-}
-
 #[derive(Error, Debug)]
 /// Error thrown when the client interacts with the blockchain
 pub enum SignerMiddlewareError<M: Middleware, S: Signer> {
@@ -99,6 +93,21 @@ pub enum SignerMiddlewareError<M: Middleware, S: Signer> {
     /// Thrown if the signer's chain_id is different than the chain_id of the transaction
     #[error("specified chain_id is different than the signer's chain_id")]
     DifferentChainID,
+}
+
+impl<M: Middleware, S: Signer> MiddlewareError for SignerMiddlewareError<M, S> {
+    type Inner = M::Error;
+
+    fn from_err(src: M::Error) -> Self {
+        SignerMiddlewareError::MiddlewareError(src)
+    }
+
+    fn as_inner(&self) -> Option<&Self::Inner> {
+        match self {
+            SignerMiddlewareError::MiddlewareError(e) => Some(e),
+            _ => None,
+        }
+    }
 }
 
 // Helper functions for locally signing transactions

--- a/ethers-middleware/src/transformer/middleware.rs
+++ b/ethers-middleware/src/transformer/middleware.rs
@@ -1,7 +1,7 @@
 use super::{Transformer, TransformerError};
 use async_trait::async_trait;
 use ethers_core::types::{transaction::eip2718::TypedTransaction, *};
-use ethers_providers::{FromErr, Middleware, PendingTransaction};
+use ethers_providers::{Middleware, MiddlewareError, PendingTransaction};
 use thiserror::Error;
 
 #[derive(Debug)]
@@ -33,9 +33,18 @@ pub enum TransformerMiddlewareError<M: Middleware> {
     MiddlewareError(M::Error),
 }
 
-impl<M: Middleware> FromErr<M::Error> for TransformerMiddlewareError<M> {
-    fn from(src: M::Error) -> TransformerMiddlewareError<M> {
+impl<M: Middleware> MiddlewareError for TransformerMiddlewareError<M> {
+    type Inner = M::Error;
+
+    fn from_err(src: M::Error) -> Self {
         TransformerMiddlewareError::MiddlewareError(src)
+    }
+
+    fn as_inner(&self) -> Option<&Self::Inner> {
+        match self {
+            TransformerMiddlewareError::MiddlewareError(e) => Some(e),
+            _ => None,
+        }
     }
 }
 

--- a/ethers-providers/src/errors.rs
+++ b/ethers-providers/src/errors.rs
@@ -1,0 +1,91 @@
+use std::{error::Error, fmt::Debug};
+use thiserror::Error;
+
+use crate::JsonRpcError;
+
+pub trait RpcError: Error + Debug + Send + Sync {
+    fn as_error_response(&self) -> Option<&JsonRpcError>;
+}
+
+pub trait MiddlewareError: Error + Sized + Send + Sync {
+    type Inner: MiddlewareError;
+
+    fn from_err(e: Self::Inner) -> Self;
+
+    fn as_inner(&self) -> Option<&Self::Inner>;
+
+    fn as_provider_error(&self) -> Option<&ProviderError> {
+        self.as_inner()?.as_provider_error()
+    }
+
+    fn from_provider_err(p: ProviderError) -> Self {
+        Self::from_err(Self::Inner::from_provider_err(p))
+    }
+
+    fn as_error_response(&self) -> Option<&JsonRpcError> {
+        MiddlewareError::as_error_response(self.as_inner()?)
+    }
+}
+
+#[derive(Debug, Error)]
+/// An error thrown when making a call to the provider
+pub enum ProviderError {
+    /// An internal error in the JSON RPC Client
+    #[error("{0}")]
+    JsonRpcClientError(Box<dyn crate::RpcError + Send + Sync>),
+
+    /// An error during ENS name resolution
+    #[error("ens name not found: {0}")]
+    EnsError(String),
+
+    /// Invalid reverse ENS name
+    #[error("reverse ens name not pointing to itself: {0}")]
+    EnsNotOwned(String),
+
+    #[error(transparent)]
+    SerdeJson(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    HexError(#[from] hex::FromHexError),
+
+    #[error(transparent)]
+    HTTPError(#[from] reqwest::Error),
+
+    #[error("custom error: {0}")]
+    CustomError(String),
+
+    #[error("unsupported RPC")]
+    UnsupportedRPC,
+
+    #[error("unsupported node client")]
+    UnsupportedNodeClient,
+
+    #[error("Attempted to sign a transaction with no available signer. Hint: did you mean to use a SignerMiddleware?")]
+    SignerUnavailable,
+}
+
+impl RpcError for ProviderError {
+    fn as_error_response(&self) -> Option<&super::JsonRpcError> {
+        if let ProviderError::JsonRpcClientError(err) = self {
+            err.as_error_response()
+        } else {
+            None
+        }
+    }
+}
+
+impl MiddlewareError for ProviderError {
+    type Inner = Self;
+
+    fn as_error_response(&self) -> Option<&super::JsonRpcError> {
+        RpcError::as_error_response(self)
+    }
+
+    fn from_err(e: Self::Inner) -> Self {
+        e
+    }
+
+    fn as_inner(&self) -> Option<&Self::Inner> {
+        None
+    }
+}

--- a/ethers-providers/src/errors.rs
+++ b/ethers-providers/src/errors.rs
@@ -3,32 +3,133 @@ use thiserror::Error;
 
 use crate::JsonRpcError;
 
+/// An `RpcError` is an abstraction over error types returned by a
+/// [`crate::JsonRpcClient`].
+///
+/// All clients can return [`JsonRpcError`] responses, as
+/// well as serde deserialization errors. However, because client errors are
+/// typically type-erased via the [`ProviderError`], the error info can be
+/// difficult to access. This trait provides convenient access to the
+/// underlying error types.
+///
+/// This trait deals only with behavior that is common to all clients.
+/// Client-specific errorvariants cannot be accessed via this trait.
 pub trait RpcError: Error + Debug + Send + Sync {
+    /// Access an underlying JSON-RPC error (if any)
+    ///
+    /// Attempts to access an underlying [`JsonRpcError`]. If the underlying
+    /// error is not a JSON-RPC error response, this function will return
+    /// `None`.
     fn as_error_response(&self) -> Option<&JsonRpcError>;
 
+    /// Returns `true` if the underlying error is a JSON-RPC error response
+    fn is_error_response(&self) -> bool {
+        self.as_error_response().is_some()
+    }
+
+    /// Access an underlying `serde_json` error (if any)
+    ///
+    /// Attempts to access an underlying [`serde_json::Error`]. If the
+    /// underlying error is not a serde_json error, this function will return
+    /// `None`.
+    ///
+    /// ### Implementor's Note
+    ///
+    /// When writing a stacked [`JsonRpcClient`] abstraction (e.g. a quorum
+    /// provider or retrying provider), be sure to account for `serde_json`
+    /// errors at your layer, as well as at lower layers.
     fn as_serde_error(&self) -> Option<&serde_json::Error>;
+
+    /// Returns `true` if the underlying error is a serde_json (de)serialization
+    /// error. This method can be used to identify
+    fn is_serde_error(&self) -> bool {
+        self.as_serde_error().is_some()
+    }
 }
 
+/// [`MiddlewareError`] is a companion trait to [`crate::Middleware`]. It
+/// describes error behavior that is common to all Middleware errors.
+///
+/// Like [`crate::Middleware`], it allows moving down through layered errors.
+///
+/// Like [`RpcError`] it exposes convenient accessors to useful underlying
+/// error information.
+///
+///
+/// ## Not to Devs:
+/// While this trait includes the same methods as [`RpcError`], it is not a
+/// supertrait. This is so that 3rd party developers do not need to learn and
+/// implement both traits. We provide default methods that delegate to inner
+/// middleware errors on the assumption that it will eventually reach a
+/// [`ProviderError`], which has correct behavior. This allows Middleware devs
+/// to ignore the methods' presence if they want. Middleware are already plenty
+/// complicated and we don't need to make it worse :)
 pub trait MiddlewareError: Error + Sized + Send + Sync {
+    /// The `Inner` type is the next lower middleware layer's error type.
     type Inner: MiddlewareError;
 
+    /// Convert the next lower middleware layer's error to this layer's error
     fn from_err(e: Self::Inner) -> Self;
 
+    /// Attempt to convert this error to the next lower middleware's error.
+    /// Conversion fails if the error is not from an inner layer (i.e. the
+    /// error originates at this middleware layer)
     fn as_inner(&self) -> Option<&Self::Inner>;
 
+    /// Returns `true` if the underlying error stems from a lower middleware
+    /// layer
+    fn is_inner(&self) -> bool {
+        self.as_inner().is_some()
+    }
+
+    /// Access an underlying `serde_json` error (if any)
+    ///
+    /// Attempts to access an underlying [`serde_json::Error`]. If the
+    /// underlying error is not a serde_json error, this function will return
+    /// `None`.
+    ///
+    /// ### Implementor's Note:
+    ///
+    /// When writing a custom middleware, if your middleware uses `serde_json`
+    /// we recommend a custom implementation of this method. It should first
+    /// check your Middleware's error for local `serde_json` errors, and then
+    /// delegate to inner if none is found. Failing to implement this method may
+    /// result in missed `serde_json` errors.
     fn as_serde_error(&self) -> Option<&serde_json::Error> {
         self.as_inner()?.as_serde_error()
     }
+
+    /// Returns `true` if the underlying error is a serde_json (de)serialization
+    /// error. This method can be used to identify
+    fn is_serde_error(&self) -> bool {
+        self.as_serde_error().is_some()
+    }
+
+    /// Attempts to access an underlying [`ProviderError`], usually by
+    /// traversing the entire middleware stack. Access fails if the underlying
+    /// error is not a [`ProviderError`]
     fn as_provider_error(&self) -> Option<&ProviderError> {
         self.as_inner()?.as_provider_error()
     }
 
+    /// Convert a [`ProviderError`] to this type, by successively wrapping it
+    /// in the error types of all lower middleware
     fn from_provider_err(p: ProviderError) -> Self {
         Self::from_err(Self::Inner::from_provider_err(p))
     }
 
+    /// Access an underlying JSON-RPC error (if any)
+    ///
+    /// Attempts to access an underlying [`JsonRpcError`]. If the underlying
+    /// error is not a JSON-RPC error response, this function will return
+    /// `None`.
     fn as_error_response(&self) -> Option<&JsonRpcError> {
-        MiddlewareError::as_error_response(self.as_inner()?)
+        self.as_inner()?.as_error_response()
+    }
+
+    /// Returns `true` if the underlying error is a JSON-RPC error response
+    fn is_error_response(&self) -> bool {
+        self.as_error_response().is_some()
     }
 }
 
@@ -87,6 +188,8 @@ impl RpcError for ProviderError {
     }
 }
 
+// Do not change these implementations, they are critical to proper middleware
+// error stack behavior.
 impl MiddlewareError for ProviderError {
     type Inner = Self;
 
@@ -103,6 +206,7 @@ impl MiddlewareError for ProviderError {
     }
 
     fn as_inner(&self) -> Option<&Self::Inner> {
+        // prevents infinite loops
         None
     }
 }

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) type PinBoxFut<'a, T> = Pin<Box<dyn Future<Output = Result<T, Provide
 pub(crate) type PinBoxFut<'a, T> =
     Pin<Box<dyn Future<Output = Result<T, ProviderError>> + Send + 'a>>;
 
-pub trait ClientError: std::error::Error + std::fmt::Display + Debug + Send + Sync {
+pub trait TransportError: std::error::Error + std::fmt::Display + Debug + Send + Sync {
     fn as_error_response(&self) -> Option<&transports::JsonRpcError>;
 }
 
@@ -74,7 +74,7 @@ pub trait ClientError: std::error::Error + std::fmt::Display + Debug + Send + Sy
 /// JSON-RPC provider.
 pub trait JsonRpcClient: Debug + Send + Sync {
     /// A JSON-RPC Error
-    type Error: Into<ProviderError> + ClientError;
+    type Error: Into<ProviderError> + TransportError;
 
     /// Sends a request with the provided JSON-RPC and parameters serialized as JSON
     async fn request<T, R>(&self, method: &str, params: T) -> Result<R, Self::Error>

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -63,6 +63,10 @@ pub(crate) type PinBoxFut<'a, T> = Pin<Box<dyn Future<Output = Result<T, Provide
 pub(crate) type PinBoxFut<'a, T> =
     Pin<Box<dyn Future<Output = Result<T, ProviderError>> + Send + 'a>>;
 
+pub trait ClientError: std::error::Error + std::fmt::Display + Debug + Send + Sync {
+    fn as_error_response(&self) -> Option<&transports::JsonRpcError>;
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[auto_impl(&, Box, Arc)]
@@ -70,7 +74,7 @@ pub(crate) type PinBoxFut<'a, T> =
 /// JSON-RPC provider.
 pub trait JsonRpcClient: Debug + Send + Sync {
     /// A JSON-RPC Error
-    type Error: Error + Into<ProviderError>;
+    type Error: Into<ProviderError> + ClientError;
 
     /// Sends a request with the provided JSON-RPC and parameters serialized as JSON
     async fn request<T, R>(&self, method: &str, params: T) -> Result<R, Self::Error>

--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -99,11 +99,12 @@ where
 ///
 /// Writing a middleware is as simple as:
 /// 1. implementing the [`inner`](crate::Middleware::inner) method to point to the next layer in the
-/// "middleware onion", 2. implementing the [`FromErr`](crate::FromErr) trait on your middleware's
+/// "middleware onion", 2. implementing the
+/// [`MiddlewareError`](crate::MiddlewareError) trait on your middleware's
 /// error type 3. implementing any of the methods you want to override
 ///
-/// ```rust
-/// use ethers_providers::{Middleware, FromErr};
+/// ```
+/// use ethers_providers::{Middleware, MiddlewareError};
 /// use ethers_core::types::{U64, TransactionRequest, U256, transaction::eip2718::TypedTransaction, BlockId};
 /// use thiserror::Error;
 /// use async_trait::async_trait;
@@ -119,9 +120,18 @@ where
 ///     // Add your middleware's specific errors here
 /// }
 ///
-/// impl<M: Middleware> FromErr<M::Error> for MyError<M> {
-///     fn from(src: M::Error) -> MyError<M> {
+/// impl<M: Middleware> MiddlewareError for MyError<M> {
+///     type Inner = M::Error;
+///
+///     fn from_err(src: M::Error) -> MyError<M> {
 ///         MyError::MiddlewareError(src)
+///     }
+///
+///     fn as_inner(&self) -> Option<&Self::Inner> {
+///         match self {
+///             MyError::MiddlewareError(e) => Some(e),
+///             _ => None,
+///         }
 ///     }
 /// }
 ///

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -114,7 +114,7 @@ impl FromErr<ProviderError> for ProviderError {
 pub enum ProviderError {
     /// An internal error in the JSON RPC Client
     #[error("{0}")]
-    JsonRpcClientError(Box<dyn crate::ClientError + Send + Sync>),
+    JsonRpcClientError(Box<dyn crate::TransportError + Send + Sync>),
 
     /// An error during ENS name resolution
     #[error("ens name not found: {0}")]
@@ -146,7 +146,7 @@ pub enum ProviderError {
     SignerUnavailable,
 }
 
-impl crate::ClientError for ProviderError {
+impl crate::TransportError for ProviderError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         if let ProviderError::JsonRpcClientError(err) = self {
             err.as_error_response()

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -113,8 +113,8 @@ impl FromErr<ProviderError> for ProviderError {
 /// An error thrown when making a call to the provider
 pub enum ProviderError {
     /// An internal error in the JSON RPC Client
-    #[error(transparent)]
-    JsonRpcClientError(#[from] Box<dyn std::error::Error + Send + Sync>),
+    #[error("{0}")]
+    JsonRpcClientError(Box<dyn crate::ClientError + Send + Sync>),
 
     /// An error during ENS name resolution
     #[error("ens name not found: {0}")]
@@ -144,6 +144,16 @@ pub enum ProviderError {
 
     #[error("Attempted to sign a transaction with no available signer. Hint: did you mean to use a SignerMiddleware?")]
     SignerUnavailable,
+}
+
+impl crate::ClientError for ProviderError {
+    fn as_error_response(&self) -> Option<&super::JsonRpcError> {
+        if let ProviderError::JsonRpcClientError(err) = self {
+            err.as_error_response()
+        } else {
+            None
+        }
+    }
 }
 
 /// Types of filters supported by the JSON-RPC.

--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -1,7 +1,7 @@
 // Code adapted from: https://github.com/althea-net/guac_rs/tree/master/web3/src/jsonrpc
 
 use super::common::{Authorization, JsonRpcError, Request, Response};
-use crate::{provider::ProviderError, JsonRpcClient};
+use crate::{errors::ProviderError, JsonRpcClient};
 use async_trait::async_trait;
 use reqwest::{header::HeaderValue, Client, Error as ReqwestError};
 use serde::{de::DeserializeOwned, Serialize};
@@ -58,7 +58,7 @@ impl From<ClientError> for ProviderError {
     }
 }
 
-impl crate::TransportError for ClientError {
+impl crate::RpcError for ClientError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         if let ClientError::JsonRpcError(err) = self {
             Some(err)

--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -58,6 +58,16 @@ impl From<ClientError> for ProviderError {
     }
 }
 
+impl crate::ClientError for ClientError {
+    fn as_error_response(&self) -> Option<&super::JsonRpcError> {
+        if let ClientError::JsonRpcError(err) = self {
+            Some(err)
+        } else {
+            None
+        }
+    }
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl JsonRpcClient for Provider {

--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -66,6 +66,13 @@ impl crate::RpcError for ClientError {
             None
         }
     }
+
+    fn as_serde_error(&self) -> Option<&serde_json::Error> {
+        match self {
+            ClientError::SerdeJson { err, .. } => Some(err),
+            _ => None,
+        }
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]

--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -58,7 +58,7 @@ impl From<ClientError> for ProviderError {
     }
 }
 
-impl crate::ClientError for ClientError {
+impl crate::TransportError for ClientError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         if let ClientError::JsonRpcError(err) = self {
             Some(err)

--- a/ethers-providers/src/transports/ipc.rs
+++ b/ethers-providers/src/transports/ipc.rs
@@ -1,6 +1,6 @@
 use super::common::Params;
 use crate::{
-    provider::ProviderError,
+    errors::ProviderError,
     transports::common::{JsonRpcError, Request, Response},
     JsonRpcClient, PubsubClient,
 };
@@ -491,7 +491,7 @@ impl From<IpcError> for ProviderError {
     }
 }
 
-impl crate::TransportError for IpcError {
+impl crate::RpcError for IpcError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         if let IpcError::JsonRpcError(err) = self {
             Some(err)

--- a/ethers-providers/src/transports/ipc.rs
+++ b/ethers-providers/src/transports/ipc.rs
@@ -491,6 +491,16 @@ impl From<IpcError> for ProviderError {
     }
 }
 
+impl crate::ClientError for IpcError {
+    fn as_error_response(&self) -> Option<&super::JsonRpcError> {
+        if let IpcError::JsonRpcError(err) = self {
+            Some(err)
+        } else {
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ethers-providers/src/transports/ipc.rs
+++ b/ethers-providers/src/transports/ipc.rs
@@ -499,6 +499,13 @@ impl crate::RpcError for IpcError {
             None
         }
     }
+
+    fn as_serde_error(&self) -> Option<&serde_json::Error> {
+        match self {
+            IpcError::JsonError(err) => Some(err),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/ethers-providers/src/transports/ipc.rs
+++ b/ethers-providers/src/transports/ipc.rs
@@ -491,7 +491,7 @@ impl From<IpcError> for ProviderError {
     }
 }
 
-impl crate::ClientError for IpcError {
+impl crate::TransportError for IpcError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         if let IpcError::JsonRpcError(err) = self {
             Some(err)

--- a/ethers-providers/src/transports/mock.rs
+++ b/ethers-providers/src/transports/mock.rs
@@ -107,7 +107,7 @@ pub enum MockError {
     EmptyResponses,
 }
 
-impl crate::TransportError for MockError {
+impl crate::RpcError for MockError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         None
     }

--- a/ethers-providers/src/transports/mock.rs
+++ b/ethers-providers/src/transports/mock.rs
@@ -111,6 +111,13 @@ impl crate::RpcError for MockError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         None
     }
+
+    fn as_serde_error(&self) -> Option<&serde_json::Error> {
+        match self {
+            MockError::SerdeJson(e) => Some(e),
+            _ => None,
+        }
+    }
 }
 
 impl From<MockError> for ProviderError {

--- a/ethers-providers/src/transports/mock.rs
+++ b/ethers-providers/src/transports/mock.rs
@@ -107,6 +107,12 @@ pub enum MockError {
     EmptyResponses,
 }
 
+impl crate::ClientError for MockError {
+    fn as_error_response(&self) -> Option<&super::JsonRpcError> {
+        None
+    }
+}
+
 impl From<MockError> for ProviderError {
     fn from(src: MockError) -> Self {
         ProviderError::JsonRpcClientError(Box::new(src))

--- a/ethers-providers/src/transports/mock.rs
+++ b/ethers-providers/src/transports/mock.rs
@@ -107,7 +107,7 @@ pub enum MockError {
     EmptyResponses,
 }
 
-impl crate::ClientError for MockError {
+impl crate::TransportError for MockError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         None
     }

--- a/ethers-providers/src/transports/mod.rs
+++ b/ethers-providers/src/transports/mod.rs
@@ -1,5 +1,5 @@
 mod common;
-pub use common::Authorization;
+pub use common::{Authorization, JsonRpcError};
 
 mod http;
 pub use self::http::{ClientError as HttpClientError, Provider as Http};

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -355,6 +355,12 @@ pub enum QuorumError {
     NoQuorumReached { values: Vec<Value>, errors: Vec<ProviderError> },
 }
 
+impl crate::ClientError for QuorumError {
+    fn as_error_response(&self) -> Option<&super::JsonRpcError> {
+        None
+    }
+}
+
 impl From<QuorumError> for ProviderError {
     fn from(src: QuorumError) -> Self {
         ProviderError::JsonRpcClientError(Box::new(src))

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -359,6 +359,10 @@ impl crate::RpcError for QuorumError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         None
     }
+
+    fn as_serde_error(&self) -> Option<&serde_json::Error> {
+        None
+    }
 }
 
 impl From<QuorumError> for ProviderError {

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -1,4 +1,4 @@
-use crate::{provider::ProviderError, JsonRpcClient, PubsubClient};
+use crate::{errors::ProviderError, JsonRpcClient, PubsubClient};
 use async_trait::async_trait;
 use ethers_core::types::{U256, U64};
 use futures_core::Stream;
@@ -355,7 +355,7 @@ pub enum QuorumError {
     NoQuorumReached { values: Vec<Value>, errors: Vec<ProviderError> },
 }
 
-impl crate::TransportError for QuorumError {
+impl crate::RpcError for QuorumError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         None
     }

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -355,7 +355,7 @@ pub enum QuorumError {
     NoQuorumReached { values: Vec<Value>, errors: Vec<ProviderError> },
 }
 
-impl crate::ClientError for QuorumError {
+impl crate::TransportError for QuorumError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         None
     }

--- a/ethers-providers/src/transports/retry.rs
+++ b/ethers-providers/src/transports/retry.rs
@@ -50,7 +50,7 @@ pub trait RetryPolicy<E>: Send + Sync + Debug {
 pub struct RetryClient<T>
 where
     T: JsonRpcClient,
-    T::Error: Sync + Send + 'static,
+    T::Error: crate::ClientError + Sync + Send + 'static,
 {
     inner: T,
     requests_enqueued: AtomicU32,
@@ -207,6 +207,16 @@ pub enum RetryClientError {
     #[error(transparent)]
     SerdeJson(serde_json::Error),
     TimerError,
+}
+
+impl crate::ClientError for RetryClientError {
+    fn as_error_response(&self) -> Option<&super::JsonRpcError> {
+        if let RetryClientError::ProviderError(err) = self {
+            err.as_error_response()
+        } else {
+            None
+        }
+    }
 }
 
 impl std::fmt::Display for RetryClientError {

--- a/ethers-providers/src/transports/retry.rs
+++ b/ethers-providers/src/transports/retry.rs
@@ -2,7 +2,7 @@
 //! with an exponential backoff.
 
 use super::{common::JsonRpcError, http::ClientError};
-use crate::{provider::ProviderError, JsonRpcClient};
+use crate::{errors::ProviderError, JsonRpcClient};
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
@@ -50,7 +50,7 @@ pub trait RetryPolicy<E>: Send + Sync + Debug {
 pub struct RetryClient<T>
 where
     T: JsonRpcClient,
-    T::Error: crate::TransportError + Sync + Send + 'static,
+    T::Error: crate::RpcError + Sync + Send + 'static,
 {
     inner: T,
     requests_enqueued: AtomicU32,
@@ -209,7 +209,7 @@ pub enum RetryClientError {
     TimerError,
 }
 
-impl crate::TransportError for RetryClientError {
+impl crate::RpcError for RetryClientError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         if let RetryClientError::ProviderError(err) = self {
             err.as_error_response()

--- a/ethers-providers/src/transports/retry.rs
+++ b/ethers-providers/src/transports/retry.rs
@@ -50,7 +50,7 @@ pub trait RetryPolicy<E>: Send + Sync + Debug {
 pub struct RetryClient<T>
 where
     T: JsonRpcClient,
-    T::Error: crate::ClientError + Sync + Send + 'static,
+    T::Error: crate::TransportError + Sync + Send + 'static,
 {
     inner: T,
     requests_enqueued: AtomicU32,
@@ -209,7 +209,7 @@ pub enum RetryClientError {
     TimerError,
 }
 
-impl crate::ClientError for RetryClientError {
+impl crate::TransportError for RetryClientError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         if let RetryClientError::ProviderError(err) = self {
             err.as_error_response()

--- a/ethers-providers/src/transports/retry.rs
+++ b/ethers-providers/src/transports/retry.rs
@@ -217,6 +217,14 @@ impl crate::RpcError for RetryClientError {
             None
         }
     }
+
+    fn as_serde_error(&self) -> Option<&serde_json::Error> {
+        match self {
+            RetryClientError::ProviderError(e) => e.as_serde_error(),
+            RetryClientError::SerdeJson(e) => Some(e),
+            _ => None,
+        }
+    }
 }
 
 impl std::fmt::Display for RetryClientError {

--- a/ethers-providers/src/transports/rw.rs
+++ b/ethers-providers/src/transports/rw.rs
@@ -68,9 +68,9 @@ impl<Read, Write> RwClient<Read, Write> {
 pub enum RwClientError<Read, Write>
 where
     Read: JsonRpcClient,
-    <Read as JsonRpcClient>::Error: Sync + Send + 'static,
+    <Read as JsonRpcClient>::Error: crate::ClientError + Sync + Send + 'static,
     Write: JsonRpcClient,
-    <Write as JsonRpcClient>::Error: Sync + Send + 'static,
+    <Write as JsonRpcClient>::Error: crate::ClientError + Sync + Send + 'static,
 {
     /// Thrown if the _read_ request failed
     #[error(transparent)]
@@ -80,6 +80,20 @@ where
     Write(Write::Error),
 }
 
+impl<Read, Write> crate::ClientError for RwClientError<Read, Write>
+where
+    Read: JsonRpcClient,
+    <Read as JsonRpcClient>::Error: crate::ClientError + Sync + Send + 'static,
+    Write: JsonRpcClient,
+    <Write as JsonRpcClient>::Error: crate::ClientError + Sync + Send + 'static,
+{
+    fn as_error_response(&self) -> Option<&super::JsonRpcError> {
+        match self {
+            RwClientError::Read(e) => e.as_error_response(),
+            RwClientError::Write(e) => e.as_error_response(),
+        }
+    }
+}
 impl<Read, Write> From<RwClientError<Read, Write>> for ProviderError
 where
     Read: JsonRpcClient + 'static,

--- a/ethers-providers/src/transports/rw.rs
+++ b/ethers-providers/src/transports/rw.rs
@@ -1,7 +1,7 @@
 //! A [JsonRpcClient] implementation that serves as a wrapper around two different [JsonRpcClient]
 //! and uses a dedicated client for read and the other for write operations
 
-use crate::{provider::ProviderError, JsonRpcClient};
+use crate::{errors::ProviderError, JsonRpcClient};
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
@@ -68,9 +68,9 @@ impl<Read, Write> RwClient<Read, Write> {
 pub enum RwClientError<Read, Write>
 where
     Read: JsonRpcClient,
-    <Read as JsonRpcClient>::Error: crate::TransportError + Sync + Send + 'static,
+    <Read as JsonRpcClient>::Error: crate::RpcError + Sync + Send + 'static,
     Write: JsonRpcClient,
-    <Write as JsonRpcClient>::Error: crate::TransportError + Sync + Send + 'static,
+    <Write as JsonRpcClient>::Error: crate::RpcError + Sync + Send + 'static,
 {
     /// Thrown if the _read_ request failed
     #[error(transparent)]
@@ -80,12 +80,12 @@ where
     Write(Write::Error),
 }
 
-impl<Read, Write> crate::TransportError for RwClientError<Read, Write>
+impl<Read, Write> crate::RpcError for RwClientError<Read, Write>
 where
     Read: JsonRpcClient,
-    <Read as JsonRpcClient>::Error: crate::TransportError + Sync + Send + 'static,
+    <Read as JsonRpcClient>::Error: crate::RpcError + Sync + Send + 'static,
     Write: JsonRpcClient,
-    <Write as JsonRpcClient>::Error: crate::TransportError + Sync + Send + 'static,
+    <Write as JsonRpcClient>::Error: crate::RpcError + Sync + Send + 'static,
 {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         match self {

--- a/ethers-providers/src/transports/rw.rs
+++ b/ethers-providers/src/transports/rw.rs
@@ -93,7 +93,15 @@ where
             RwClientError::Write(e) => e.as_error_response(),
         }
     }
+
+    fn as_serde_error(&self) -> Option<&serde_json::Error> {
+        match self {
+            RwClientError::Read(e) => e.as_serde_error(),
+            RwClientError::Write(e) => e.as_serde_error(),
+        }
+    }
 }
+
 impl<Read, Write> From<RwClientError<Read, Write>> for ProviderError
 where
     Read: JsonRpcClient + 'static,

--- a/ethers-providers/src/transports/rw.rs
+++ b/ethers-providers/src/transports/rw.rs
@@ -68,9 +68,9 @@ impl<Read, Write> RwClient<Read, Write> {
 pub enum RwClientError<Read, Write>
 where
     Read: JsonRpcClient,
-    <Read as JsonRpcClient>::Error: crate::ClientError + Sync + Send + 'static,
+    <Read as JsonRpcClient>::Error: crate::TransportError + Sync + Send + 'static,
     Write: JsonRpcClient,
-    <Write as JsonRpcClient>::Error: crate::ClientError + Sync + Send + 'static,
+    <Write as JsonRpcClient>::Error: crate::TransportError + Sync + Send + 'static,
 {
     /// Thrown if the _read_ request failed
     #[error(transparent)]
@@ -80,12 +80,12 @@ where
     Write(Write::Error),
 }
 
-impl<Read, Write> crate::ClientError for RwClientError<Read, Write>
+impl<Read, Write> crate::TransportError for RwClientError<Read, Write>
 where
     Read: JsonRpcClient,
-    <Read as JsonRpcClient>::Error: crate::ClientError + Sync + Send + 'static,
+    <Read as JsonRpcClient>::Error: crate::TransportError + Sync + Send + 'static,
     Write: JsonRpcClient,
-    <Write as JsonRpcClient>::Error: crate::ClientError + Sync + Send + 'static,
+    <Write as JsonRpcClient>::Error: crate::TransportError + Sync + Send + 'static,
 {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         match self {

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -507,7 +507,7 @@ impl crate::RpcError for ClientError {
 
     fn as_serde_error(&self) -> Option<&serde_json::Error> {
         match self {
-            ClientError::JsonError(err) => Some(&err),
+            ClientError::JsonError(err) => Some(err),
             _ => None,
         }
     }

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -504,6 +504,13 @@ impl crate::RpcError for ClientError {
             None
         }
     }
+
+    fn as_serde_error(&self) -> Option<&serde_json::Error> {
+        match self {
+            ClientError::JsonError(err) => Some(&err),
+            _ => None,
+        }
+    }
 }
 
 impl From<ClientError> for ProviderError {

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -463,7 +463,7 @@ pub enum ClientError {
     #[error("{0}")]
     ChannelError(String),
 
-    #[error(transparent)]
+    #[error("{0}")]
     Canceled(#[from] oneshot::Canceled),
 
     /// Remote server sent a Close message
@@ -472,7 +472,7 @@ pub enum ClientError {
     WsClosed(CloseFrame<'static>),
 
     /// Remote server sent a Close message
-    #[error("Websocket closed with info")]
+    #[error("Websocket closed")]
     #[cfg(target_arch = "wasm32")]
     WsClosed,
 
@@ -496,7 +496,7 @@ pub enum ClientError {
     RequestError(#[from] http::Error),
 }
 
-impl crate::ClientError for ClientError {
+impl crate::TransportError for ClientError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         if let ClientError::JsonRpcError(err) = self {
             Some(err)

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -496,6 +496,16 @@ pub enum ClientError {
     RequestError(#[from] http::Error),
 }
 
+impl crate::ClientError for ClientError {
+    fn as_error_response(&self) -> Option<&super::JsonRpcError> {
+        if let ClientError::JsonRpcError(err) = self {
+            Some(err)
+        } else {
+            None
+        }
+    }
+}
+
 impl From<ClientError> for ProviderError {
     fn from(src: ClientError) -> Self {
         ProviderError::JsonRpcClientError(Box::new(src))

--- a/ethers-providers/src/transports/ws.rs
+++ b/ethers-providers/src/transports/ws.rs
@@ -1,6 +1,6 @@
 use super::common::{Params, Response};
 use crate::{
-    provider::ProviderError,
+    errors::ProviderError,
     transports::common::{JsonRpcError, Request},
     JsonRpcClient, PubsubClient,
 };
@@ -496,7 +496,7 @@ pub enum ClientError {
     RequestError(#[from] http::Error),
 }
 
-impl crate::TransportError for ClientError {
+impl crate::RpcError for ClientError {
     fn as_error_response(&self) -> Option<&super::JsonRpcError> {
         if let ClientError::JsonRpcError(err) = self {
             Some(err)

--- a/ethers-providers/tests/ws_errors.rs
+++ b/ethers-providers/tests/ws_errors.rs
@@ -25,7 +25,7 @@ async fn graceful_disconnect_on_ws_errors() {
     spawn_ws_server().await;
 
     // Connect to the fake server
-    let (ws, _) = connect_async(format!("ws://{}", WS_ENDPOINT)).await.unwrap();
+    let (ws, _) = connect_async(format!("ws://{WS_ENDPOINT}")).await.unwrap();
     let provider = Provider::new(Ws::new(ws));
     let filter = Filter::new().event("Transfer(address,address,uint256)");
     let mut stream = provider.subscribe_logs(&filter).await.unwrap();

--- a/examples/providers/examples/custom.rs
+++ b/examples/providers/examples/custom.rs
@@ -23,7 +23,7 @@ pub enum WsOrIpcError {
     Ipc(#[from] IpcError),
 }
 
-impl TransportError for WsOrIpcError {
+impl RpcError for WsOrIpcError {
     fn as_error_response(&self) -> Option<&ethers::providers::JsonRpcError> {
         match self {
             WsOrIpcError::Ws(e) => e.as_error_response(),

--- a/examples/providers/examples/custom.rs
+++ b/examples/providers/examples/custom.rs
@@ -23,6 +23,15 @@ pub enum WsOrIpcError {
     Ipc(#[from] IpcError),
 }
 
+impl TransportError for WsOrIpcError {
+    fn as_error_response(&self) -> Option<&ethers::providers::JsonRpcError> {
+        match self {
+            WsOrIpcError::Ws(e) => e.as_error_response(),
+            WsOrIpcError::Ipc(e) => e.as_error_response(),
+        }
+    }
+}
+
 impl From<WsOrIpcError> for ProviderError {
     fn from(value: WsOrIpcError) -> Self {
         Self::JsonRpcClientError(Box::new(value))

--- a/examples/providers/examples/custom.rs
+++ b/examples/providers/examples/custom.rs
@@ -30,6 +30,14 @@ impl RpcError for WsOrIpcError {
             WsOrIpcError::Ipc(e) => e.as_error_response(),
         }
     }
+
+    fn as_serde_error(&self) -> Option<&serde_json::Error> {
+        match self {
+            WsOrIpcError::Ws(WsClientError::JsonError(e)) => Some(e),
+            WsOrIpcError::Ipc(IpcError::JsonError(e)) => Some(e),
+            _ => None,
+        }
+    }
 }
 
 impl From<WsOrIpcError> for ProviderError {


### PR DESCRIPTION

## Motivation

Currently there's no way to get JSON-RPC error response out of the provider or middleware error. They're type-erased in the ProviderError.

## Solution

This adds a `ClientError` trait which helps cast `ProviderError` to `JsonRpcError`. 

I consider this to be a bit of an unpleasant kludge. I'm not sure it should be merged. Hypothetically this would allow us to access and decode revert data from contracts tho, which is definitely a big user need.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
