### PR TITLE
Workaround for https://github.com/LedgerHQ/app-ethereum/issues/409

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,6 +284,8 @@
 
 ### Unreleased
 
+- fix: `LedgerSigner` has improved tracing and a ledger app bug mitigation
+  [#2192](https://github.com/gakonst/ethers-rs/pull/2192)
 - `eth-keystore-rs` crate updated. Allow an optional name for the to-be-generated
   keystore file [#910](https://github.com/gakonst/ethers-rs/pull/910)
 - [1983](https://github.com/gakonst/ethers-rs/pull/1983) Added a `from_bytes` function for the `Wallet` type.

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -29,6 +29,7 @@ yubihsm = { version = "0.41.0", features = ["secp256k1", "http", "usb"], optiona
 futures-util = { version = "^0.3", optional = true }
 futures-executor = { version = "^0.3", optional = true }
 semver = { version = "1.0.16", optional = true }
+tracing = { version = "0.1.37" }
 trezor-client = { version = "0.0.7", optional = true, default-features = false, features = [
     "f_ethereum",
 ] }
@@ -36,7 +37,6 @@ trezor-client = { version = "0.0.7", optional = true, default-features = false, 
 # aws
 rusoto_core = { version = "0.48.0", default-features = false, optional = true }
 rusoto_kms = { version = "0.48.0", default-features = false, optional = true }
-tracing = { version = "0.1.37", optional = true }
 spki = { version = "0.6.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -60,5 +60,5 @@ futures = ["futures-util", "futures-executor"]
 celo = ["ethers-core/celo"]
 ledger = ["coins-ledger", "futures", "semver"]
 yubi = ["yubihsm"]
-aws = ["rusoto_core/rustls", "rusoto_kms/rustls", "tracing", "spki"]
+aws = ["rusoto_core/rustls", "rusoto_kms/rustls", "spki"]
 trezor = ["trezor-client", "futures", "semver", "home"]

--- a/ethers-signers/src/ledger/types.rs
+++ b/ethers-signers/src/ledger/types.rs
@@ -38,7 +38,6 @@ pub enum LedgerError {
     /// Device response was unexpectedly none
     #[error("Received unexpected response from device. Expected data in response, found none.")]
     UnexpectedNullResponse,
-
     #[error(transparent)]
     /// Error when converting from a hex string
     HexError(#[from] hex::FromHexError),
@@ -51,6 +50,12 @@ pub enum LedgerError {
     /// Error when signing EIP712 struct with not compatible Ledger ETH app
     #[error("Ledger ethereum app requires at least version: {0:?}")]
     UnsupportedAppVersion(String),
+    /// Got a response, but it didn't contain as much data as expected
+    #[error("Cannot deserialize ledger response, insufficient bytes. Got {got} expected at least {at_least}")]
+    ShortResponse { got: usize, at_least: usize },
+    /// Payload is empty
+    #[error("Payload must not be empty")]
+    EmptyPayload,
 }
 
 pub const P1_FIRST: u8 = 0x00;

--- a/ethers-signers/src/ledger/types.rs
+++ b/ethers-signers/src/ledger/types.rs
@@ -71,6 +71,18 @@ pub enum INS {
     SIGN_ETH_EIP_712 = 0x0C,
 }
 
+impl std::fmt::Display for INS {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            INS::GET_PUBLIC_KEY => write!(f, "GET_PUBLIC_KEY"),
+            INS::SIGN => write!(f, "SIGN"),
+            INS::GET_APP_CONFIGURATION => write!(f, "GET_APP_CONFIGURATION"),
+            INS::SIGN_PERSONAL_MESSAGE => write!(f, "SIGN_PERSONAL_MESSAGE"),
+            INS::SIGN_ETH_EIP_712 => write!(f, "SIGN_ETH_EIP_712"),
+        }
+    }
+}
+
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[allow(non_camel_case_types)]


### PR DESCRIPTION
makes chunk size dynamic to avoid running into this:
https://github.com/LedgerHQ/app-ethereum/issues/409

## Motivation

https://github.com/foundry-rs/foundry/issues/4362

## Solution

- find the highest chunk size <= 255 that will not trigger the bug
- drive-by: address some edge cases in payload handling that would have caused panics with incorrect ledger usage
- drive-by: add tracing to ledger app (WIP)

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [x] Updated the changelog
-   [ n/a ] Breaking changes
