### PR TITLE
fix: parse_log in public interface

### DIFF
--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -19,7 +19,7 @@ mod factory;
 pub use factory::{ContractDeployer, ContractDeploymentTx, ContractFactory, DeploymentTxFactory};
 
 mod event;
-pub use event::{EthEvent, Event};
+pub use event::{parse_log, EthEvent, Event};
 
 mod log;
 pub use log::{decode_logs, EthLogDecode, LogMeta};


### PR DESCRIPTION
Parse log was inadvertently removed from re-export by #2105 