### PR TITLE
feat(core): improve I256 implementation

### DIFF
--- a/ethers-core/src/abi/mod.rs
+++ b/ethers-core/src/abi/mod.rs
@@ -240,6 +240,7 @@ impl_abi_type_tuple!(19, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S
 impl_abi_type_tuple!(20, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T);
 impl_abi_type_tuple!(21, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U);
 
+#[allow(clippy::extra_unused_type_parameters)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ethers-core/src/types/i256.rs
+++ b/ethers-core/src/types/i256.rs
@@ -212,7 +212,6 @@ impl I256 {
             Some(b'-') => (Sign::Negative, &value[1..]),
             _ => (Sign::Positive, value),
         };
-
         let abs = U256::from_dec_str(value)?;
         Self::checked_from_sign_and_abs(sign, abs).ok_or(ParseI256Error::IntegerOverflow)
     }
@@ -236,10 +235,7 @@ impl I256 {
             abs.0[i] = u64::from_str_radix(word, 16).map_err(|_| ParseI256Error::InvalidDigit)?;
         }
 
-        let result =
-            Self::checked_from_sign_and_abs(sign, abs).ok_or(ParseI256Error::IntegerOverflow)?;
-
-        Ok(result)
+        Self::checked_from_sign_and_abs(sign, abs).ok_or(ParseI256Error::IntegerOverflow)
     }
 
     /// Returns a number representing sign of `self`.

--- a/ethers-core/src/types/i256.rs
+++ b/ethers-core/src/types/i256.rs
@@ -1372,113 +1372,101 @@ impl cmp::Ord for I256 {
 }
 
 // arithmetic ops - implemented above
