### PR TITLE
chore: move etherscan api key env var matching to Chain enum

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/source/online.rs
+++ b/ethers-contract/ethers-contract-abigen/src/source/online.rs
@@ -67,7 +67,8 @@ impl Explorer {
         let chain = self.chain();
         let client = match api_key {
             Some(api_key) => Client::new(chain, api_key),
-            None => Client::new_from_env(chain),
+            None => Client::new_from_env(chain)
+                .or_else(|_| Client::builder().chain(chain).and_then(|b| b.build())),
         }?;
         Ok(client)
     }

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -216,8 +216,8 @@ impl Chain {
         use Chain::*;
 
         let ms = match self {
+            Mainnet => 12_000,
             Arbitrum | ArbitrumTestnet | ArbitrumGoerli | ArbitrumNova => 1_300,
-            Mainnet | Optimism => 13_000,
             Polygon | PolygonMumbai => 2_100,
             Moonbeam | Moonriver => 12_500,
             BinanceSmartChain | BinanceSmartChainTestnet => 3_000,
@@ -230,12 +230,11 @@ impl Chain {
             Emerald => 6_000,
             Dev | AnvilHardhat => 200,
             Celo | CeloAlfajores | CeloBaklava => 5_000,
-            // Explictly handle all network to make it easier not to forget this match when new
-            // networks are added.
+
+            // Explicitly exhaustive. See NB above.
             Morden | Ropsten | Rinkeby | Goerli | Kovan | XDai | Chiado | Sepolia | Moonbase |
-            MoonbeamDev | OptimismGoerli | OptimismKovan | Poa | Sokol | Rsk | EmeraldTestnet => {
-                return None
-            }
+            MoonbeamDev | Optimism | OptimismGoerli | OptimismKovan | Poa | Sokol | Rsk |
+            EmeraldTestnet => return None,
         };
 
         Some(Duration::from_millis(ms))

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -463,6 +463,7 @@ impl Chain {
 
             Canto | CantoTestnet => "BLOCKSCOUT_API_KEY",
 
+            // Explicitly exhaustive. See NB above.
             XDai | Chiado | Sepolia | Rsk | Sokol | Poa | Oasis | Emerald | EmeraldTestnet |
             Evmos | EvmosTestnet | AnvilHardhat | Dev => return None,
         };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Title, from `ethers-etherscan` to `ethers-core::types::Chain`, so that all the non-exhaustive chain matches are in the same file.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
