### PR TITLE
perf(solc): wrap source content in Arc

### DIFF
--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["ethereum", "web3", "solc", "solidity", "ethers"]
 [dependencies]
 ethers-core = { version = "^1.0.0", path = "../ethers-core", default-features = false }
 serde_json = "1.0.68"
-serde = { version = "1.0.130", features = ["derive"] }
+serde = { version = "1.0.130", features = ["derive", "rc"] }
 semver = { version = "1.0.16", features = ["serde"] }
 walkdir = "2.3.2"
 tokio = { version = "1.18", default-features = false, features = ["rt"] }

--- a/ethers-solc/src/buildinfo.rs
+++ b/ethers-solc/src/buildinfo.rs
@@ -104,7 +104,7 @@ mod tests {
     fn build_info_serde() {
         let inputs = CompilerInput::with_sources(BTreeMap::from([(
             PathBuf::from("input.sol"),
-            Source { content: "".to_string() },
+            Source::new(""),
         )]));
         let output = CompilerOutput::default();
         let v: Version = "0.8.4+commit.c7e474f2".parse().unwrap();

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -909,6 +909,6 @@ mod tests {
     ///// helpers
 
     fn source(version: &str) -> Source {
-        Source { content: format!("pragma solidity {version};\n") }
+        Source::new(format!("pragma solidity {version};\n"))
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
followup for https://github.com/gakonst/ethers-rs/pull/2136

prevents large String clones by wrapping source in `Arc`, this is useful to make content clones cheap, especially in multi-version builds.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
