### PR TITLE
Mattie/better debug logging

### DIFF
--- a/ethers-middleware/src/nonce_manager.rs
+++ b/ethers-middleware/src/nonce_manager.rs
@@ -1,17 +1,20 @@
 use async_trait::async_trait;
 use ethers_core::types::{transaction::eip2718::TypedTransaction, *};
 use ethers_providers::{FromErr, Middleware, PendingTransaction};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::{
+    fmt::Debug,
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+};
 use thiserror::Error;
 
 #[derive(Debug)]
 /// Middleware used for calculating nonces locally, useful for signing multiple
 /// consecutive transactions without waiting for them to hit the mempool
 pub struct NonceManagerMiddleware<M> {
-    inner: M,
     initialized: AtomicBool,
     nonce: AtomicU64,
     address: Address,
+    inner: M,
 }
 
 impl<M> NonceManagerMiddleware<M>

--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -62,9 +62,9 @@ use thiserror::Error;
 ///
 /// [`Signer`]: ethers_signers::Signer
 pub struct SignerMiddleware<M, S> {
-    pub(crate) inner: M,
     pub(crate) signer: S,
     pub(crate) address: Address,
+    pub(crate) inner: M,
 }
 
 impl<M: Middleware, S: Signer> FromErr<M::Error> for SignerMiddlewareError<M, S> {

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -36,7 +36,12 @@ use url::{ParseError, Url};
 use ethers_core::types::Chain;
 use futures_util::{lock::Mutex, try_join};
 use std::{
-    collections::VecDeque, convert::TryFrom, fmt::Debug, str::FromStr, sync::Arc, time::Duration,
+    collections::VecDeque,
+    convert::TryFrom,
+    fmt::{Debug, Display},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
 };
 use tracing::trace;
 use tracing_futures::Instrument;
@@ -86,7 +91,7 @@ impl FromStr for NodeClient {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Provider<P> {
     inner: P,
     ens: Option<Address>,
@@ -107,6 +112,16 @@ impl<P> AsRef<P> for Provider<P> {
 impl FromErr<ProviderError> for ProviderError {
     fn from(src: ProviderError) -> Self {
         src
+    }
+}
+
+impl<P: Debug> Debug for Provider<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Provider {{ ens: {:?}, interval: {:?}, from: {:?}, inner: {:?} }}",
+            self.ens, self.interval, self.from, self.inner
+        )
     }
 }
 

--- a/ethers-providers/src/provider.rs
+++ b/ethers-providers/src/provider.rs
@@ -38,7 +38,7 @@ use futures_util::{lock::Mutex, try_join};
 use std::{
     collections::VecDeque,
     convert::TryFrom,
-    fmt::{Debug, Display},
+    fmt::Debug,
     str::FromStr,
     sync::Arc,
     time::Duration,

--- a/ethers-providers/src/transports/http.rs
+++ b/ethers-providers/src/transports/http.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use reqwest::{header::HeaderValue, Client, Error as ReqwestError};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
+    fmt::Debug,
     str::FromStr,
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -28,11 +29,16 @@ use super::common::{Authorization, JsonRpcError, Request, Response};
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug)]
 pub struct Provider {
     id: AtomicU64,
     client: Client,
     url: Url,
+}
+
+impl Debug for Provider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Http {{ id: {:?}, url: {} }}", self.id, self.url)
+    }
 }
 
 #[derive(Error, Debug)]

--- a/ethers-providers/src/transports/mod.rs
+++ b/ethers-providers/src/transports/mod.rs
@@ -33,7 +33,9 @@ mod ws;
 pub use ws::{ClientError as WsClientError, Ws};
 
 mod quorum;
-pub use quorum::{JsonRpcClientWrapper, Quorum, QuorumError, QuorumProvider, WeightedProvider, WrappedParams};
+pub use quorum::{
+    JsonRpcClientWrapper, Quorum, QuorumError, QuorumProvider, WeightedProvider, WrappedParams,
+};
 
 mod rw;
 pub use rw::{RwClient, RwClientError};

--- a/ethers-providers/src/transports/mod.rs
+++ b/ethers-providers/src/transports/mod.rs
@@ -33,7 +33,7 @@ mod ws;
 pub use ws::{ClientError as WsClientError, Ws};
 
 mod quorum;
