### PR TITLE
fix(ci): change windows target ABI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: dtolnay/rust-toolchain@stable
+              with:
+                toolchain: ${{ matrix.os == 'windows-latest' && 'stable-x86_64-pc-windows-gnu' }}
             - name: Install Anvil
               uses: foundry-rs/foundry-toolchain@v1
               with:


### PR DESCRIPTION
Fix failing CI by changing the target ABI for Windows
More information about target ABIs can be found [here](https://rust-lang.github.io/rustup/installation/windows.html#:%7E:text=Or%20to%20choose%20the%2064%20bit%20GNU%20toolchain)
See also [dtolnay's comment](https://github.com/dtolnay/rust-toolchain/issues/46#issuecomment-1345689658)