### PR TITLE
use Option for CliqueConfig fields

### DIFF
--- a/ethers-core/src/utils/genesis.rs
+++ b/ethers-core/src/utils/genesis.rs
@@ -71,7 +71,7 @@ impl Genesis {
     /// Enables all hard forks up to London at genesis.
     pub fn new(chain_id: u64, signer_addr: Address) -> Genesis {
         // set up a clique config with an instant sealing period and short (8 block) epoch
-        let clique_config = CliqueConfig { period: 0, epoch: 8 };
+        let clique_config = CliqueConfig { period: Some(0), epoch: Some(8) };
 
         let config = ChainConfig {
             chain_id,
@@ -255,10 +255,12 @@ pub struct EthashConfig {}
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CliqueConfig {
     /// Number of seconds between blocks to enforce.
-    pub period: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub period: Option<u64>,
 
     /// Epoch length to reset votes and checkpoints.
-    pub epoch: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub epoch: Option<u64>,
 }
 
 #[cfg(test)]
@@ -553,5 +555,62 @@ mod tests {
         assert_eq!(genesis.number, Some(0.into()));
         assert_eq!(genesis.gas_used, Some(0.into()));
         assert_eq!(genesis.parent_hash, Some(H256::zero()));
+    }
+
+    #[test]
+    fn parse_hive_rpc_genesis_full() {
+        let geth_genesis = r#"
+        {
+          "config": {
+            "clique": {
+              "period": 1
+            },
+            "chainId": 7,
+            "homesteadBlock": 0,
+            "eip150Block": 0,
+            "eip155Block": 0,
+            "eip158Block": 0
+          },
+          "coinbase": "0x0000000000000000000000000000000000000000",
+          "difficulty": "0x020000",
+          "extraData": "0x0000000000000000000000000000000000000000000000000000000000000000658bdf435d810c91414ec09147daa6db624063790000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "gasLimit": "0x2fefd8",
+          "nonce": "0x0000000000000000",
+          "timestamp": "0x1234",
+          "alloc": {
+            "cf49fda3be353c69b41ed96333cd24302da4556f": {
+              "balance": "0x123450000000000000000"
+            },
+            "0161e041aad467a890839d5b08b138c1e6373072": {
+              "balance": "0x123450000000000000000"
+            },
+            "87da6a8c6e9eff15d703fc2773e32f6af8dbe301": {
+              "balance": "0x123450000000000000000"
+            },
+            "b97de4b8c857e4f6bc354f226dc3249aaee49209": {
+              "balance": "0x123450000000000000000"
+            },
+            "c5065c9eeebe6df2c2284d046bfc906501846c51": {
+              "balance": "0x123450000000000000000"
+            },
+            "0000000000000000000000000000000000000314": {
+              "balance": "0x0",
+              "code": "0x60606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063a223e05d1461006a578063abd1a0cf1461008d578063abfced1d146100d4578063e05c914a14610110578063e6768b451461014c575b610000565b346100005761007761019d565b6040518082815260200191505060405180910390f35b34610000576100be600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919050506101a3565b6040518082815260200191505060405180910390f35b346100005761010e600480803573ffffffffffffffffffffffffffffffffffffffff169060200190919080359060200190919050506101ed565b005b346100005761014a600480803590602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610236565b005b346100005761017960048080359060200190919080359060200190919080359060200190919050506103c4565b60405180848152602001838152602001828152602001935050505060405180910390f35b60005481565b6000600160008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205490505b919050565b80600160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055505b5050565b7f6031a8d62d7c95988fa262657cd92107d90ed96e08d8f867d32f26edfe85502260405180905060405180910390a17f47e2689743f14e97f7dcfa5eec10ba1dff02f83b3d1d4b9c07b206cbbda66450826040518082815260200191505060405180910390a1817fa48a6b249a5084126c3da369fbc9b16827ead8cb5cdc094b717d3f1dcd995e2960405180905060405180910390a27f7890603b316f3509577afd111710f9ebeefa15e12f72347d9dffd0d65ae3bade81604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390a18073ffffffffffffffffffffffffffffffffffffffff167f7efef9ea3f60ddc038e50cccec621f86a0195894dc0520482abf8b5c6b659e4160405180905060405180910390a28181604051808381526020018273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019250505060405180910390a05b5050565b6000600060008585859250925092505b935093509390505600a165627a7a72305820aaf842d0d0c35c45622c5263cbb54813d2974d3999c8c38551d7c613ea2bc1170029",
+              "storage": {
+                "0x0000000000000000000000000000000000000000000000000000000000000000": "0x1234",
+                "0x6661e9d6d8b923d5bbaab1b96e1dd51ff6ea2a93520fdc9eb75d059238b8c5e9": "0x01"
+              }
+            },
+            "0000000000000000000000000000000000000315": {
+              "balance": "0x9999999999999999999999999999999",
+              "code": "0x60606040526000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063ef2769ca1461003e575b610000565b3461000057610078600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190505061007a565b005b8173ffffffffffffffffffffffffffffffffffffffff166108fc829081150290604051809050600060405180830381858888f1935050505015610106578173ffffffffffffffffffffffffffffffffffffffff167f30a3c50752f2552dcc2b93f5b96866280816a986c0c0408cb6778b9fa198288f826040518082815260200191505060405180910390a25b5b50505600a165627a7a72305820637991fabcc8abad4294bf2bb615db78fbec4edff1635a2647d3894e2daf6a610029"
+            }
+          },
+          "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        }
+        "#;
+
+        let _genesis: Genesis = serde_json::from_str(geth_genesis).unwrap();
     }
 }

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -389,7 +389,7 @@ impl Geth {
             if is_clique {
                 use super::CliqueConfig;
                 // set up a clique config with an instant sealing period and short (8 block) epoch
-                let clique_config = CliqueConfig { period: 0, epoch: 8 };
+                let clique_config = CliqueConfig { period: Some(0), epoch: Some(8) };
                 genesis.config.clique = Some(clique_config);
 
                 // set the extraData field


### PR DESCRIPTION
## Motivation

The `CliqueConfig` field of a genesis file does not necessarily require both a populated `epoch` and `period` field. This results in a `ChainConfig` like the following to fail to parse:
```json
"config": {
  "clique": {
    "period": 1
  },
  "chainId": 7,
  "homesteadBlock": 0,
  "eip150Block": 0,
  "eip155Block": 0,
  "eip158Block": 0
},
```

## Solution

Change the `CliqueConfig` fields to be options, and include `serde(default)` for deserialization.

Add a test for deserializing a `genesis.json` passed from hive, that only has the `period` field.

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
