### PR TITLE
Make order of types in shared_types deterministic

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -5,7 +5,7 @@ use inflector::Inflector;
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     fs,
     io::Write,
     path::{Path, PathBuf},
@@ -178,12 +178,12 @@ impl MultiExpansion {
         let mut shared_types = Vec::new();
         // this keeps track of those contracts that need to be updated after a struct was
         // extracted from the contract's module and moved to the shared module
-        let mut dirty_contracts = HashSet::new();
+        let mut dirty_contracts = BTreeSet::new();
 
         // merge all types if more than 1 contract
         if expansions.len() > 1 {
             // check for type conflicts across all contracts
-            let mut conflicts: HashMap<String, Vec<usize>> = HashMap::new();
+            let mut conflicts: BTreeMap<String, Vec<usize>> = BTreeMap::new();
             for (idx, (_, ctx)) in expansions.iter().enumerate() {
                 for type_identifier in ctx.internal_structs().rust_type_names().keys() {
                     conflicts
@@ -230,7 +230,7 @@ pub struct MultiExpansionResult {
     root: Option<PathBuf>,
     contracts: Vec<(ExpandedContract, Context)>,
     /// contains the indices of contracts with structs that need to be updated
-    dirty_contracts: HashSet<usize>,
+    dirty_contracts: BTreeSet<usize>,
     /// all type definitions of types that are shared by multiple contracts
     shared_types: Vec<TokenStream>,
 }

--- a/flake.lock
+++ b/flake.lock
@@ -88,6 +88,42 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "foundry": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1676884188,
+        "narHash": "sha256-jaVDZcl+YfNkvdGrmWozrvuzOjW45Iuyx8HhR/kE7Bs=",
+        "owner": "shazow",
+        "repo": "foundry.nix",
+        "rev": "ff07b373aaea4d27e15c7291d344d9f92b614fc6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shazow",
+        "repo": "foundry.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -245,6 +281,7 @@
         "devenv": "devenv",
         "fenix": "fenix",
         "flake-utils": "flake-utils_2",
+        "foundry": "foundry",
         "nixpkgs": "nixpkgs_2"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,10 @@
       url = "github:nix-community/fenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    foundry = {
+      url = "github:shazow/foundry.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
@@ -13,6 +17,7 @@
     , nixpkgs
     , flake-utils
     , fenix
+    , foundry
     , devenv
     } @ inputs:
     flake-utils.lib.eachDefaultSystem (system:
@@ -28,6 +33,9 @@
           {
             packages = with pkgs; [
               solc
+              gcc
+              foundry.defaultPackage.${system}
+              go-ethereum
             ] ++ lib.optionals stdenv.isDarwin (with darwin.apple_sdk; [
               libiconv
               frameworks.Security


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
The order in which the types in `shared_types.rs` appear is not deterministic. This is can be frustrating if the bindings are committed to version control.

Unfortunately I don't have a simple repro or a test case right now.

The PR also includes some additions (gcc, anvil, geth) necessary to run the tests in the dev shell on NixOS. cc @onsails 

Unfortunately I still can't run clippy, which fails with 
```
/nix/store/ir58ws685pawbh0q3ys66aixy7hnv2vx-devenv-profile/bin/cargo-clippy: error while loading shared libraries: libstd-62c4894b82797b30.so: cannot open shared object file: No such file or directory
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Instead of using HashMap/HashSet use BTree so that items are iterated over in order.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
