### PR TITLE
fix(core): properly parse genesis alloc storage

### DIFF
--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -506,7 +506,7 @@ where
             }
             Ok(Some(res_map))
         }
-        None => return Ok(None),
+        None => Ok(None),
     }
 }
 

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -469,19 +469,6 @@ pub fn eip1559_default_estimator(base_fee_per_gas: U256, rewards: Vec<Vec<U256>>
     (max_fee_per_gas, max_priority_fee_per_gas)
 }
 
-/// Deserializes the (0x-prefixed) input into a H256, accepting inputs that are less than 64 hex
-/// characters long.
-pub fn from_unformatted_hex<'de, D>(deserializer: D) -> Result<H256, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    // first deserialize to Bytes
-    let bytes = Bytes::deserialize(deserializer)?;
-
-    // then convert to H256
-    from_bytes_to_h256::<'de, D>(bytes)
-}
-
 /// Converts a Bytes value into a H256, accepting inputs that are less than 32 bytes long. These
 /// inputs will be left padded with zeros.
 pub fn from_bytes_to_h256<'de, D>(bytes: Bytes) -> Result<H256, D::Error>


### PR DESCRIPTION
## Motivation

Previously we were not properly parsing the storage field of GenesisAlloc. The first issue was in using `serde(flatten)`, which is just incorrect because storage is not encoded flattened. The second issue was in the parsing of `H256` keys and values. Some of the storage values in hive genesis examples were encoded in less than 64 hex characters, such as the string `0x22`. This would not succeed normal H256 parsing, but is consistent with [JSON-RPC unformatted encoding](https://ethereum.org/en/developers/docs/apis/json-rpc/#unformatted-data-encoding).

## Solution

 * Introduce `from_unformatted_hex_map` to properly deserialize the storage map.
 * Modify existing genesis parsing tests to check parsed storage and code values against expected values.
 * Introduce new genesis parsing test from the hive smoke tests, checking full struct equality.

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
