### PR TITLE
contracts: allow upper case acronyms lint

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract.rs
@@ -56,7 +56,11 @@ impl ExpandedContract {
            // export all the created data types
             pub use #module::*;
 
-            #[allow(clippy::too_many_arguments, non_camel_case_types)]
+            #[allow(
+                clippy::too_many_arguments,
+                non_camel_case_types,
+                clippy::upper_case_acronyms
+            )]
             pub mod #module {
                 #imports
                 #contract


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

I have a contract named `DKG` for which the auto-generated code created the following clippy warning:
```
warning: name `DKG` contains a capitalized acronym
  --> crates/dkg-cli/src/dkg_contract.rs:25:16
   |
25 |     pub struct DKG<M>(ethers::contract::Contract<M>);
   |                ^^^ help: consider making the acronym lowercase, except the initial letter: `Dkg`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms
   = note: `#[warn(clippy::upper_case_acronyms)]` on by default
```

According to the solidity style guide the name is fine: https://docs.soliditylang.org/en/v0.5.3/style-guide.html#naming-styles

## Solution

Allow that clippy lint by default

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
