### PR TITLE
chore: replace rpc urls with generic ones

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,9 +173,7 @@ documentation test:
 /// use ethers::providers::{JsonRpcClient, Provider, Http};
 /// use std::convert::TryFrom;
 ///
-/// let provider = Provider::<Http>::try_from(
-///     "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27"
-/// ).expect("could not instantiate HTTP Provider");
+/// let provider = Provider::<Http>::try_from("https://eth.llamarpc.com").expect("could not instantiate HTTP Provider");
 ///
 /// # async fn foo<P: JsonRpcClient>(provider: &Provider<P>) -> Result<(), Box<dyn std::error::Error>> {
 /// let block = provider.get_block(100u64).await?;

--- a/book/getting-started/connect_to_an_ethereum_node.md
+++ b/book/getting-started/connect_to_an_ethereum_node.md
@@ -4,28 +4,28 @@ Ethers-rs allows application to connect the blockchain using web3 providers. Pro
 
 Some common actions you can perform using a provider include:
 
-* Getting the current block number
-* Getting the balance of an Ethereum address
-* Sending a transaction to the blockchain
-* Calling a smart contract function
-* Subscribe logs and smart contract events
-* Getting the transaction history of an address
+- Getting the current block number
+- Getting the balance of an Ethereum address
+- Sending a transaction to the blockchain
+- Calling a smart contract function
+- Subscribe logs and smart contract events
+- Getting the transaction history of an address
 
 Providers are an important part of web3 libraries because they allow you to easily interact with the Ethereum blockchain without having to manage the underlying connection to the node yourself.
 
 Code below shows a basic setup to connect a provider to a node:
 
 ```rust
-// The `prelude` module provides a convenient way to import a number 
-// of common dependencies at once. This can be useful if you are working 
-// with multiple parts of the library and want to avoid having 
+// The `prelude` module provides a convenient way to import a number
+// of common dependencies at once. This can be useful if you are working
+// with multiple parts of the library and want to avoid having
 // to import each dependency individually.
 use ethers::prelude::*;
 
-const RPC_URL: &str = "https://mainnet.infura.io/v3/your-project-id";
+const RPC_URL: &str = "https://eth.llamarpc.com";
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {    
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let provider = Provider::<Http>::try_from(RPC_URL)?;
     let block_number: U64 = provider.get_block_number().await?;
     println!("{block_number}");

--- a/book/providers/advanced_usage.md
+++ b/book/providers/advanced_usage.md
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let rpc_url = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+    let rpc_url = "https://eth.llamarpc.com";
     let provider: Arc<Provider<Http>> = Arc::new(Provider::<Http>::try_from(rpc_url)?);
 
     let from_adr: H160 = "0x6fC21092DA55B392b045eD78F4732bff3C580e2c".parse()?;
@@ -50,7 +50,7 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let rpc_url = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+    let rpc_url = "https://eth.llamarpc.com";
     let provider: Arc<Provider<Http>> = Arc::new(Provider::<Http>::try_from(rpc_url)?);
 
     let from_adr: H160 = "0x6fC21092DA55B392b045eD78F4732bff3C580e2c".parse()?;
@@ -85,7 +85,7 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let rpc_url = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+    let rpc_url = "https://eth.llamarpc.com";
     let provider: Arc<Provider<Http>> = Arc::new(Provider::<Http>::try_from(rpc_url)?);
 
     let from_adr: H160 = "0x6fC21092DA55B392b045eD78F4732bff3C580e2c".parse()?;

--- a/book/providers/http.md
+++ b/book/providers/http.md
@@ -12,7 +12,7 @@ use ethers::providers::{Http, Middleware, Provider};
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     // Initialize a new Http provider
-    let rpc_url = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+    let rpc_url = "https://eth.llamarpc.com";
     let provider = Provider::try_from(rpc_url)?;
 
     Ok(())
@@ -60,7 +60,7 @@ use ethers::providers::{Http, Middleware, Provider};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let rpc_url = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+    let rpc_url = "https://eth.llamarpc.com";
     let provider = Provider::try_from(rpc_url)?;
 
     let chain_id = provider.get_chainid().await?;
@@ -88,7 +88,7 @@ abigen!(
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let rpc_url = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+    let rpc_url = "https://eth.llamarpc.com";
     let provider = Arc::new(Provider::try_from(rpc_url)?);
 
     // Initialize a new instance of the Weth/Dai Uniswap V2 pair contract
@@ -108,13 +108,12 @@ This example is a little more complicated, so let's walk through what is going o
 It is very common to wrap a provider in an `Arc` to share the provider across threads. Let's look at another example where the provider is used asynchronously across two tokio threads. In the next example, a new provider is initialized and used to asynchronously fetch the number of Ommer blocks from the most recent block, as well as the previous block.
 
 ```rust
