### PR TITLE
chore: added canto network

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -114,6 +114,9 @@ pub enum Chain {
 
     Aurora = 1313161554,
     AuroraTestnet = 1313161555,
+
+    Canto = 7700,
+    CantoTestnet = 740,
 }
 
 // === impl Chain ===
@@ -220,7 +223,7 @@ impl Chain {
             BinanceSmartChain | BinanceSmartChainTestnet => 3_000,
             Avalanche | AvalancheFuji => 2_000,
             Fantom | FantomTestnet => 1_200,
-            Cronos | CronosTestnet => 5_700,
+            Cronos | CronosTestnet | Canto | CantoTestnet => 5_700,
             Evmos | EvmosTestnet => 1_900,
             Aurora | AuroraTestnet => 1_100,
             Oasis => 5_500,
@@ -320,6 +323,8 @@ impl Chain {
             CeloBaklava => {
                 ("https://explorer.celo.org/baklava", "https://explorer.celo.org/baklava/api")
             }
+            Canto => ("https://evm.explorer.canto.io/", "https://evm.explorer.canto.io/api"),
+            CantoTestnet => ("https://testnet-explorer.canto.neobase.one/", "https://testnet-explorer.canto.neobase.one/api"),
             AnvilHardhat | Dev | Morden | MoonbeamDev => {
                 // this is explicitly exhaustive so we don't forget to add new urls when adding a
                 // new chain
@@ -363,7 +368,7 @@ impl Chain {
             // Unknown / not applicable, default to false for backwards compatibility
             Dev | AnvilHardhat | Morden | Ropsten | Rinkeby | Cronos | CronosTestnet | Kovan |
             Sokol | Poa | XDai | Moonbeam | MoonbeamDev | Moonriver | Moonbase | Evmos |
-            EvmosTestnet | Chiado | Aurora | AuroraTestnet => false,
+            EvmosTestnet | Chiado | Aurora | AuroraTestnet | Canto | CantoTestnet => false,
         }
     }
 }

--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -120,6 +120,9 @@ impl Client {
             Chain::Moonbeam | Chain::Moonbase | Chain::MoonbeamDev | Chain::Moonriver => {
                 std::env::var("MOONSCAN_API_KEY")?
             }
+            Chain::Canto | Chain::CantoTestnet => {
+                std::env::var("BLOCKSCOUT_API_KEY")?
+            }
             Chain::AnvilHardhat | Chain::Dev => {
                 return Err(EtherscanError::LocalNetworksNotSupported)
             }


### PR DESCRIPTION
## Motivation

Include Canto and CantoTestnet as a Chain in the ethers project
## Solution

Add in Canto and CantoTestnet chain ids (7700 and 740)

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