-impl ops::Add for I256 {
+impl<T: Into<I256>> ops::Add<T> for I256 {
     type Output = Self;
 
-    #[inline(always)]
     #[track_caller]
-    fn add(self, rhs: Self) -> Self::Output {
-        handle_overflow(self.overflowing_add(rhs))
+    fn add(self, rhs: T) -> Self::Output {
+        handle_overflow(self.overflowing_add(rhs.into()))
     }
 }
 
-impl ops::AddAssign for I256 {
-    #[inline(always)]
+impl<T: Into<I256>> ops::AddAssign<T> for I256 {
     #[track_caller]
-    fn add_assign(&mut self, rhs: Self) {
+    fn add_assign(&mut self, rhs: T) {
         *self = *self + rhs
     }
 }
 
-impl ops::Sub for I256 {
+impl<T: Into<I256>> ops::Sub<T> for I256 {
     type Output = Self;
 
-    #[inline(always)]
     #[track_caller]
-    fn sub(self, rhs: Self) -> Self::Output {
-        handle_overflow(self.overflowing_sub(rhs))
+    fn sub(self, rhs: T) -> Self::Output {
+        handle_overflow(self.overflowing_sub(rhs.into()))
     }
 }
 
-impl ops::SubAssign for I256 {
-    #[inline(always)]
+impl<T: Into<I256>> ops::SubAssign<T> for I256 {
     #[track_caller]
-    fn sub_assign(&mut self, rhs: Self) {
+    fn sub_assign(&mut self, rhs: T) {
         *self = *self - rhs;
     }
 }
 
-impl ops::Mul for I256 {
+impl<T: Into<I256>> ops::Mul<T> for I256 {
     type Output = Self;
 
-    #[inline(always)]
     #[track_caller]
-    fn mul(self, rhs: Self) -> Self::Output {
-        handle_overflow(self.overflowing_mul(rhs))
+    fn mul(self, rhs: T) -> Self::Output {
+        handle_overflow(self.overflowing_mul(rhs.into()))
     }
 }
 
-impl ops::MulAssign for I256 {
-    #[inline(always)]
+impl<T: Into<I256>> ops::MulAssign<T> for I256 {
     #[track_caller]
-    fn mul_assign(&mut self, rhs: Self) {
+    fn mul_assign(&mut self, rhs: T) {
         *self = *self * rhs;
     }
 }
 
-impl ops::Div for I256 {
+impl<T: Into<I256>> ops::Div<T> for I256 {
     type Output = Self;
 
-    #[inline(always)]
     #[track_caller]
-    fn div(self, rhs: Self) -> Self::Output {
-        handle_overflow(self.overflowing_div(rhs))
+    fn div(self, rhs: T) -> Self::Output {
+        handle_overflow(self.overflowing_div(rhs.into()))
     }
 }
 
-impl ops::DivAssign for I256 {
-    #[inline(always)]
+impl<T: Into<I256>> ops::DivAssign<T> for I256 {
     #[track_caller]
-    fn div_assign(&mut self, rhs: Self) {
+    fn div_assign(&mut self, rhs: T) {
         *self = *self / rhs;
     }
 }
 
-impl ops::Rem for I256 {
+impl<T: Into<I256>> ops::Rem<T> for I256 {
     type Output = Self;
 
-    #[inline(always)]
     #[track_caller]
-    fn rem(self, rhs: Self) -> Self::Output {
-        handle_overflow(self.overflowing_rem(rhs))
+    fn rem(self, rhs: T) -> Self::Output {
+        handle_overflow(self.overflowing_rem(rhs.into()))
     }
 }
 
-impl ops::RemAssign for I256 {
-    #[inline(always)]
+impl<T: Into<I256>> ops::RemAssign<T> for I256 {
     #[track_caller]
-    fn rem_assign(&mut self, rhs: Self) {
+    fn rem_assign(&mut self, rhs: T) {
         *self = *self % rhs;
     }
 }
 
-impl iter::Sum for I256 {
-    #[inline(always)]
+impl<T: Into<I256>> iter::Sum<T> for I256 {
     #[track_caller]
     fn sum<I>(iter: I) -> Self
     where
-        I: Iterator<Item = Self>,
+        I: Iterator<Item = T>,
     {
         iter.fold(I256::zero(), |acc, x| acc + x)
     }
 }
 
-impl iter::Product for I256 {
-    #[inline(always)]
+impl<T: Into<I256>> iter::Product<T> for I256 {
     #[track_caller]
     fn product<I>(iter: I) -> Self
     where
-        I: Iterator<Item = Self>,
+        I: Iterator<Item = T>,
     {
         iter.fold(I256::one(), |acc, x| acc * x)
     }

--- a/ethers-core/src/types/i256.rs
+++ b/ethers-core/src/types/i256.rs
@@ -930,7 +930,7 @@ impl I256 {
     /// of exponentiation can be computed even if the actual result is too large
     /// to fit in 256-bit signed integer.
     #[inline(always)]
-    fn pow_sign(self, exp: u32) -> Sign {
+    const fn pow_sign(self, exp: u32) -> Sign {
         let is_exp_odd = exp % 2 != 0;
         if is_exp_odd && self.is_negative() {
             Sign::Negative

--- a/ethers-core/src/types/i256.rs
+++ b/ethers-core/src/types/i256.rs
@@ -246,8 +246,8 @@ impl I256 {
     /// - `1` if the number is positive
     /// - `-1` if the number is negative
     #[inline(always)]
-    pub const fn signum(self) -> Self {
-        Self(U256([self.signum64() as u64, 0, 0, 0]))
+    pub fn signum(self) -> Self {
+        self.signum64().into()
     }
 
     /// Returns an `i64` representing the sign of the number.

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -547,7 +547,7 @@ fn estimate_priority_fee(rewards: Vec<Vec<U256>>) -> U256 {
         .map(|(a, b)| {
             let a = I256::try_from(*a).expect("priority fee overflow");
             let b = I256::try_from(*b).expect("priority fee overflow");
-            ((b - a) * 100.into()) / a
+            ((b - a) * 100) / a
         })
         .collect();
     percentage_change.pop();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Closes #2174

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `#[track_caller]` to methods that can panic
Add `#[inline]` or `#[inline(always)]` to all methods
Make methods `const` where possible
Implement `as_*`, `low_*`, `From<*> For I256`, `TryFrom<I256> For *` using a macro
Implement more bit shift methods using usize

Breaking (minor):
Remove bit shift implementations for types >= usize due to panic in U256
Make arithmetic ops generic over `T: Into<I256>` like `U256`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
