### PR TITLE
feat(contract): improve Multicall result handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,6 +301,8 @@
 
 ### Unreleased
 
+- (Breaking) Improve Multicall result handling
+  [#2164](https://github.com/gakonst/ethers-rs/pull/2105)
 - (Breaking) Make `Event` objects generic over borrow & remove lifetime
   [#2105](https://github.com/gakonst/ethers-rs/pull/2105)
 - Make `Factory` objects generic over the borrow trait, to allow non-arc mware

--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ethers-contract"
 version = "1.0.2"
-edition = "2018"
+edition = "2021"
 rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
 license = "MIT OR Apache-2.0"

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -1342,7 +1342,7 @@ contract Enum {
  [package]
         name = "ethers-contract"
         version = "1.0.0"
-        edition = "2018"
+        edition = "2021"
         rust-version = "1.64"
         authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
         license = "MIT OR Apache-2.0"
@@ -1388,7 +1388,7 @@ contract Enum {
  [package]
         name = "ethers-contract"
         version = "1.0.0"
-        edition = "2018"
+        edition = "2021"
         rust-version = "1.64"
         authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
         license = "MIT OR Apache-2.0"
@@ -1435,7 +1435,7 @@ contract Enum {
     [package]
         name = "ethers-contract"
         version = "1.0.0"
-        edition = "2018"
+        edition = "2021"
         rust-version = "1.64"
         authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
         license = "MIT OR Apache-2.0"
@@ -1482,7 +1482,7 @@ contract Enum {
     [package]
         name = "ethers-contract"
         version = "1.0.0"
-        edition = "2018"
+        edition = "2021"
         rust-version = "1.64"
         authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
         license = "MIT OR Apache-2.0"

--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -190,12 +190,9 @@ where
     ///
     /// Note: this function _does not_ send a transaction from your account
     pub async fn call(&self) -> Result<D, ContractError<M>> {
-        let bytes = self
-            .client
-            .borrow()
-            .call(&self.tx, self.block)
-            .await
-            .map_err(ContractError::MiddlewareError)?;
+        let client: &M = self.client.borrow();
+        let bytes =
+            client.call(&self.tx, self.block).await.map_err(ContractError::MiddlewareError)?;
 
         // decode output
         let data = decode_function_data(&self.function, &bytes, false)?;

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -31,8 +31,8 @@ mod multicall;
 #[cfg(any(test, feature = "abigen"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "abigen")))]
 pub use multicall::{
-    multicall_contract, Call, Multicall, MulticallContract, MulticallError, MulticallVersion,
-    MULTICALL_ADDRESS, MULTICALL_SUPPORTED_CHAIN_IDS,
+    contract as multicall_contract, Call, Multicall, MulticallContract, MulticallError,
+    MulticallVersion, MULTICALL_ADDRESS, MULTICALL_SUPPORTED_CHAIN_IDS,
 };
 
 /// This module exposes low lever builder structures which are only consumed by the

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -314,10 +314,18 @@ impl MulticallVersion {
 pub struct Multicall<M> {
     /// The Multicall contract interface.
     pub contract: MulticallContract<M>,
+
+    /// The version of which methods to use when making the contract call.
     pub version: MulticallVersion,
+
+    /// Whether to use a legacy or a EIP-1559 transaction.
     pub legacy: bool,
+
+    /// The `block` field of the Multicall aggregate call.
     pub block: Option<BlockNumber>,
-    pub calls: Vec<Call>,
+
+    /// The internal call vector.
+    calls: Vec<Call>,
 }
 
 // Manually implement Clone and Debug to avoid trait bounds.

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -502,18 +502,15 @@ impl<M: Middleware> Multicall<M> {
         if data.is_none() && !call.function.outputs.is_empty() {
             return self
         }
-        match to {
-            Some(NameOrAddress::Address(target)) => {
-                let call = Call {
-                    target,
-                    data: data.unwrap_or_default(),
-                    value: value.unwrap_or_default(),
-                    allow_failure,
-                    function: call.function,
-                };
-                self.calls.push(call);
-            }
-            _ => {}
+        if let Some(NameOrAddress::Address(target)) = to {
+            let call = Call {
+                target,
+                data: data.unwrap_or_default(),
+                value: value.unwrap_or_default(),
+                allow_failure,
+                function: call.function,
+            };
+            self.calls.push(call);
         }
         self
     }

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -7,14 +7,18 @@ use ethers_core::{
 use ethers_providers::{Middleware, PendingTransaction};
 use std::{convert::TryFrom, fmt, sync::Arc};
 
-pub mod multicall_contract;
-use multicall_contract::multicall_3::{
+/// The Multicall contract bindings. Auto-generated with `abigen`.
+pub mod contract {
+    ethers_contract_derive::abigen!(Multicall3, "src/multicall/multicall_abi.json");
+}
+
+use contract::multicall_3::{
     Call as Multicall1Call, Call3 as Multicall3Call, Call3Value as Multicall3CallValue,
     Result as MulticallResult,
 };
 
 // Export the contract interface
-pub use multicall_contract::multicall_3::Multicall3 as MulticallContract;
+pub use contract::multicall_3::Multicall3 as MulticallContract;
 
 /// The Multicall3 contract address that is deployed in [`MULTICALL_SUPPORTED_CHAIN_IDS`]:
 /// [`0xcA11bde05977b3631167028862bE2a173976CA11`](https://etherscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11)
@@ -101,6 +105,7 @@ pub enum MulticallError<M: Middleware> {
     IllegalRevert,
 }
 
+/// Type alias for `Result<T, MulticallError<M>>`
 pub type Result<T, M> = std::result::Result<T, MulticallError<M>>;
 
 /// Helper struct for managing calls to be made to the `function` in smart contract `target`

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -1,24 +1,23 @@
 use crate::call::{ContractCall, ContractError};
 use ethers_core::{
-    abi::{AbiDecode, Detokenize, Function, Token},
-    types::{Address, BlockNumber, Bytes, Chain, NameOrAddress, H160, U256},
+    abi::{AbiDecode, Detokenize, Function, InvalidOutputType, Token, Tokenizable},
+    types::{
+        transaction::eip2718::TypedTransaction, Address, BlockNumber, Bytes, Chain, NameOrAddress,
+        H160, U256,
+    },
 };
-
 use ethers_providers::{Middleware, PendingTransaction};
-use std::{convert::TryFrom, fmt, sync::Arc};
+use std::{convert::TryFrom, fmt, result::Result as StdResult, sync::Arc};
 
 /// The Multicall contract bindings. Auto-generated with `abigen`.
 pub mod contract {
     ethers_contract_derive::abigen!(Multicall3, "src/multicall/multicall_abi.json");
 }
-
-use contract::multicall_3::{
+pub use contract::Multicall3 as MulticallContract;
+use contract::{
     Call as Multicall1Call, Call3 as Multicall3Call, Call3Value as Multicall3CallValue,
     Result as MulticallResult,
 };
-
-// Export the contract interface
-pub use contract::multicall_3::Multicall3 as MulticallContract;
 
 /// The Multicall3 contract address that is deployed in [`MULTICALL_SUPPORTED_CHAIN_IDS`]:
 /// [`0xcA11bde05977b3631167028862bE2a173976CA11`](https://etherscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11)
@@ -93,6 +92,9 @@ pub const MULTICALL_SUPPORTED_CHAIN_IDS: &[u64] = {
     ]
 };
 
+/// Type alias for `Result<T, MulticallError<M>>`
+pub type Result<T, M> = StdResult<T, MulticallError<M>>;
+
 #[derive(Debug, thiserror::Error)]
 pub enum MulticallError<M: Middleware> {
     #[error(transparent)]
@@ -103,10 +105,47 @@ pub enum MulticallError<M: Middleware> {
 
     #[error("Illegal revert: Multicall2 call reverted when it wasn't allowed to.")]
     IllegalRevert,
+
+    #[error("Call reverted with data: \"{}\"", decode_error(_0))]
+    CallReverted(Bytes),
 }
 
-/// Type alias for `Result<T, MulticallError<M>>`
-pub type Result<T, M> = std::result::Result<T, MulticallError<M>>;
+impl<M: Middleware> From<ethers_core::abi::Error> for MulticallError<M> {
+    fn from(value: ethers_core::abi::Error) -> Self {
+        Self::ContractError(ContractError::DecodingError(value))
+    }
+}
+
+impl<M: Middleware> From<InvalidOutputType> for MulticallError<M> {
+    fn from(value: InvalidOutputType) -> Self {
+        Self::ContractError(ContractError::DetokenizationError(value))
+    }
+}
+
+impl<M: Middleware> MulticallError<M> {
+    pub fn into_bytes(self) -> Result<Bytes, M> {
+        match self {
+            Self::CallReverted(bytes) => Ok(bytes),
+            e => Err(e),
+        }
+    }
+
+    /// Returns the bytes that the call reverted with.
+    pub fn get_bytes(&self) -> Option<&Bytes> {
+        match self {
+            Self::CallReverted(bytes) => Some(bytes),
+            _ => None,
+        }
+    }
+
+    /// Formats the bytes that the call reverted with.
+    pub fn format_bytes(&self) -> Option<String> {
+        match self {
+            Self::CallReverted(bytes) => Some(decode_error(bytes)),
+            _ => None,
+        }
+    }
+}
 
 /// Helper struct for managing calls to be made to the `function` in smart contract `target`
 /// with `data`.
@@ -146,7 +185,7 @@ impl From<MulticallVersion> for u8 {
 
 impl TryFrom<u8> for MulticallVersion {
     type Error = String;
-    fn try_from(v: u8) -> std::result::Result<Self, Self::Error> {
+    fn try_from(v: u8) -> StdResult<Self, Self::Error> {
         match v {
             1 => Ok(MulticallVersion::Multicall),
             2 => Ok(MulticallVersion::Multicall2),
@@ -212,7 +251,7 @@ impl MulticallVersion {
 /// let abi: Abi = serde_json::from_str(r#"[{"inputs":[{"internalType":"string","name":"value","type":"string"}],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"author","type":"address"},{"indexed":true,"internalType":"address","name":"oldAuthor","type":"address"},{"indexed":false,"internalType":"string","name":"oldValue","type":"string"},{"indexed":false,"internalType":"string","name":"newValue","type":"string"}],"name":"ValueChanged","type":"event"},{"inputs":[],"name":"getValue","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"lastSender","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"string","name":"value","type":"string"}],"name":"setValue","outputs":[],"stateMutability":"nonpayable","type":"function"}]"#)?;
 ///
 /// // connect to the network
-/// let client = Provider::<Http>::try_from("https://kovan.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27")?;
+/// let client = Provider::<Http>::try_from("https://goerli.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27")?;
 ///
 /// // create the contract object. This will be used to construct the calls for multicall
 /// let client = Arc::new(client);
@@ -223,24 +262,18 @@ impl MulticallVersion {
 /// let first_call = contract.method::<_, String>("getValue", ())?;
 /// let second_call = contract.method::<_, Address>("lastSender", ())?;
 ///
-/// // Since this example connects to the Kovan testnet, we need not provide an address for
+/// // Since this example connects to a known chain, we need not provide an address for
 /// // the Multicall contract and we set that to `None`. If you wish to provide the address
 /// // for the Multicall contract, you can pass the `Some(multicall_addr)` argument.
 /// // Construction of the `Multicall` instance follows the builder pattern:
-/// let mut multicall = Multicall::new(client.clone(), None).await?.version(MulticallVersion::Multicall);
+/// let mut multicall = Multicall::new(client.clone(), None).await?;
 /// multicall
 ///     .add_call(first_call, false)
 ///     .add_call(second_call, false);
 ///
 /// // `await`ing on the `call` method lets us fetch the return values of both the above calls
 /// // in one single RPC call
-/// let _return_data: (String, Address) = multicall.call().await?;
-///
-/// // using Multicall2 (version 2) or Multicall3 (version 3) differs when parsing `.call()` results
-/// multicall = multicall.version(MulticallVersion::Multicall3);
-///
-/// // each call returns the results in a tuple, with the success status as the first element
-/// let _return_data: ((bool, String), (bool, Address)) = multicall.call().await?;
+/// let return_data: (String, Address) = multicall.call().await?;
 ///
 /// // the same `Multicall` instance can be re-used to do a different batch of transactions.
 /// // Say we wish to broadcast (send) a couple of transactions via the Multicall contract.
@@ -253,27 +286,17 @@ impl MulticallVersion {
 ///
 /// // `await`ing the `send` method waits for the transaction to be broadcast, which also
 /// // returns the transaction hash
-/// let _tx_receipt = multicall.send().await?.await.expect("tx dropped");
+/// let tx_receipt = multicall.send().await?.await.expect("tx dropped");
 ///
 /// // you can also query ETH balances of multiple addresses
 /// let address_1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse::<Address>()?;
 /// let address_2 = "ffffffffffffffffffffffffffffffffffffffff".parse::<Address>()?;
 ///
-/// // using version 1
-/// multicall = multicall.version(MulticallVersion::Multicall);
 /// multicall
 ///     .clear_calls()
 ///     .add_get_eth_balance(address_1, false)
 ///     .add_get_eth_balance(address_2, false);
-/// let _balances: (U256, U256) = multicall.call().await?;
-///
-/// // or with version 2 and above
-/// multicall = multicall.version(MulticallVersion::Multicall3);
-/// multicall
-///     .clear_calls()
-///     .add_get_eth_balance(address_1, false)
-///     .add_get_eth_balance(address_2, false);
-/// let _balances: ((bool, U256), (bool, U256)) = multicall.call().await?;
+/// let balances: (U256, U256) = multicall.call().await?;
 ///
 /// # Ok(())
 /// # }
@@ -291,10 +314,10 @@ impl MulticallVersion {
 pub struct Multicall<M> {
     /// The Multicall contract interface.
     pub contract: MulticallContract<M>,
-    version: MulticallVersion,
-    legacy: bool,
-    block: Option<BlockNumber>,
-    calls: Vec<Call>,
+    pub version: MulticallVersion,
+    pub legacy: bool,
+    pub block: Option<BlockNumber>,
+    pub calls: Vec<Call>,
 }
 
 // Manually implement Clone and Debug to avoid trait bounds.
@@ -451,10 +474,10 @@ impl<M: Middleware> Multicall<M> {
     /// Appends a `call` to the list of calls of the Multicall instance.
     ///
     /// Version specific details:
-    /// - 1: `allow_failure` is ignored.
-    /// - >=2: `allow_failure` specifies whether or not this call is allowed to revert in the
+    /// - `1`: `allow_failure` is ignored.
+    /// - `>=2`: `allow_failure` specifies whether or not this call is allowed to revert in the
     ///   multicall.
-    /// - 3: Transaction values are used when broadcasting transactions with [`send`], otherwise
+    /// - `3`: Transaction values are used when broadcasting transactions with [`send`], otherwise
     ///   they are always ignored.
     ///
     /// [`send`]: #method.send
@@ -463,32 +486,35 @@ impl<M: Middleware> Multicall<M> {
         call: ContractCall<M, D>,
         allow_failure: bool,
     ) -> &mut Self {
-        match (call.tx.to(), call.tx.data()) {
-            (Some(NameOrAddress::Address(target)), Some(data)) => {
+        let (to, data, value) = match call.tx {
+            TypedTransaction::Legacy(tx) => (tx.to, tx.data, tx.value),
+            TypedTransaction::Eip2930(tx) => (tx.tx.to, tx.tx.data, tx.tx.value),
+            TypedTransaction::Eip1559(tx) => (tx.to, tx.data, tx.value),
+        };
+        if data.is_none() && !call.function.outputs.is_empty() {
+            return self
+        }
+        match to {
+            Some(NameOrAddress::Address(target)) => {
                 let call = Call {
-                    target: *target,
-                    data: data.clone(),
-                    value: call.tx.value().cloned().unwrap_or_default(),
+                    target,
+                    data: data.unwrap_or_default(),
+                    value: value.unwrap_or_default(),
                     allow_failure,
                     function: call.function,
                 };
                 self.calls.push(call);
-                self
             }
-            _ => self,
+            _ => {}
         }
+        self
     }
 
     /// Appends multiple `call`s to the list of calls of the Multicall instance.
     ///
-    /// Version specific details:
-    /// - 1: `allow_failure` is ignored.
-    /// - >=2: `allow_failure` specifies whether or not this call is allowed to revert in the
-    ///   multicall.
-    /// - 3: Transaction values are used when broadcasting transactions with [`send`], otherwise
-    ///   they are always ignored.
+    /// See [`add_call`] for more details.
     ///
-    /// [`send`]: #method.send
+    /// [`add_call`]: #method.add_call
     pub fn add_calls<D: Detokenize>(
         &mut self,
         allow_failure: bool,
@@ -633,21 +659,24 @@ impl<M: Middleware> Multicall<M> {
 
     /// Queries the Ethereum blockchain using `eth_call`, but via the Multicall contract.
     ///
-    /// Note: this method _does not_ send a transaction from your account.
+    /// For handling calls that have the same result type, see [`call_array`].
+    ///
+    /// For handling each call's result individually, see [`call_raw`].
+    ///
+    /// [`call_raw`]: #method.call_raw
+    /// [`call_array`]: #method.call_array
     ///
     /// # Errors
     ///
     /// Returns a [`MulticallError`] if there are any errors in the RPC call or while detokenizing
     /// the tokens back to the expected return type.
     ///
-    /// # Panics
-    ///
-    /// If more than the maximum number of supported calls are added (16). The maximum limit is
-    /// constrained due to tokenization/detokenization support for tuples.
+    /// Returns an error if any call failed, even if `allow_failure` was set, or if the return data
+    /// was empty.
     ///
     /// # Examples
     ///
-    /// The return type must be annotated while calling this method:
+    /// The return type must be annotated as a tuple when calling this method:
     ///
     /// ```no_run
     /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
@@ -663,30 +692,31 @@ impl<M: Middleware> Multicall<M> {
     /// // 1. `returns (uint256)`
     /// // 2. `returns (string, address)`
     /// // 3. `returns (bool)`
-    /// // Version 1:
     /// let result: (U256, (String, Address), bool) = multicall.call().await?;
-    /// // Version 2 and above (each call returns also the success status as the first element):
-    /// let result: ((bool, U256), (bool, (String, Address)), (bool, bool)) = multicall.call().await?;
+    /// // or using the turbofish syntax:
+    /// let result = multicall.call::<(U256, (String, Address), bool)>().await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn call<D: Detokenize>(&self) -> Result<D, M> {
-        assert!(self.calls.len() <= 16, "Cannot decode more than 16 calls");
-        let tokens = self.call_raw().await?;
-        let tokens = vec![Token::Tuple(tokens)];
-        let data = D::from_tokens(tokens).map_err(ContractError::DetokenizationError)?;
-        Ok(data)
+    pub async fn call<T: Tokenizable>(&self) -> Result<T, M> {
+        let results = self.call_raw().await?;
+        let tokens = results
+            .into_iter()
+            .map(|res| res.map_err(MulticallError::CallReverted))
+            .collect::<Result<_, _>>()?;
+        T::from_token(Token::Tuple(tokens)).map_err(Into::into)
     }
 
     /// Queries the Ethereum blockchain using `eth_call`, but via the Multicall contract, assuming
-    /// that every call returns same data type.
-    ///
-    /// Note: this method _does not_ send a transaction from your account.
+    /// that every call returns same type.
     ///
     /// # Errors
     ///
     /// Returns a [`MulticallError`] if there are any errors in the RPC call or while detokenizing
     /// the tokens back to the expected return type.
+    ///
+    /// Returns an error if any call failed, even if `allow_failure` was set, or if the return data
+    /// was empty.
     ///
     /// # Examples
     ///
@@ -707,18 +737,24 @@ impl<M: Middleware> Multicall<M> {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn call_array<D: Detokenize>(&self) -> Result<Vec<D>, M> {
-        let tokens = self.call_raw().await?;
-        let res: std::result::Result<Vec<D>, ContractError<M>> = tokens
+    pub async fn call_array<T: Tokenizable>(&self) -> Result<Vec<T>, M> {
+        self.call_raw()
+            .await?
             .into_iter()
-            .map(|token| D::from_tokens(vec![token]).map_err(ContractError::DetokenizationError))
-            .collect();
-
-        Ok(res?)
+            .map(|res| {
+                res.map_err(MulticallError::CallReverted)
+                    .and_then(|token| T::from_token(token).map_err(Into::into))
+            })
+            .collect()
     }
 
-    /// Queries the Ethereum blockchain using `eth_call`, but via the Multicall contract and
-    /// without detokenization.
+    /// Queries the Ethereum blockchain using `eth_call`, but via the Multicall contract.
+    ///
+    /// Returns a vector of `Result<Token, Bytes>` for each call added to the Multicall:
+    /// `Err(Bytes)` if the individual call failed while allowed or the return data was empty,
+    /// `Ok(Token)` otherwise.
+    ///
+    /// If the Multicall version is 1, this will always be a vector of `Ok`.
     ///
     /// # Errors
     ///
@@ -737,95 +773,67 @@ impl<M: Middleware> Multicall<M> {
     /// #
     /// # let multicall = Multicall::new(client, None).await?;
     /// // The consumer of the API is responsible for detokenizing the results
-    /// // as the results will be a Vec<Token>
     /// let tokens = multicall.call_raw().await?;
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// Note: this method _does not_ send a transaction from your account
-    ///
-    /// [`ContractError<M>`]: crate::ContractError<M>
-    pub async fn call_raw(&self) -> Result<Vec<Token>, M> {
+    pub async fn call_raw(&self) -> Result<Vec<StdResult<Token, Bytes>>, M> {
         // Different call result types based on version
         match self.version {
-            MulticallVersion::Multicall => self.call_v1().await,
+            // Wrap the return data with `success: true` since version 1 reverts if any call failed
+            MulticallVersion::Multicall => {
+                let call = self.as_aggregate();
+                let (_, bytes) = ContractCall::call(&call).await?;
+                self.parse_call_result(
+                    bytes
+                        .into_iter()
+                        .map(|return_data| MulticallResult { success: true, return_data }),
+                )
+            }
             // Same result type (`MulticallResult`)
-            MulticallVersion::Multicall2 | MulticallVersion::Multicall3 => self.call_v2_v3().await,
+            MulticallVersion::Multicall2 | MulticallVersion::Multicall3 => {
+                let call = if self.version.is_v2() {
+                    self.as_try_aggregate()
+                } else {
+                    self.as_aggregate_3()
+                };
+                let results = ContractCall::call(&call).await?;
+                self.parse_call_result(results.into_iter())
+            }
         }
     }
 
-    #[inline]
-    async fn call_v1(&self) -> Result<Vec<Token>, M> {
-        let call = self.as_aggregate();
-        let (_, return_data) = call.call().await?;
-        self.calls
-            .iter()
-            .zip(&return_data)
-            .map(|(call, bytes)| {
-                // Always return an empty Bytes token for calls that return no data
-                if bytes.is_empty() {
-                    Ok(Token::Bytes(Default::default()))
-                } else {
-                    let mut tokens =
-                        call.function.decode_output(bytes).map_err(ContractError::DecodingError)?;
-                    Ok(match tokens.len() {
-                        0 => Token::Tuple(vec![]),
-                        1 => tokens.pop().unwrap(),
-                        _ => Token::Tuple(tokens),
-                    })
+    /// For each call and its `return_data`: if `success` is true, parses `return_data` with the
+    /// call's function outputs, otherwise returns the bytes in `Err`.
+    fn parse_call_result(
+        &self,
+        return_data: impl Iterator<Item = MulticallResult>,
+    ) -> Result<Vec<StdResult<Token, Bytes>>, M> {
+        let mut results = Vec::with_capacity(self.calls.len());
+        for (call, MulticallResult { success, return_data }) in self.calls.iter().zip(return_data) {
+            let result = if !success || return_data.is_empty() {
+                // v2: In the function call to `tryAggregate`, the `allow_failure` check
+                // is done on a per-transaction basis, and we set this transaction-wide
+                // check to true when *any* call is allowed to fail. If this is true
+                // then a call that is not allowed to revert (`call.allow_failure`) may
+                // still do so because of other calls that are in the same multicall
+                // aggregate.
+                if !success && !call.allow_failure {
+                    return Err(MulticallError::IllegalRevert)
                 }
-            })
-            .collect()
-    }
 
-    #[inline]
-    async fn call_v2_v3(&self) -> Result<Vec<Token>, M> {
-        let call =
-            if self.version.is_v2() { self.as_try_aggregate() } else { self.as_aggregate_3() };
-        let return_data = ContractCall::call(&call).await?;
-        self.calls
-            .iter()
-            .zip(return_data.into_iter())
-            .map(|(call, res)| {
-                let bytes = &res.return_data;
-                // Always return an empty Bytes token for calls that return no data
-                let res_token: Token = if bytes.is_empty() {
-                    Token::Bytes(Default::default())
-                } else if res.success {
-                    // Decode using call.function
-                    let mut res_tokens =
-                        call.function.decode_output(bytes).map_err(ContractError::DecodingError)?;
-                    match res_tokens.len() {
-                        0 => Token::Tuple(vec![]),
-                        1 => res_tokens.pop().unwrap(),
-                        _ => Token::Tuple(res_tokens),
-                    }
+                Err(return_data)
+            } else {
+                let mut res_tokens = call.function.decode_output(return_data.as_ref())?;
+                Ok(if res_tokens.len() == 1 {
+                    res_tokens.pop().unwrap()
                 } else {
-                    // Call reverted
-
-                    // v2: In the function call to `tryAggregate`, the `allow_failure` check
-                    // is done on a per-transaction basis, and we set this transaction-wide
-                    // check to true when *any* call is allowed to fail. If this is true
-                    // then a call that is not allowed to revert (`call.allow_failure`) may
-                    // still do so because of other calls that are in the same multicall
-                    // aggregate.
-                    if !call.allow_failure {
-                        return Err(MulticallError::IllegalRevert)
-                    }
-
-                    // Decode with "Error(string)" (0x08c379a0)
-                    if bytes.len() >= 4 && bytes[..4] == [0x08, 0xc3, 0x79, 0xa0] {
-                        Token::String(String::decode(&bytes[4..]).map_err(ContractError::AbiError)?)
-                    } else {
-                        Token::Bytes(bytes.to_vec())
-                    }
-                };
-
-                // (bool, (...))
-                Ok(Token::Tuple(vec![Token::Bool(res.success), res_token]))
-            })
-            .collect()
+                    Token::Tuple(res_tokens)
+                })
+            };
+            results.push(result);
+        }
+        Ok(results)
     }
 
     /// Signs and broadcasts a batch of transactions by using the Multicall contract as proxy,
@@ -857,15 +865,15 @@ impl<M: Middleware> Multicall<M> {
             MulticallVersion::Multicall2 => self.as_try_aggregate().tx,
             MulticallVersion::Multicall3 => self.as_aggregate_3_value().tx,
         };
-
-        self.contract
-            .client_ref()
+        let client: &M = self.contract.client_ref();
+        client
             .send_transaction(tx, self.block.map(Into::into))
             .await
             .map_err(|e| MulticallError::ContractError(ContractError::MiddlewareError(e)))
     }
 
     /// v1
+    #[inline]
     fn as_aggregate(&self) -> ContractCall<M, (U256, Vec<Bytes>)> {
         // Map the calls vector into appropriate types for `aggregate` function
         let calls: Vec<Multicall1Call> = self
@@ -882,6 +890,7 @@ impl<M: Middleware> Multicall<M> {
     }
 
     /// v2
+    #[inline]
     fn as_try_aggregate(&self) -> ContractCall<M, Vec<MulticallResult>> {
         let mut allow_failure = false;
         // Map the calls vector into appropriate types for `try_aggregate` function
@@ -905,6 +914,7 @@ impl<M: Middleware> Multicall<M> {
     }
 
     /// v3
+    #[inline]
     fn as_aggregate_3(&self) -> ContractCall<M, Vec<MulticallResult>> {
         // Map the calls vector into appropriate types for `aggregate_3` function
         let calls: Vec<Multicall3Call> = self
@@ -925,6 +935,7 @@ impl<M: Middleware> Multicall<M> {
     }
 
     /// v3 + values (only .send())
+    #[inline]
     fn as_aggregate_3_value(&self) -> ContractCall<M, Vec<MulticallResult>> {
         // Map the calls vector into appropriate types for `aggregate_3_value` function
         let mut total_value = U256::zero();
@@ -967,4 +978,14 @@ impl<M: Middleware> Multicall<M> {
             call
         }
     }
+}
+
+fn decode_error(bytes: &Bytes) -> String {
+    // Try decoding with "Error(string)" (0x08c379a0)
+    if bytes.len() >= 4 && bytes[..4] == [0x08, 0xc3, 0x79, 0xa0] {
+        if let Ok(string) = String::decode(&bytes[4..]) {
+            return string
+        }
+    }
+    bytes.to_string()
 }

--- a/ethers-contract/src/multicall/multicall_contract.rs
+++ b/ethers-contract/src/multicall/multicall_contract.rs
@@ -1,1 +1,0 @@
-ethers_contract_derive::abigen!(Multicall3, "src/multicall/multicall_abi.json");

--- a/ethers-core/src/abi/tokens.rs
+++ b/ethers-core/src/abi/tokens.rs
@@ -29,12 +29,7 @@ impl Detokenize for () {
 
 impl<T: Tokenizable> Detokenize for T {
     fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, InvalidOutputType> {
-        let token = match tokens.len() {
-            0 => Token::Tuple(vec![]),
-            1 => tokens.pop().unwrap(),
-            _ => Token::Tuple(tokens),
-        };
-
+        let token = if tokens.len() == 1 { tokens.pop().unwrap() } else { Token::Tuple(tokens) };
         Self::from_token(token)
     }
 }

--- a/ethers-core/src/abi/tokens.rs
+++ b/ethers-core/src/abi/tokens.rs
@@ -1,11 +1,11 @@
 //! Contract Functions Output types.
-// Adapted from: [rust-web3](https://github.com/tomusdrw/rust-web3/blob/master/src/contract/tokens.rs)
-#![allow(clippy::all)]
+//!
+//! Adapted from [rust-web3](https://github.com/tomusdrw/rust-web3/blob/master/src/contract/tokens.rs).
+
 use crate::{
     abi::Token,
     types::{Address, Bytes, H256, I256, U128, U256},
 };
-
 use arrayvec::ArrayVec;
 use thiserror::Error;
 
@@ -395,8 +395,7 @@ impl<const N: usize> Tokenizable for [u8; N] {
                 Ok(arr)
             }
             other => {
-                Err(InvalidOutputType(format!("Expected `FixedBytes({})`, got {:?}", N, other))
-                    .into())
+                Err(InvalidOutputType(format!("Expected `FixedBytes({})`, got {:?}", N, other)))
             }
         }
     }
@@ -432,8 +431,7 @@ impl<T: TokenizableItem + Clone, const N: usize> Tokenizable for [T; N] {
                 }
             }
             other => {
-                Err(InvalidOutputType(format!("Expected `FixedArray({})`, got {:?}", N, other))
-                    .into())
+                Err(InvalidOutputType(format!("Expected `FixedArray({})`, got {:?}", N, other)))
             }
         }
     }

--- a/ethers-core/src/abi/tokens.rs
+++ b/ethers-core/src/abi/tokens.rs
@@ -22,10 +22,7 @@ pub trait Detokenize {
 }
 
 impl Detokenize for () {
-    fn from_tokens(_: Vec<Token>) -> std::result::Result<Self, InvalidOutputType>
-    where
-        Self: Sized,
-    {
+    fn from_tokens(_: Vec<Token>) -> std::result::Result<Self, InvalidOutputType> {
         Ok(())
     }
 }
@@ -34,7 +31,7 @@ impl<T: Tokenizable> Detokenize for T {
     fn from_tokens(mut tokens: Vec<Token>) -> Result<Self, InvalidOutputType> {
         let token = match tokens.len() {
             0 => Token::Tuple(vec![]),
-            1 => tokens.remove(0),
+            1 => tokens.pop().unwrap(),
             _ => Token::Tuple(tokens),
         };
 
@@ -50,13 +47,18 @@ pub trait Tokenize {
 
 impl<'a> Tokenize for &'a [Token] {
     fn into_tokens(self) -> Vec<Token> {
-        flatten_tokens(self.to_vec())
+        let mut tokens = self.to_vec();
+        if tokens.len() == 1 {
+            flatten_token(tokens.pop().unwrap())
+        } else {
+            tokens
+        }
     }
 }
 
 impl<T: Tokenizable> Tokenize for T {
     fn into_tokens(self) -> Vec<Token> {
-        flatten_tokens(vec![self.into_token()])
+        flatten_token(self.into_token())
     }
 }
 
@@ -72,13 +74,15 @@ pub trait Tokenizable {
     fn from_token(token: Token) -> Result<Self, InvalidOutputType>
     where
         Self: Sized;
+
     /// Converts a specified type back into token.
     fn into_token(self) -> Token;
 }
 
 macro_rules! impl_tuples {
-    ($num: expr, $( $ty: ident : $no: tt, )+) => {
-        impl<$($ty, )+> Tokenizable for ($($ty,)+) where
+    ($num:expr, $( $ty:ident : $no:tt ),+ $(,)?) => {
+        impl<$( $ty ),+> Tokenizable for ($( $ty, )+)
+        where
             $(
                 $ty: Tokenizable,
             )+
@@ -88,11 +92,12 @@ macro_rules! impl_tuples {
                     Token::Tuple(mut tokens) => {
                         let mut it = tokens.drain(..);
                         Ok(($(
-                          $ty::from_token(it.next().expect("All elements are in vector; qed"))?,
+                            $ty::from_token(it.next().expect("All elements are in vector; qed"))?,
                         )+))
                     },
                     other => Err(InvalidOutputType(format!(
-                        "Expected `Tuple`, got {:?}",
+                        "Expected `Tuple` of length {}, got {:?}",
+                        $num,
                         other,
                     ))),
                 }
@@ -133,6 +138,7 @@ impl Tokenizable for Token {
     fn from_token(token: Token) -> Result<Self, InvalidOutputType> {
         Ok(token)
     }
+
     fn into_token(self) -> Token {
         self
     }
@@ -212,6 +218,18 @@ impl Tokenizable for Address {
     }
 }
 
+impl Tokenizable for bool {
+    fn from_token(token: Token) -> Result<Self, InvalidOutputType> {
+        match token {
+            Token::Bool(data) => Ok(data),
+            other => Err(InvalidOutputType(format!("Expected `bool`, got {:?}", other))),
+        }
+    }
+    fn into_token(self) -> Token {
+        Token::Bool(self)
+    }
+}
+
 macro_rules! eth_uint_tokenizable {
     ($uint: ident, $name: expr) => {
         impl Tokenizable for $uint {
@@ -279,18 +297,6 @@ int_tokenizable!(u32, Uint);
 int_tokenizable!(u64, Uint);
 int_tokenizable!(u128, Uint);
 
-impl Tokenizable for bool {
-    fn from_token(token: Token) -> Result<Self, InvalidOutputType> {
-        match token {
-            Token::Bool(data) => Ok(data),
-            other => Err(InvalidOutputType(format!("Expected `bool`, got {:?}", other))),
-        }
-    }
-    fn into_token(self) -> Token {
-        Token::Bool(self)
-    }
-}
-
 /// Marker trait for `Tokenizable` types that are can tokenized to and from a
 /// `Token::Array` and `Token:FixedArray`.
 pub trait TokenizableItem: Tokenizable {}
@@ -309,8 +315,9 @@ tokenizable_item! {
 }
 
 macro_rules! impl_tokenizable_item_tuple {
-    ($( $ty: ident , )+) => {
-        impl<$($ty, )+> TokenizableItem for ($($ty,)+) where
+    ($( $ty:ident ),+ $(,)?) => {
+        impl<$( $ty ),+> TokenizableItem for ($( $ty, )+)
+        where
             $(
                 $ty: Tokenizable,
             )+
@@ -438,19 +445,15 @@ impl<T: TokenizableItem + Clone, const N: usize> Tokenizable for [T; N] {
 
 impl<T: TokenizableItem + Clone, const N: usize> TokenizableItem for [T; N] {}
 
-/// Helper for flattening non-nested tokens into their inner
-/// types, e.g. (A, B, C ) would get tokenized to Tuple([A, B, C])
-/// when in fact we need [A, B, C].
-fn flatten_tokens(mut tokens: Vec<Token>) -> Vec<Token> {
-    if tokens.len() == 1 {
-        // flatten the tokens if required
-        // and there is no nesting
-        match tokens.remove(0) {
-            Token::Tuple(inner) => inner,
-            other => vec![other],
-        }
-    } else {
-        tokens
+/// Helper for flattening non-nested tokens into their inner types;
+///
+/// e.g. `(A, B, C)` would get tokenized to `Tuple([A, B, C])` when in fact we need `[A, B, C]`.
+#[inline]
+fn flatten_token(token: Token) -> Vec<Token> {
+    // flatten the tokens if required and there is no nesting
+    match token {
+        Token::Tuple(inner) => inner,
+        token => vec![token],
     }
 }
 
@@ -460,33 +463,33 @@ mod tests {
     use crate::types::{Address, U256};
     use ethabi::Token;
 
-    fn output<R: Detokenize>() -> R {
+    fn assert_detokenize<T: Detokenize>() -> T {
         unimplemented!()
     }
 
     #[test]
     #[ignore]
     fn should_be_able_to_compile() {
-        let _tokens: Vec<Token> = output();
-        let _uint: U256 = output();
-        let _address: Address = output();
-        let _string: String = output();
-        let _bool: bool = output();
-        let _bytes: Vec<u8> = output();
+        let _tokens: Vec<Token> = assert_detokenize();
+        let _uint: U256 = assert_detokenize();
+        let _address: Address = assert_detokenize();
+        let _string: String = assert_detokenize();
+        let _bool: bool = assert_detokenize();
+        let _bytes: Vec<u8> = assert_detokenize();
 
-        let _pair: (U256, bool) = output();
-        let _vec: Vec<U256> = output();
-        let _array: [U256; 4] = output();
-        let _bytes: Vec<[[u8; 1]; 64]> = output();
+        let _pair: (U256, bool) = assert_detokenize();
+        let _vec: Vec<U256> = assert_detokenize();
+        let _array: [U256; 4] = assert_detokenize();
+        let _bytes: Vec<[[u8; 1]; 64]> = assert_detokenize();
 
-        let _mixed: (Vec<Vec<u8>>, [U256; 4], Vec<U256>, U256) = output();
+        let _mixed: (Vec<Vec<u8>>, [U256; 4], Vec<U256>, U256) = assert_detokenize();
 
-        let _ints: (i16, i32, i64, i128) = output();
-        let _uints: (u16, u32, u64, u128) = output();
+        let _ints: (i16, i32, i64, i128) = assert_detokenize();
+        let _uints: (u16, u32, u64, u128) = assert_detokenize();
 
-        let _tuple: (Address, Vec<Vec<u8>>) = output();
-        let _vec_of_tuple: Vec<(Address, String)> = output();
-        let _vec_of_tuple_5: Vec<(Address, Vec<Vec<u8>>, String, U256, bool)> = output();
+        let _tuple: (Address, Vec<Vec<u8>>) = assert_detokenize();
+        let _vec_of_tuple: Vec<(Address, String)> = assert_detokenize();
+        let _vec_of_tuple_5: Vec<(Address, Vec<Vec<u8>>, String, U256, bool)> = assert_detokenize();
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Currently, if Multicall version is set to 2 or 3, `.call()`'s result will be a tuple of `(bool, <_>)` where bool is success. This is not the best API since it differs from version 1 and it is likely to throw and error when if the bool success variable is false, since the revert data almost never matches the success data.

This PR addresses this by making use of  the standard `Result` type to represent the call's result, where `Ok` is used when the `success` boolean is true, `Err` otherwise.

Breaking changes:
- `.call()`'s generic result type in all versions is now just the tuple of types, instead of a tuple of `(bool, <_>)` tuples
- `.raw_call()`'s concrete result type was changed from `Vec<Token>` to `Vec<Result<Token, Bytes>>`, explained above

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

On top of the changes described above:
- made all of the `Multicall` struct's fields public
- changed `.call()` and `.call_array()`'s generic type trait bound from `Detokenize` to `Tokenizable`, because it is better suit for what these methods do, which is take a vector of tokens and map them to a Rust tuple (single token). This is not a breaking change since `Detokenize` is a supertrait of `Tokenizable`
- improved the `Detokenize` implementation
- changed `ethers-contract`'s edition to 2021 to match the other crates
- improved existing multicall test and reflected changes in the methods' and the `Multicall` struct's docs

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [x] Updated the changelog
-   [x] Breaking changes
