### PR TITLE
fix(abigen): use event name from abi attribute

### DIFF
--- a/ethers-contract/ethers-contract-derive/src/event.rs
+++ b/ethers-contract/ethers-contract-derive/src/event.rs
@@ -58,7 +58,7 @@ pub(crate) fn derive_eth_event_impl(input: DeriveInput) -> TokenStream {
         }
     };
 
-    if let Some((attribute_name,_)) = attributes.name {
+    if let Some((attribute_name, _)) = attributes.name {
         event.name = attribute_name;
     }
 

--- a/ethers-contract/ethers-contract-derive/src/event.rs
+++ b/ethers-contract/ethers-contract-derive/src/event.rs
@@ -28,8 +28,6 @@ pub(crate) fn derive_eth_event_impl(input: DeriveInput) -> TokenStream {
         Err(errors) => return errors,
     };
 
-    let event_name = attributes.name.map(|(s, _)| s).unwrap_or_else(|| input.ident.to_string());
-
     let mut event = if let Some((src, span)) = attributes.abi {
         // try to parse as solidity event
         if let Ok(event) = HumanReadableParser::parse_event(&src) {
@@ -60,7 +58,10 @@ pub(crate) fn derive_eth_event_impl(input: DeriveInput) -> TokenStream {
         }
     };
 
-    event.name = event_name.clone();
+    if let Some((attribute_name,_)) = attributes.name {
+        event.name = attribute_name;
+    }
+
     if let Some((anon, _)) = attributes.anonymous.as_ref() {
         event.anonymous = *anon;
     }
@@ -79,6 +80,7 @@ pub(crate) fn derive_eth_event_impl(input: DeriveInput) -> TokenStream {
     };
 
     let anon = attributes.anonymous.map(|(b, _)| b).unwrap_or_default();
+    let event_name = &event.name;
 
     let ethevent_impl = quote! {
         impl #contract_crate::EthEvent for #name {
@@ -286,7 +288,7 @@ fn derive_decode_from_log_impl(
 /// Determine the event's ABI by parsing the AST
 fn derive_abi_event_from_fields(input: &DeriveInput) -> Result<Event, Error> {
     let event = Event {
-        name: "".to_string(),
+        name: input.ident.to_string(),
         inputs: utils::derive_abi_inputs_from_fields(input, "EthEvent")?
             .into_iter()
             .map(|(name, kind)| EventParam { name, kind, indexed: false })

--- a/ethers-contract/tests/it/common/derive.rs
+++ b/ethers-contract/tests/it/common/derive.rs
@@ -647,3 +647,25 @@ fn can_use_human_readable_error() {
 
     assert_etherror::<MyError>();
 }
+
+// <https://github.com/gakonst/ethers-rs/issues/2142>
+#[test]
+fn derives_abi_name() {
+    #[derive(Debug, EthEvent)]
+    #[ethevent(abi = "Transfer(address,address,uint256)")]
+    struct Erc20TransferEvent {
+        #[ethevent(indexed, name = "_from")]
+        from: Address,
+        #[ethevent(indexed, name = "_to")]
+        to: Address,
+        #[ethevent(name = "_value")]
+        value: U256,
+    }
+
+    assert_eq!(Erc20TransferEvent::abi_signature(), "Transfer(address,address,uint256)");
+
+    assert_eq!(
+        Erc20TransferEvent::signature(),
+        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef".parse().unwrap()
+    );
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Closes https://github.com/gakonst/ethers-rs/issues/2142

use the parsed event name from the `abi` attribute instead of the ident by default.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
