### PR TITLE
feat: deseralize other fields on tx receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Add `other: OtherFields` to `TransactionReceipt` [#2209[](https://github.com/gakonst/ethers-rs/pull/2209)
 - Add `Signature::recover_typed_data` [#2120](https://github.com/gakonst/ethers-rs/pull/2120)
 - Add `abi::encode_packed` [#2104](https://github.com/gakonst/ethers-rs/pull/2104)
 - Add support for custom JavaScript tracer to `debug_traceCall` and `debug_traceTransaction` [#2064](https://github.com/gakonst/ethers-rs/pull/2064)

--- a/ethers-core/src/types/transaction/response.rs
+++ b/ethers-core/src/types/transaction/response.rs
@@ -433,6 +433,10 @@ pub struct TransactionReceipt {
     /// amount that's actually paid by users can only be determined post-execution
     #[serde(rename = "effectiveGasPrice", default, skip_serializing_if = "Option::is_none")]
     pub effective_gas_price: Option<U256>,
+    /// Captures unknown fields such as additional fields used by L2s
+    #[cfg(not(feature = "celo"))]
+    #[serde(flatten)]
+    pub other: crate::types::OtherFields,
 }
 
 impl rlp::Encodable for TransactionReceipt {


### PR DESCRIPTION
## Motivation

Similar to `Transaction` and `Block`, L2s (particularly Optimism) have custom fields on `TransactionReceipt`. These fields may be necessary in determining the gas cost of a transaction.

## Solution

Simply added `other: OtherFields` to `TransactionReceipt`, same as existing usage on `Transaction`. I've also confirmed this works on Optimism's custom params.

Please let me know if there was a reason this type was skipped in the initial roll out of `OtherFields`

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