-pub use quorum::{JsonRpcClientWrapper, Quorum, QuorumError, QuorumProvider, WeightedProvider};
+pub use quorum::{JsonRpcClientWrapper, Quorum, QuorumError, QuorumProvider, WeightedProvider, WrappedParams};
 
 mod rw;
 pub use rw::{RwClient, RwClientError};

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -193,13 +193,13 @@ impl<T: JsonRpcClientWrapper> QuorumProvider<T> {
         });
 
         // find the highest possible block number a quorum agrees on
-        let mut weight_set = vec![];
+        let mut cumulative_weight = 0;
         let mut block = U64::from(0);
         for (provider, n) in numbers.iter().copied() {
-            weight_set.push(provider);
+            cumulative_weight += provider.weight;
             debug_assert!(block == U64::from(0) || block >= n);
             block = n;
-            if self.quorum.weight(weight_set.iter().copied()) >= self.quorum_weight {
+            if cumulative_weight >= self.quorum_weight {
                 return Ok(block)
             }
         }
@@ -278,23 +278,20 @@ pub enum Quorum {
 }
 
 impl Quorum {
-    fn weight<'a, T: 'a>(
-        self,
-        providers: impl IntoIterator<Item = &'a WeightedProvider<T>>,
-    ) -> u64 {
+    fn weight<T>(self, providers: &[WeightedProvider<T>]) -> u64 {
         match self {
-            Quorum::All => providers.into_iter().map(|p| p.weight).sum::<u64>(),
+            Quorum::All => providers.iter().map(|p| p.weight).sum::<u64>(),
             Quorum::Majority => {
-                let total = providers.into_iter().map(|p| p.weight).sum::<u64>();
+                let total = providers.iter().map(|p| p.weight).sum::<u64>();
                 let rem = total % 2;
                 total / 2 + rem
             }
             Quorum::Percentage(p) => {
-                providers.into_iter().map(|p| p.weight).sum::<u64>() * (p as u64) / 100
+                providers.iter().map(|p| p.weight).sum::<u64>() * (p as u64) / 100
             }
             Quorum::ProviderCount(num) => {
                 // take the lowest `num` weights
-                let mut weights = providers.into_iter().map(|p| p.weight).collect::<Vec<_>>();
+                let mut weights = providers.iter().map(|p| p.weight).collect::<Vec<_>>();
                 weights.sort_unstable();
                 weights.into_iter().take(num).sum()
             }
@@ -684,6 +681,120 @@ mod tests {
                 assert_eq!(requested as u64, w);
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_get_quorum_block_number() {
+        let mut providers = Vec::new();
+
+        for value in [100, 101, 68, 100, 102] {
+            let mock = MockProvider::new();
+            for _ in 0..6 {
+                mock.push(U64::from(value)).unwrap();
+            }
+            providers.push(WeightedProvider::new(mock.clone()));
+        }
+
+        let quorum = QuorumProvider::builder()
+            .add_providers(providers.clone())
+            .quorum(Quorum::ProviderCount(5))
+            .build();
+        assert_eq!(quorum.get_quorum_block_number().await.unwrap().as_u64(), 68);
+
+        let quorum = QuorumProvider::builder()
+            .add_providers(providers.clone())
+            .quorum(Quorum::ProviderCount(4))
+            .build();
+        assert_eq!(quorum.get_quorum_block_number().await.unwrap().as_u64(), 100);
+
+        let quorum = QuorumProvider::builder()
+            .add_providers(providers.clone())
+            .quorum(Quorum::ProviderCount(3))
+            .build();
+        assert_eq!(quorum.get_quorum_block_number().await.unwrap().as_u64(), 100);
+
+        let quorum = QuorumProvider::builder()
+            .add_providers(providers.clone())
+            .quorum(Quorum::ProviderCount(2))
+            .build();
+        assert_eq!(quorum.get_quorum_block_number().await.unwrap().as_u64(), 101);
+
+        let quorum = QuorumProvider::builder()
+            .add_providers(providers.clone())
+            .quorum(Quorum::ProviderCount(1))
+            .build();
+        assert_eq!(quorum.get_quorum_block_number().await.unwrap().as_u64(), 102);
+
+        let quorum = QuorumProvider::builder()
+            .add_providers(providers.clone())
+            .quorum(Quorum::Majority)
+            .build();
+        assert_eq!(quorum.get_quorum_block_number().await.unwrap().as_u64(), 100);
+    }
+
+    #[tokio::test]
+    async fn test_get_quorum_block_number_with_errors() {
+        let mut providers = Vec::new();
+
+        let mock = MockProvider::new();
+        for _ in 0..2 {
+            mock.push(U64::from(100)).unwrap();
+        }
+        providers.push(WeightedProvider::new(mock.clone()));
+
+        let mock = MockProvider::new();
+        // this one will error
+        providers.push(WeightedProvider::new(mock.clone()));
+
+        let mock = MockProvider::new();
+
+        for _ in 0..2 {
+            mock.push(U64::from(101)).unwrap();
+        }
+        providers.push(WeightedProvider::new(mock.clone()));
+
+        let quorum = QuorumProvider::builder()
+            .add_providers(providers.clone())
+            .quorum(Quorum::ProviderCount(2))
+            .build();
+        assert_eq!(quorum.get_quorum_block_number().await.unwrap().as_u64(), 100);
+
+        let quorum = QuorumProvider::builder()
+            .add_providers(providers.clone())
+            .quorum(Quorum::Majority)
+            .build();
+        assert_eq!(quorum.get_quorum_block_number().await.unwrap().as_u64(), 100);
+    }
+
+    #[tokio::test]
+    async fn test_get_quorum_block_number_fails_to_reach_quorum() {
+        let mut providers = Vec::new();
+
+        let mock = MockProvider::new();
+        for _ in 0..2 {
+            mock.push(U64::from(100)).unwrap();
+        }
+        providers.push(WeightedProvider::new(mock.clone()));
+
+        let mock = MockProvider::new();
+        // this one will error
+        providers.push(WeightedProvider::new(mock.clone()));
+
+        let mock = MockProvider::new();
+        // this one will error
+        providers.push(WeightedProvider::new(mock.clone()));
+
+        let quorum = QuorumProvider::builder()
+            .add_providers(providers.clone())
+            .quorum(Quorum::ProviderCount(2))
+            .build();
+        assert!(quorum.get_quorum_block_number().await.is_err());
+
+        let quorum = QuorumProvider::builder()
+            .add_providers(providers.clone())
+            .quorum(Quorum::Majority)
+            .build();
+        assert!(quorum.get_quorum_block_number().await.is_err());
     }
 
     #[tokio::test]

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -401,8 +401,8 @@ impl<'a, T> Future for QuorumRequest<'a, T> {
 /// The configuration of a provider for the `QuorumProvider`
 #[derive(Debug, Clone)]
 pub struct WeightedProvider<T> {
-    inner: T,
     weight: u64,
+    inner: T,
 }
 
 impl<T> WeightedProvider<T> {

--- a/ethers-providers/src/transports/quorum.rs
+++ b/ethers-providers/src/transports/quorum.rs
@@ -227,6 +227,7 @@ impl<T: JsonRpcClientWrapper> QuorumProvider<T> {
             "eth_getStorageAt" |
             "eth_getCode" |
             "eth_getProof" |
+            "eth_estimateGas" |
             "trace_call" |
             "trace_block" => {
                 // calls that include the block number in the params at the last index of json array
@@ -401,7 +402,7 @@ impl<T> WeightedProvider<T> {
 #[derive(Error, Debug)]
 /// Error thrown when sending an HTTP request
 pub enum QuorumError {
-    #[error("No Quorum reached.")]
+    #[error("No Quorum reached. (Values: {:?}, Errors: {:?})", values, errors)]
     NoQuorumReached { values: Vec<Value>, errors: Vec<ProviderError> },
 }
 


### PR DESCRIPTION
This is what our Mailbox used to look like in the logs (if pretty formatted)

```
EthereumMailbox {
    contract: Mailbox(0x4ed7c70f96b99c776995fb64377f0d4ab3b0e1c1),
    domain: HyperlaneDomain(test2 (13372)),
    provider: SignerMiddleware {
        inner: NonceManagerMiddleware {
            inner: PrometheusMiddleware(
                Provider {
                    inner: QuorumProvider {
                        quorum: Majority,
                        quorum_weight: 2,
                        providers: [
                            WeightedProvider {
                                inner: RetryingProvider {
                                    inner: PrometheusJsonRpcClient(
                                        Provider {
                                            id: 8,
                                            client: Client {
                                                accepts: Accepts,
                                                proxies: [Proxy(System({}), None)],
                                                referer: true,
                                                default_headers: {"accept": "*/*"},
                                                timeout: 60s
                                            },
                                            url: Url {
                                                scheme: "http",
                                                cannot_be_a_base: false,
                                                username: "",
                                                password: None,
                                                host: Some(Ipv4(127.0.0.1)),
                                                port: Some(8545),
                                                path: "/",
                                                query: None,
                                                fragment: None
                                            }
                                        }
                                    ),
                                    max_requests: 5,
                                    base_retry_ms: 1000
                                },
                                weight: 1
                            },
                            WeightedProvider {
                                inner: RetryingProvider {
                                    inner: PrometheusJsonRpcClient(
                                        Provider {
                                            id: 8,
                                            client: Client {
                                                accepts: Accepts,
                                                proxies: [Proxy(System({}), None)],
                                                referer: true,
                                                default_headers: {"accept": "*/*"},
                                                timeout: 60s
                                            },
                                            url: Url {
                                                scheme: "http",
                                                cannot_be_a_base: false,
                                                username: "",
                                                password: None,
                                                host: Some(Ipv4(127.0.0.1)),
                                                port: Some(8545),
                                                path: "/",
                                                query: None,
                                                fragment: None
                                            }
                                        }
                                    ),
                                    max_requests: 5,
                                    base_retry_ms: 1000
                                },
                                weight: 1
                            },
                            WeightedProvider {
                                inner: RetryingProvider {
                                    inner: PrometheusJsonRpcClient(
                                        Provider {
                                            id: 8,
                                            client: Client {
                                                accepts: Accepts,
                                                proxies: [Proxy(System({}), None)],
                                                referer: true,
                                                default_headers: {"accept": "*/*"},
                                                timeout: 60s
                                            },
                                            url: Url {
                                                scheme: "http",
                                                cannot_be_a_base: false,
                                                username: "",
                                                password: None,
                                                host: Some(Ipv4(127.0.0.1)),
                                                port: Some(8545),
                                                path: "/",
                                                query: None,
                                                fragment: None
                                            }
                                        }
                                    ),
                                    max_requests: 5,
                                    base_retry_ms: 1000
                                },
                                weight: 1
                            }
                        ]
                    },
                    ens: None,
                    interval: None,
                    from: None,
                    _node_client: Mutex {
                        is_locked: false,
                        has_waiters: false
                    }
                }
            ),
            initialized: false,
            nonce: 0,
            address: 0xbcd4042de499d14e55001ccbb24a551f3b954096
        },
        signer: Local(
            Wallet {
                address: 0xbcd4042de499d14e55001ccbb24a551f3b954096,
                chain_Id: 31337
            }
        ),
        address: 0xbcd4042de499d14e55001ccbb24a551f3b954096
    }
}
```

And this is what it looks like now (if pretty formatted)
```
EthereumMailbox {
    contract: Mailbox(0x4ed7c70f96b99c776995fb64377f0d4ab3b0e1c1),
    domain: HyperlaneDomain(test2 (13372)),
    provider: SignerMiddleware {
        signer: Local(
            Wallet {
                address: 0xbcd4042de499d14e55001ccbb24a551f3b954096,
                chain_Id: 31337
            }
        ),
        address: 0xbcd4042de499d14e55001ccbb24a551f3b954096,
        inner: NonceManagerMiddleware {
            initialized: false,
            nonce: 0,
            address: 0xbcd4042de499d14e55001ccbb24a551f3b954096,
            inner: PrometheusMiddleware(
                Provider {
                    ens: None,
                    interval: None,
                    from: None,
                    inner: QuorumProvider {
                        quorum: Majority,
                        quorum_weight: 2,
                        providers: [
                            WeightedProvider {
                                weight: 1,
                                inner: RetryingProvider {
                                    max_requests: 5,
                                    base_retry_ms: 1000,
                                    inner: PrometheusJsonRpcClient(
                                        Http { id: 44, url: http://127.0.0.1:8545/ }
                                    )
                                }
                            },
                            WeightedProvider {
                                weight: 1,
                                inner: RetryingProvider {
                                    max_requests: 5,
                                    base_retry_ms: 1000,
                                    inner: PrometheusJsonRpcClient(
                                        Http { id: 44, url: http://127.0.0.1:8545/ }
                                    )
                                }
                            },
                            WeightedProvider {
                                weight: 1,
                                inner: RetryingProvider {
                                    max_requests: 5,
                                    base_retry_ms: 1000,
                                    inner: PrometheusJsonRpcClient(
                                        Http { id: 44, url: http://127.0.0.1:8545/ }
                                    )
                                }
                            }
                        ]
                    }
                }
            )
        }
    }
}
```