### PR TITLE
fix: docsrs builds final

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ default-members = [
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]

--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -57,4 +57,5 @@ openssl = ["ethers-contract-abigen/openssl"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -43,6 +43,7 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]

--- a/ethers-contract/ethers-contract-derive/Cargo.toml
+++ b/ethers-contract/ethers-contract-derive/Cargo.toml
@@ -30,4 +30,5 @@ eyre = "0.6"
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -69,7 +69,7 @@ pub use once_cell::sync::Lazy;
 #[cfg(feature = "eip712")]
 pub use ethers_derive_eip712::*;
 
-// For Abigen expansions in docs.rs builds.
+// For macro expansions only, not public API.
 
 #[doc(hidden)]
 #[allow(unused_extern_crates)]
@@ -77,23 +77,15 @@ extern crate self as ethers_contract;
 
 #[doc(hidden)]
 #[allow(unused_extern_crates)]
-#[cfg(docsrs)]
 extern crate self as ethers;
 
 #[doc(hidden)]
-#[cfg(docsrs)]
-pub mod core {
-    pub use ethers_core::*;
-}
-
-#[doc(hidden)]
-#[cfg(docsrs)]
 pub mod contract {
     pub use crate::*;
 }
 
 #[doc(hidden)]
-#[cfg(docsrs)]
-pub mod providers {
-    pub use ethers_providers::*;
-}
+pub use ethers_core as core;
+
+#[doc(hidden)]
+pub use ethers_providers as providers;

--- a/ethers-contract/src/lib.rs
+++ b/ethers-contract/src/lib.rs
@@ -70,6 +70,7 @@ pub use once_cell::sync::Lazy;
 pub use ethers_derive_eip712::*;
 
 // For macro expansions only, not public API.
+// See: [#2235](https://github.com/gakonst/ethers-rs/pull/2235)
 
 #[doc(hidden)]
 #[allow(unused_extern_crates)]

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -66,4 +66,5 @@ macros = ["syn", "cargo_metadata", "once_cell"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/ethers-etherscan/Cargo.toml
+++ b/ethers-etherscan/Cargo.toml
@@ -42,6 +42,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["e
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["ethereum", "web3", "celo", "ethers"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/ethers-middleware/src/lib.rs
+++ b/ethers-middleware/src/lib.rs
@@ -40,3 +40,18 @@ pub use timelag::TimeLag;
 /// [`Middleware`](ethers_providers::Middleware) in a concise way
 pub mod builder;
 pub use builder::MiddlewareBuilder;
+
+// For macro expansions only, not public API.
+
+#[doc(hidden)]
+#[allow(unused_extern_crates)]
+extern crate self as ethers;
+
+#[doc(hidden)]
+pub use ethers_contract as contract;
+
+#[doc(hidden)]
+pub use ethers_core as core;
+
+#[doc(hidden)]
+pub use ethers_providers as providers;

--- a/ethers-middleware/src/lib.rs
+++ b/ethers-middleware/src/lib.rs
@@ -42,6 +42,7 @@ pub mod builder;
 pub use builder::MiddlewareBuilder;
 
 // For macro expansions only, not public API.
+// See: [#2235](https://github.com/gakonst/ethers-rs/pull/2235)
 
 #[doc(hidden)]
 #[allow(unused_extern_crates)]

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["ethereum", "web3", "celo", "ethers"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["ethereum", "web3", "celo", "ethers"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,11 +83,6 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms), allow(dead_code, unused_variables))))]
 
-// For macro expansion
-#[doc(hidden)]
-#[allow(unused_extern_crates)]
-extern crate self as ethers;
-
 #[doc(inline)]
 pub use ethers_addressbook as addressbook;
 #[doc(inline)]
@@ -129,3 +124,8 @@ pub mod prelude {
     #[cfg(feature = "ethers-solc")]
     pub use super::solc::*;
 }
+
+// For macro expansions only, not public API.
+#[doc(hidden)]
+#[allow(unused_extern_crates)]
+extern crate self as ethers;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

For some reason (I believe because the build process isn't normal and maybe our resolution doesn't work with the given environment) the docs.rs builds always return `ethers` as the crate name (default). Tested multiple times on a local docs.rs instance and I can 99.9999999% confirm that this PR solves it by doing the following:

- re-export the internal crate as `ethers`
- export core, contract and providers at the top level
- rustc flags also have to be set to --cfg docsrs (for `#[cfg(docsrs)]` on the re-exports)
  - this is technically not necessary now because I removed the `cfg`s, just to be safe
  
this needs to be done in every (release) crate that uses a macro that uses `ethers_core::macros::*`, which right now includes contract and middleware.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
