### PR TITLE
chore(deps): bump tokio to 1.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -978,7 +978,7 @@ dependencies = [
  "hashbrown",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.6",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -2346,7 +2346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2364,7 +2364,7 @@ dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2585,14 +2585,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2864,7 +2864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.6",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -2883,15 +2883,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3557,7 +3557,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3653,7 +3653,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3931,9 +3931,9 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -4156,7 +4156,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4287,9 +4287,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -4302,7 +4302,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4812,6 +4812,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ rand = "0.8.5"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 tempfile = "3.3.0"
-tokio = { version = "1.18", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.25", features = ["macros", "rt-multi-thread"] }
 
 # profile for the wasm example
 [profile.release.package.ethers-wasm]

--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -39,7 +39,7 @@ ethers-derive-eip712 = { version = "^1.0.0", path = "../ethers-core/ethers-deriv
 ethers-solc = { version = "^1.0.0", path = "../ethers-solc", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "1.18", default-features = false, features = ["macros"] }
+tokio = { version = "1.25", default-features = false, features = ["macros"] }
 
 [features]
 default = ["abigen"]

--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1.6.0"
 toml = "0.5.9"
 
 reqwest = { version = "0.11.3", default-features = false, features = ["blocking"], optional = true }
-tokio = { version = "1.0", default-features = false, features = ["sync"], optional = true }
+tokio = { version = "1.25", default-features = false, features = ["sync"], optional = true }
 url = { version = "2.3.1", default-features = false, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/ethers-etherscan/Cargo.toml
+++ b/ethers-etherscan/Cargo.toml
@@ -36,7 +36,7 @@ getrandom = { version = "0.2", features = ["js"] }
 ethers-solc = { version = "^1.0.0", path = "../ethers-solc", default-features = false }
 
 tempfile = "3.4.0"
-tokio = { version = "1.18", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.25", features = ["macros", "rt-multi-thread", "time"] }
 serial_test = "1.0.0"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -40,7 +40,7 @@ serde_json = { version = "1.0.64", default-features = false }
 instant = { version = "0.1.12", features = ["now"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.18" }
+tokio = { version = "1.25" }
 
 [dev-dependencies]
 ethers-providers = { version = "^1.0.0", path = "../ethers-providers", default-features = false, features = [
@@ -55,7 +55,7 @@ once_cell = "1.17.1"
 reqwest = { version = "0.11.14", default-features = false, features = ["json", "rustls"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "1.18", default-features = false, features = ["rt", "macros", "time"] }
+tokio = { version = "1.25", default-features = false, features = ["rt", "macros", "time"] }
 
 [features]
 default = ["rustls"]

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -51,7 +51,7 @@ winapi = { version = "0.3", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # tokio
-tokio = { version = "1.18", default-features = false, features = ["time"] }
+tokio = { version = "1.25", default-features = false, features = ["time"] }
 tokio-tungstenite = { version = "0.18.0", default-features = false, features = [
     "connect",
 ], optional = true }
@@ -68,7 +68,7 @@ parking_lot = { version = "0.11", features = ["wasm-bindgen"] }
 getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "1.18", default-features = false, features = ["rt", "macros", "time"] }
+tokio = { version = "1.25", default-features = false, features = ["rt", "macros", "time"] }
 tempfile = "3.4.0"
 
 [features]

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -49,7 +49,7 @@ ethers-derive-eip712 = { version = "^1.0.0", path = "../ethers-core/ethers-deriv
 
 serde_json = { version = "1.0.64" }
 yubihsm = { version = "0.41.0", features = ["secp256k1", "usb", "mockhsm"] }
-tokio = { version = "1.18", default-features = false, features = ["macros", "rt"] }
+tokio = { version = "1.25", default-features = false, features = ["macros", "rt"] }
 tempfile = "3.4.0"
 
 [features]

--- a/ethers-signers/src/aws/mod.rs
+++ b/ethers-signers/src/aws/mod.rs
@@ -279,19 +279,12 @@ impl super::Signer for AwsSigner {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::Signer;
     use rusoto_core::{
         credential::{EnvironmentProvider, StaticProvider},
         Client, HttpClient, Region,
     };
-    use tracing::metadata::LevelFilter;
-
-    use super::*;
-    use crate::Signer;
-
-    #[allow(dead_code)]
-    fn setup_tracing() {
-        tracing_subscriber::fmt().with_max_level(LevelFilter::DEBUG).try_init().unwrap();
-    }
 
     #[allow(dead_code)]
     fn static_client() -> KmsClient {
@@ -318,7 +311,6 @@ mod tests {
             Ok(id) => id,
             _ => return,
         };
-        setup_tracing();
         let client = env_client();
         let signer = AwsSigner::new(client, key_id, chain_id).await.unwrap();
 

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0.68"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 semver = { version = "1.0.16", features = ["serde"] }
 walkdir = "2.3.2"
-tokio = { version = "1.18", default-features = false, features = ["rt"] }
+tokio = { version = "1.25", default-features = false, features = ["rt"] }
 futures-util = { version = "^0.3", optional = true }
 once_cell = "1.17.1"
 regex = "1.7.1"
@@ -61,7 +61,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["e
 rand = "0.8.5"
 pretty_assertions = "1.3.0"
 tempfile = "3.4.0"
-tokio = { version = "1.18", features = ["full"] }
+tokio = { version = "1.25", features = ["full"] }
 serde_path_to_error = "0.1.9"
 
 [[bench]]

--- a/examples/anvil/Cargo.toml
+++ b/examples/anvil/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 [dev-dependencies]
 ethers = { path = "../..", version = "1.0.0" }
 eyre = "0.6"
-tokio = { version = "1.18", features = ["full"] }
+tokio = { version = "1.25", features = ["full"] }

--- a/examples/contracts/Cargo.toml
+++ b/examples/contracts/Cargo.toml
@@ -14,6 +14,6 @@ ethers = { path = "../..", version = "1.0.0", features = ["abigen", "ethers-solc
 eyre = "0.6"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.64"
-tokio = { version = "1.18", features = ["macros"] }
+tokio = { version = "1.25", features = ["macros"] }
 
 

--- a/examples/events/Cargo.toml
+++ b/examples/events/Cargo.toml
@@ -10,4 +10,4 @@ ethers = { path = "../..", version = "1.0.0" }
 eyre = "0.6"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.64"
-tokio = { version = "1.18", features = ["macros"] }
+tokio = { version = "1.25", features = ["macros"] }

--- a/examples/middleware/Cargo.toml
+++ b/examples/middleware/Cargo.toml
@@ -11,5 +11,5 @@ async-trait = { version = "0.1.50", default-features = false }
 eyre = "0.6"
 serde_json = "1.0.61"
 thiserror = { version = "1.0", default-features = false }
-tokio = { version = "1.18", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.25", features = ["macros", "rt", "rt-multi-thread"] }
 

--- a/examples/providers/Cargo.toml
+++ b/examples/providers/Cargo.toml
@@ -11,7 +11,7 @@ eyre = "0.6"
 reqwest = { version = "0.11.14", default-features = false }
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.64"
-tokio = { version = "1.18", features = ["macros"] }
+tokio = { version = "1.25", features = ["macros"] }
 
 async-trait = "0.1"
 url = "2.3"

--- a/examples/queries/Cargo.toml
+++ b/examples/queries/Cargo.toml
@@ -10,4 +10,4 @@ ethers = { path = "../..", version = "1.0.0", features = ["abigen", "rustls", "w
 eyre = "0.6"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.64"
-tokio = { version = "1.18", features = ["macros"] }
+tokio = { version = "1.25", features = ["macros"] }

--- a/examples/subscriptions/Cargo.toml
+++ b/examples/subscriptions/Cargo.toml
@@ -10,4 +10,4 @@ ethers = { path = "../..", version = "1.0.0", features = ["abigen", "rustls", "w
 eyre = "0.6"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.64"
-tokio = { version = "1.18", features = ["macros"] }
+tokio = { version = "1.25", features = ["macros"] }

--- a/examples/transactions/Cargo.toml
+++ b/examples/transactions/Cargo.toml
@@ -10,4 +10,4 @@ ethers = { path = "../..", version = "1.0.0", features = ["abigen", "rustls", "w
 eyre = "0.6"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.64"
-tokio = { version = "1.18", features = ["macros"] }
+tokio = { version = "1.25", features = ["macros"] }

--- a/examples/wallets/Cargo.toml
+++ b/examples/wallets/Cargo.toml
@@ -16,5 +16,5 @@ ethers = { path = "../..", version = "1.0.0", features = ["abigen", "eip712", "l
 eyre = "0.6"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.64"
-tokio = { version = "1.18", features = ["macros"] }
+tokio = { version = "1.25", features = ["macros"] }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

- [RUSTSEC-2023-0005]<https://rustsec.org/advisories/RUSTSEC-2023-0005.html)
- #2190

Note: This bumps from 1.24.1 in 1.25.0

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