-use std::sync::Arc;
-
 use ethers::providers::{Http, Middleware, Provider};
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let rpc_url = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+    let rpc_url = "https://eth.llamarpc.com";
     let provider = Arc::new(Provider::try_from(rpc_url)?);
 
     let current_block_number = provider.get_block_number().await?;

--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -134,7 +134,7 @@ impl MulticallVersion {
 /// let abi: Abi = serde_json::from_str(r#"[{"inputs":[{"internalType":"string","name":"value","type":"string"}],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"author","type":"address"},{"indexed":true,"internalType":"address","name":"oldAuthor","type":"address"},{"indexed":false,"internalType":"string","name":"oldValue","type":"string"},{"indexed":false,"internalType":"string","name":"newValue","type":"string"}],"name":"ValueChanged","type":"event"},{"inputs":[],"name":"getValue","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"lastSender","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"string","name":"value","type":"string"}],"name":"setValue","outputs":[],"stateMutability":"nonpayable","type":"function"}]"#)?;
 ///
 /// // connect to the network
-/// let client = Provider::<Http>::try_from("https://goerli.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27")?;
+/// let client = Provider::<Http>::try_from("http://localhost:8545")?;
 ///
 /// // create the contract object. This will be used to construct the calls for multicall
 /// let client = Arc::new(client);

--- a/ethers-providers/README.md
+++ b/ethers-providers/README.md
@@ -9,15 +9,13 @@ For more documentation on the available calls, refer to the
 
 # Examples
 
-```no_run
+```rust,no_run
 use ethers_core::types::Address;
 use ethers_providers::{Provider, Http, Middleware};
 use std::convert::TryFrom;
 
 # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
-let provider = Provider::<Http>::try_from(
-    "https://mainnet.infura.io/v3/YOUR_API_KEY"
-)?;
+let provider = Provider::<Http>::try_from("https://eth.llamarpc.com")?;
 
 let block = provider.get_block(100u64).await?;
 println!("Got block: {}", serde_json::to_string(&block)?);
@@ -50,13 +48,12 @@ versa). The default ENS address is
 and can be overriden by calling the [`ens`](./struct.Provider.html#method.ens)
 method on the provider.
 
-```no_run
+```rust,no_run
 # use ethers_providers::{Provider, Http, Middleware};
 # use std::convert::TryFrom;
 # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
-# let provider = Provider::<Http>::try_from(
-#     "https://mainnet.infura.io/v3/YOUR_API_KEY"
-# )?;
+let provider = Provider::<Http>::try_from("https://eth.llamarpc.com")?;
+
 // Resolve ENS name to Address
 let name = "vitalik.eth";
 let address = provider.resolve_name(name).await?;

--- a/ethers-providers/src/middleware.rs
+++ b/ethers-providers/src/middleware.rs
@@ -242,7 +242,7 @@ pub trait Middleware: Sync + Send + Debug {
     /// # use std::convert::TryFrom;
     /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() {
-    /// # let provider = Provider::<HttpProvider>::try_from("https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27").unwrap();
+    /// # let provider = Provider::<HttpProvider>::try_from("https://eth.llamarpc.com").unwrap();
     /// let avatar = provider.resolve_avatar("parishilton.eth").await.unwrap();
     /// assert_eq!(avatar.to_string(), "https://i.imgur.com/YW3Hzph.jpg");
     /// # }
@@ -264,7 +264,7 @@ pub trait Middleware: Sync + Send + Debug {
     /// # use std::{str::FromStr, convert::TryFrom};
     /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() {
-    /// # let provider = Provider::<HttpProvider>::try_from("https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27").unwrap();
+    /// # let provider = Provider::<HttpProvider>::try_from("https://eth.llamarpc.com").unwrap();
     /// let token = ethers_providers::erc::ERCNFT::from_str("erc721:0xc92ceddfb8dd984a89fb494c376f9a48b999aafc/9018").unwrap();
     /// let token_image = provider.resolve_nft(token).await.unwrap();
     /// assert_eq!(token_image.to_string(), "https://creature.mypinata.cloud/ipfs/QmNwj3aUzXfG4twV3no7hJRYxLLAWNPk6RrfQaqJ6nVJFa/9018.jpg");

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -87,7 +87,7 @@ impl FromStr for NodeClient {
 /// use std::convert::TryFrom;
 ///
 /// let provider = Provider::<Http>::try_from(
-///     "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27"
+///     "https://eth.llamarpc.com"
 /// ).expect("could not instantiate HTTP Provider");
 ///
 /// let block = provider.get_block(100u64).await?;
@@ -1387,20 +1387,20 @@ mod sealed {
 ///
 /// Note that this will send an RPC to retrieve the chain id.
 ///
-/// ```
+/// ```no_run
 ///  # use ethers_providers::{Http, Provider, ProviderExt};
 ///  # async fn t() {
-/// let http_provider = Provider::<Http>::connect("https://eth-mainnet.alchemyapi.io/v2/API_KEY").await;
+/// let http_provider = Provider::<Http>::connect("https://eth.llamarpc.com").await;
 /// # }
 /// ```
 ///
 /// This is essentially short for
 ///
-/// ```
+/// ```no_run
 /// use std::convert::TryFrom;
 /// use ethers_core::types::Chain;
 /// use ethers_providers::{Http, Provider, ProviderExt};
-/// let http_provider = Provider::<Http>::try_from("https://eth-mainnet.alchemyapi.io/v2/API_KEY").unwrap().set_chain(Chain::Mainnet);
+/// let http_provider = Provider::<Http>::try_from("https://eth.llamarpc.com").unwrap().set_chain(Chain::Mainnet);
 /// ```
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]

--- a/examples/anvil/examples/anvil_fork.rs
+++ b/examples/anvil/examples/anvil_fork.rs
@@ -6,8 +6,7 @@ use eyre::Result;
 #[tokio::main]
 async fn main() -> Result<()> {
     // ensure `anvil` is available in $PATH
-    let anvil =
-        Anvil::new().fork("https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27").spawn();
+    let anvil = Anvil::new().fork("https://eth.llamarpc.com").spawn();
 
     println!("Anvil running at `{}`", anvil.endpoint());
 

--- a/examples/contracts/examples/abigen.rs
+++ b/examples/contracts/examples/abigen.rs
@@ -63,7 +63,7 @@ async fn rust_inline_generation() -> Result<()> {
         ]"#,
     );
 
-    const RPC_URL: &str = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+    const RPC_URL: &str = "https://eth.llamarpc.com";
     const WETH_ADDRESS: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 
     let provider = Provider::<Http>::try_from(RPC_URL)?;

--- a/examples/contracts/examples/events.rs
+++ b/examples/contracts/examples/events.rs
@@ -14,7 +14,7 @@ abigen!(
     ]"#,
 );
 
-const WSS_URL: &str = "wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+const WSS_URL: &str = "wss://eth.llamarpc.com";
 const WETH_ADDRESS: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 
 #[tokio::main]

--- a/examples/contracts/examples/events_with_meta.rs
+++ b/examples/contracts/examples/events_with_meta.rs
@@ -17,9 +17,7 @@ abigen!(
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let client =
-        Provider::<Ws>::connect("wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27")
-            .await?;
+    let client = Provider::<Ws>::connect("wss://eth.llamarpc.com").await?;
 
     let client = Arc::new(client);
 

--- a/examples/events/examples/filtering.rs
+++ b/examples/events/examples/filtering.rs
@@ -5,7 +5,7 @@ use ethers::{
 use eyre::Result;
 use std::sync::Arc;
 
-const HTTP_URL: &str = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+const HTTP_URL: &str = "https://eth.llamarpc.com";
 const V3FACTORY_ADDRESS: &str = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
 const DAI_ADDRESS: &str = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 const USDC_ADDRESS: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";

--- a/examples/middleware/examples/builder.rs
+++ b/examples/middleware/examples/builder.rs
@@ -10,7 +10,7 @@ use ethers::{
 };
 use std::convert::TryFrom;
 
-const RPC_URL: &str = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+const RPC_URL: &str = "https://eth.llamarpc.com";
 const SIGNING_KEY: &str = "fdb33e2105f08abe41a8ee3b758726a31abdd57b7a443f470f23efce853af169";
 
 /// In ethers-rs, middleware is a way to customize the behavior of certain aspects of the library by

--- a/examples/middleware/examples/gas_oracle.rs
+++ b/examples/middleware/examples/gas_oracle.rs
@@ -73,7 +73,7 @@ async fn polygon() {
 }
 
 async fn provider_oracle() {
-    const RPC_URL: &str = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+    const RPC_URL: &str = "https://eth.llamarpc.com";
     let provider = Provider::<Http>::try_from(RPC_URL).unwrap();
     let oracle = ProviderOracle::new(provider);
     match oracle.fetch().await {

--- a/examples/providers/examples/http.rs
+++ b/examples/providers/examples/http.rs
@@ -5,7 +5,7 @@ use ethers::prelude::*;
 use reqwest::header::{HeaderMap, HeaderValue};
 use std::sync::Arc;
 
-const RPC_URL: &str = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+const RPC_URL: &str = "https://eth.llamarpc.com";
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {

--- a/examples/providers/examples/retry.rs
+++ b/examples/providers/examples/retry.rs
@@ -10,7 +10,7 @@ use ethers::prelude::*;
 use reqwest::Url;
 use std::time::Duration;
 
-const RPC_URL: &str = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+const RPC_URL: &str = "https://eth.llamarpc.com";
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {

--- a/examples/providers/examples/ws.rs
+++ b/examples/providers/examples/ws.rs
@@ -6,7 +6,7 @@
 
 use ethers::prelude::*;
 
-const WSS_URL: &str = "wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+const WSS_URL: &str = "wss://eth.llamarpc.com";
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {

--- a/examples/queries/examples/paginated_logs.rs
+++ b/examples/queries/examples/paginated_logs.rs
@@ -10,9 +10,7 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let client: Provider<Ws> =
-        Provider::<Ws>::connect("wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27")
-            .await?;
+    let client: Provider<Ws> = Provider::<Ws>::connect("wss://eth.llamarpc.com").await?;
     let client = Arc::new(client);
 
     let last_block = client.get_block(BlockNumber::Latest).await?.unwrap().number.unwrap();

--- a/examples/queries/examples/uniswapv2_pair.rs
+++ b/examples/queries/examples/uniswapv2_pair.rs
@@ -17,9 +17,7 @@ abigen!(
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let client = Provider::<Http>::try_from(
-        "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27",
-    )?;
+    let client = Provider::<Http>::try_from("https://eth.llamarpc.com")?;
     let client = Arc::new(client);
 
     // ETH/USDT pair on Uniswap V2

--- a/examples/subscriptions/examples/subscribe_events_by_type.rs
+++ b/examples/subscriptions/examples/subscribe_events_by_type.rs
@@ -46,7 +46,5 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 async fn get_client() -> Provider<Ws> {
-    Provider::<Ws>::connect("wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27")
-        .await
-        .unwrap()
+    Provider::<Ws>::connect("wss://eth.llamarpc.com").await.unwrap()
 }

--- a/examples/subscriptions/examples/subscribe_logs.rs
+++ b/examples/subscriptions/examples/subscribe_logs.rs
@@ -10,9 +10,7 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let client =
-        Provider::<Ws>::connect("wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27")
-            .await?;
+    let client = Provider::<Ws>::connect("wss://eth.llamarpc.com").await?;
     let client = Arc::new(client);
 
     let last_block = client.get_block(BlockNumber::Latest).await?.unwrap().number.unwrap();

--- a/examples/subscriptions/examples/watch_blocks.rs
+++ b/examples/subscriptions/examples/watch_blocks.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let ws_endpoint = "wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+    let ws_endpoint = "wss://eth.llamarpc.com";
     let ws = Ws::connect(ws_endpoint).await?;
     let provider = Provider::new(ws).interval(Duration::from_millis(2000));
     let mut stream = provider.watch_blocks().await?.take(1);

--- a/examples/transactions/examples/ens.rs
+++ b/examples/transactions/examples/ens.rs
@@ -7,8 +7,7 @@ use eyre::Result;
 #[tokio::main]
 async fn main() -> Result<()> {
     // fork mainnet
-    let anvil =
-        Anvil::new().fork("https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27").spawn();
+    let anvil = Anvil::new().fork("https://eth.llamarpc.com").spawn();
     let from = anvil.addresses()[0];
     // connect to the network
     let provider = Provider::<Http>::try_from(anvil.endpoint()).unwrap().with_sender(from);

--- a/examples/transactions/examples/gas_price_usd.rs
+++ b/examples/transactions/examples/gas_price_usd.rs
@@ -23,7 +23,7 @@ abigen!(
 const ETH_DECIMALS: u32 = 18;
 const USD_PRICE_DECIMALS: u32 = 8;
 const ETH_USD_FEED: &str = "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419";
-const RPC_URI: &str = "https://mainnet.infura.io/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+const RPC_URI: &str = "https://eth.llamarpc.com";
 
 /// Retrieves the USD amount per gas unit, using a Chainlink price oracle.
 /// Function gets the amount of `wei` to be spent per gas unit then multiplies


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Replace infura/api_key with [llamanodes](https://llamanodes.com/) rpc and localhost for examples and docs. Test rpcs are being changed in #2189 to local anvil. Infura can rate limit in CI and make example job fail.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
