### PR TITLE
dep: solang-parser 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4027,9 +4027,9 @@ dependencies = [
 
 [[package]]
 name = "solang-parser"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9653f278d9531b60f042c29732bb835d519943f4167b1e5684c7e820dd9fec"
+checksum = "58feb14d4002859db0b744b0915840bae403b8a5675efded3e8adddb6beb85b2"
 dependencies = [
  "itertools",
  "lalrpop",

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -37,7 +37,7 @@ tempfile = { version = "3.3.0", optional = true }
 fs_extra = { version = "1.3.0", optional = true }
 sha2 = { version = "0.10.6", default-features = false, optional = true }
 dunce = "1.0.3"
-solang-parser = { default-features = false, version = "=0.2.1" }
+solang-parser = { default-features = false, version = "=0.2.2" }
 rayon = "1.6.0"
 rand = { version = "0.8.5", optional = true }
 path-slash = "0.2.1"


### PR DESCRIPTION
Upgrade solang-parser to the latest release to enabled foundry upgrade