### PR TITLE
feature: contract revert trait

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract/errors.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/errors.rs
@@ -112,6 +112,9 @@ impl Context {
             impl #ethers_core::abi::AbiDecode for #enum_name {
                 fn decode(data: impl AsRef<[u8]>) -> ::core::result::Result<Self, #ethers_core::abi::AbiError> {
                     let data = data.as_ref();
+                    // NB: This implementation does not include selector information, and ABI encoded types
+                    // are incredibly ambiguous, so it's possible to have bad false positives. Instead, we default
+                    // to a String to minimize amount of decoding attempts
                     if let Ok(decoded) = <::std::string::String as #ethers_core::abi::AbiDecode>::decode(data) {
                         return Ok(Self::RevertString(decoded))
                     }

--- a/ethers-contract/ethers-contract-abigen/src/contract/errors.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/errors.rs
@@ -104,7 +104,7 @@ impl Context {
             #[derive(Clone, #ethers_contract::EthAbiType, #derives)]
             pub enum #enum_name {
                 #( #variants(#variants), )*
-                RevertString(String),
+                RevertString(::std::string::String),
             }
 
             impl #ethers_core::abi::AbiDecode for #enum_name {
@@ -136,10 +136,11 @@ impl Context {
             impl #ethers_contract::ContractRevert for #enum_name {
                 fn valid_selector(selector: [u8; 4]) -> bool {
                     match selector {
+                        // Error(string) -- standard solidity revert
+                        [0x08, 0xc3, 0x79, 0xa0] => true,
                         #(
                             _ if selector == <#variants as #ethers_contract::EthError>::selector() => true,
                         )*
-                        _ if selector == <::std::string::String as #ethers_contract::EthError>::selector() => true,
                         _ => false,
                     }
                 }

--- a/ethers-contract/ethers-contract-abigen/src/contract/errors.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/errors.rs
@@ -104,6 +104,8 @@ impl Context {
             #[derive(Clone, #ethers_contract::EthAbiType, #derives)]
             pub enum #enum_name {
                 #( #variants(#variants), )*
+                /// The standard solidity revert string, with selector
+                /// Error(string) -- 0x08c379a0
                 RevertString(::std::string::String),
             }
 
