### PR TITLE
fix(core): set miner.etherbase in clique mode

### DIFF
--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -406,8 +406,8 @@ impl Geth {
                 genesis.extra_data = extra_data;
 
                 // we must set the etherbase if using clique
-                // need to use format! / Debug here because the Address Display impl doesn't show the
-                // entire address
+                // need to use format! / Debug here because the Address Display impl doesn't show
+                // the entire address
                 cmd.arg("--miner.etherbase").arg(format!("{clique_addr:?}"));
             }
         } else if is_clique {

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -241,8 +241,11 @@ impl Geth {
         self
     }
 
-    /// Sets the Clique Private Key  to the `geth` executable, which will be later
+    /// Sets the Clique Private Key to the `geth` executable, which will be later
     /// loaded on the node.
+    ///
+    /// The address derived from this private key will be used to set the `miner.etherbase` field
+    /// on the node.
     #[must_use]
     pub fn set_clique_private_key<T: Into<SigningKey>>(mut self, private_key: T) -> Self {
         self.clique_private_key = Some(private_key.into());

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -415,6 +415,8 @@ impl Geth {
             ));
 
             // we must set the etherbase if using clique
+            // need to use format! / Debug here because the Address Display impl doesn't show the
+            // entire address
             cmd.arg("--miner.etherbase").arg(format!("{clique_addr:?}"));
         }
 

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -406,7 +406,9 @@ impl Geth {
                 genesis.extra_data = extra_data;
 
                 // we must set the etherbase if using clique
-                cmd.arg("--miner.etherbase").arg(clique_addr.to_string());
+                // need to use format! / Debug here because the Address Display impl doesn't show the
+                // entire address
+                cmd.arg("--miner.etherbase").arg(format!("{clique_addr:?}"));
             }
         } else if is_clique {
             let clique_addr =

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -415,7 +415,7 @@ impl Geth {
             ));
 
             // we must set the etherbase if using clique
-            cmd.arg("--miner.etherbase").arg(clique_addr.to_string());
+            cmd.arg("--miner.etherbase").arg(format!("{clique_addr:?}"));
         }
 
         if let Some(ref genesis) = self.genesis {


### PR DESCRIPTION
## Motivation

https://github.com/ethereum/go-ethereum/pull/26413 caused the default clique configuration for the `GethInstance` to fail to start mining, because we did not pass a `--miner.etherbase` flag on startup.

For example, this would cause error logs in reth integration tests when we would try to start mining over RPC:
```
thread 'can_peer_with_geth' panicked at 'called `Result::unwrap()` on an `Err` value: ProviderError(MiddlewareError(JsonRpcClientError(JsonRpcError(JsonRpcError { code: -32000, message: "etherbase missing: etherbase must be explicitly specified", data: None }))))', crates/staged-sync/tests/sync.rs:93:72
```

## Solution

Adds a `--miner.etherbase` flag with the clique signer address as the argument, when clique is enabled.

Ran reth integration tests multiple times after patching ethers

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
