### PR TITLE
fix(core): block FromStr implementation

### DIFF
--- a/ethers-core/src/types/block.rs
+++ b/ethers-core/src/types/block.rs
@@ -535,8 +535,7 @@ impl FromStr for BlockId {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.strip_prefix("0x").unwrap_or(s);
-        if s.len() == 64 {
+        if s.starts_with("0x") && s.len() == 66 {
             let hash = s.parse::<H256>().map_err(|e| e.to_string());
             hash.map(Self::Hash)
         } else {
@@ -645,15 +644,10 @@ impl FromStr for BlockNumber {
             "safe" => Ok(Self::Safe),
             "earliest" => Ok(Self::Earliest),
             "pending" => Ok(Self::Pending),
-            n => {
-                if let Ok(n) = n.parse::<U64>() {
-                    Ok(Self::Number(n))
-                } else if let Ok(n) = n.parse::<u64>() {
-                    Ok(Self::Number(n.into()))
-                } else {
-                    Err("Invalid block number".into())
-                }
-            }
+            // hex
+            n if n.starts_with("0x") => n.parse().map(Self::Number).map_err(|e| e.to_string()),
+            // decimal
+            n => n.parse::<u64>().map(|n| Self::Number(n.into())).map_err(|e| e.to_string()),
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Numbers get parsed first as hex, so a decimal number is default treated as hex

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

only parse as hex if prefixed by 0x
the prefix is handled by `U64::from_str`
only downside to current fix is that a non-prefixed hex gets parsed as decimal, ex: `a` is invalid while `0xa` is valid
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