@@ -136,7 +138,7 @@ impl Context {
             impl #ethers_contract::ContractRevert for #enum_name {
                 fn valid_selector(selector: [u8; 4]) -> bool {
                     match selector {
-                        // Error(string) -- standard solidity revert
+                        // Error(string) -- 0x08c379a0 -- standard solidity revert
                         [0x08, 0xc3, 0x79, 0xa0] => true,
                         #(
                             _ if selector == <#variants as #ethers_contract::EthError>::selector() => true,

--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::return_self_not_must_use)]
 
-use crate::EthError;
+use crate::{error::ContractRevert, EthError};
 
 use super::base::{decode_function_data, AbiError};
 use ethers_core::{
@@ -112,6 +112,15 @@ impl<M: Middleware> ContractError<M> {
     /// Decode revert data into an [`EthError`] type. Returns `None` if
     /// decoding fails, or if this is not a revert
     pub fn decode_revert<Err: EthError>(&self) -> Option<Err> {
+        self.as_revert().and_then(|data| Err::decode_with_selector(data))
+    }
+
+    /// Decode revert data into a [`ContractRevert`] type. Returns `None` if
+    /// decoding fails, or if this is not a revert
+    ///
+    /// This is intended to be used with error enum outputs from `abigen!`
+    /// contracts
+    pub fn decode_contract_revert<Err: ContractRevert>(&self) -> Option<Err> {
         self.as_revert().and_then(|data| Err::decode_with_selector(data))
     }
 

--- a/ethers-contract/src/error.rs
+++ b/ethers-contract/src/error.rs
@@ -63,6 +63,10 @@ impl EthError for String {
     fn abi_signature() -> Cow<'static, str> {
         Cow::Borrowed("Error(string)")
     }
+
+    fn selector() -> Selector {
+        [0x08, 0xc3, 0x79, 0xa0]
+    }
 }
 
 #[cfg(test)]

--- a/ethers-contract/src/error.rs
+++ b/ethers-contract/src/error.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 /// A trait for enums unifying [`EthError`] types.
 ///
 /// We do not recommend manual implementations of this trait. Instead, use the
-/// automatically generated implementation in the [`abigen`] macro
+/// automatically generated implementation in the [`crate::abigen`] macro
 pub trait ContractRevert: AbiDecode + AbiEncode + Send + Sync {
     /// Decode the error from EVM revert data including an Error selector
     fn decode_with_selector(data: &Bytes) -> Option<Self> {

--- a/ethers-contract/src/error.rs
+++ b/ethers-contract/src/error.rs
@@ -16,8 +16,7 @@ pub trait ContractRevert: AbiDecode + AbiEncode + Send + Sync {
         if data.len() < 4 {
             return None
         }
-        let mut selector = [0u8; 4];
-        selector.copy_from_slice(&data[..4]);
+        let selector = data.try_into().expect("checked by len");
         if !Self::valid_selector(selector) {
             return None
         }

--- a/ethers-contract/src/error.rs
+++ b/ethers-contract/src/error.rs
@@ -1,6 +1,6 @@
 use ethers_core::{
     abi::{AbiDecode, AbiEncode, Tokenizable},
-    types::{Bytes, Selector},
+    types::Selector,
     utils::id,
 };
 use ethers_providers::JsonRpcError;
@@ -12,7 +12,7 @@ use std::borrow::Cow;
 /// automatically generated implementation in the [`crate::abigen`] macro
 pub trait ContractRevert: AbiDecode + AbiEncode + Send + Sync {
     /// Decode the error from EVM revert data including an Error selector
-    fn decode_with_selector(data: &Bytes) -> Option<Self> {
+    fn decode_with_selector(data: &[u8]) -> Option<Self> {
         if data.len() < 4 {
             return None
         }
@@ -39,7 +39,7 @@ pub trait EthError: Tokenizable + AbiDecode + AbiEncode + Send + Sync {
     }
 
     /// Decode the error from EVM revert data including an Error selector
-    fn decode_with_selector(data: &Bytes) -> Option<Self> {
+    fn decode_with_selector(data: &[u8]) -> Option<Self> {
         // This will return none if selector mismatch.
         <Self as AbiDecode>::decode(data.strip_prefix(&Self::selector())?).ok()
     }

--- a/ethers-contract/src/error.rs
+++ b/ethers-contract/src/error.rs
@@ -11,8 +11,8 @@ use std::borrow::Cow;
 /// solidity custom errors + revert strings.
 ///
 /// This trait should be accessed via
-/// `ContractError::decode_contract_revert()`. It is generally unnecessary to
-/// import this trait into your code.
+/// [`crate::ContractError::decode_contract_revert`]. It is generally
+/// unnecessary to import this trait into your code.
 ///
 /// # Implementor's Note
 ///

--- a/ethers-contract/src/error.rs
+++ b/ethers-contract/src/error.rs
@@ -6,10 +6,23 @@ use ethers_core::{
 use ethers_providers::JsonRpcError;
 use std::borrow::Cow;
 
-/// A trait for enums unifying [`EthError`] types.
+/// A trait for enums unifying [`EthError`] types. This trait is usually used
+/// to represent the errors that a specific contract might throw. I.e. all
+/// solidity custom errors + revert strings.
+///
+/// This trait should be accessed via
+/// `ContractError::decode_contract_revert()`. It is generally unnecessary to
+/// import this trait into your code.
+///
+/// # Implementor's Note
 ///
 /// We do not recommend manual implementations of this trait. Instead, use the
 /// automatically generated implementation in the [`crate::abigen`] macro
+///
+/// However, sophisticated users may wish to represent the errors of multiple
+/// contracts as a single unified enum. E.g. if your contract calls Uniswap,
+/// you may wish to implement this on `pub enum MyContractOrUniswapErrors`.
+/// In that case, it should be straightforward to delegate to the inner types.
 pub trait ContractRevert: AbiDecode + AbiEncode + Send + Sync {
     /// Decode the error from EVM revert data including an Error selector
     fn decode_with_selector(data: &[u8]) -> Option<Self> {

--- a/ethers-contract/src/error.rs
+++ b/ethers-contract/src/error.rs
@@ -29,7 +29,7 @@ pub trait ContractRevert: AbiDecode + AbiEncode + Send + Sync {
         if data.len() < 4 {
             return None
         }
-        let selector = data.try_into().expect("checked by len");
+        let selector = data[..4].try_into().expect("checked by len");
         if !Self::valid_selector(selector) {
             return None
         }

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -13,7 +13,7 @@ mod call;
 pub use call::{ContractCall, ContractError, EthCall, FunctionCall};
 
 mod error;
-pub use error::EthError;
+pub use error::{ContractRevert, EthError};
 
 mod factory;
 pub use factory::{ContractDeployer, ContractDeploymentTx, ContractFactory, DeploymentTxFactory};

--- a/ethers-core/src/types/bytes.rs
+++ b/ethers-core/src/types/bytes.rs
@@ -16,6 +16,18 @@ pub struct Bytes(
     pub  bytes::Bytes,
 );
 
+impl FromIterator<u8> for Bytes {
+    fn from_iter<T: IntoIterator<Item = u8>>(iter: T) -> Self {
+        iter.into_iter().collect::<bytes::Bytes>().into()
+    }
+}
+
+impl<'a> FromIterator<&'a u8> for Bytes {
+    fn from_iter<T: IntoIterator<Item = &'a u8>>(iter: T) -> Self {
+        iter.into_iter().copied().collect::<bytes::Bytes>().into()
+    }
+}
+
 impl Bytes {
     /// Creates a new empty `Bytes`.
     ///


### PR DESCRIPTION
## Motivation

Followup work to #2172. Allows easier decoding of error types for generated contracts

## Solution

- Introduce the `ContractRevert` trait
- Auto-derive `ContractRevert` on the error enum in `abigen!` contract modules
- Add `RevertString(String)` to contract error enum in `abigen!` contract modules
- Add `ContractError::decode_contract_revert<Err: ContractRevert(&self) -> Option<Err>`
- (drive-by) add missing `FromIterator` impls to `ethers::core::types::Bytes`


This is a breaing change to `abigen!` generated bindings (again) but i promise this one is also really good :)

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [ ] Updated the changelog
-   [x] Breaking changes
