### PR TITLE
added keys and mnemonic to wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Unreleased
 
+- Added pub key, priv key and mnemonic to Wallet struct.
 - Add `other: OtherFields` to `TransactionReceipt` [#2209[](https://github.com/gakonst/ethers-rs/pull/2209)
 - Add `Signature::recover_typed_data` [#2120](https://github.com/gakonst/ethers-rs/pull/2120)
 - Add `abi::encode_packed` [#2104](https://github.com/gakonst/ethers-rs/pull/2104)

--- a/ethers-signers/src/wallet/mnemonic.rs
+++ b/ethers-signers/src/wallet/mnemonic.rs
@@ -11,6 +11,7 @@ use ethers_core::{
 };
 use rand::Rng;
 use std::{fs::File, io::Write, marker::PhantomData, path::PathBuf, str::FromStr};
+
 use thiserror::Error;
 
 const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/60'/0'/0/";
@@ -184,7 +185,11 @@ impl<W: Wordlist> MnemonicBuilder<W> {
         let signer = SigningKey::from_bytes(&key.to_bytes())?;
         let address = secret_key_to_address(&signer);
 
-        Ok(Wallet::<SigningKey> { signer, address, chain_id: 1 })
+        let mnemonic = Some(mnemonic.to_phrase().unwrap());
+        let private_key = Some(format!("0x{:02X?}", signer.to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
+        let public_key = Some(format!("0x{:02X?}", signer.verifying_key().to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
+
+        Ok(Wallet::<SigningKey> { signer, address, chain_id: 1, mnemonic, private_key, public_key })
     }
 }
 

--- a/ethers-signers/src/wallet/mod.rs
+++ b/ethers-signers/src/wallet/mod.rs
@@ -71,12 +71,21 @@ pub struct Wallet<D: DigestSigner<Sha256Proxy, RecoverableSignature>> {
     pub(crate) address: Address,
     /// The wallet's chain id (for EIP-155)
     pub(crate) chain_id: u64,
+    // The wallet's mnemonic
+    pub mnemonic: Option<String>,
+    // The wallet's private key
+    pub private_key: Option<String>,
+    // The wallet's public key
+    pub public_key: Option<String>
 }
 
 impl<D: DigestSigner<Sha256Proxy, RecoverableSignature>> Wallet<D> {
     /// Construct a new wallet with an external Signer
     pub fn new_with_signer(signer: D, address: Address, chain_id: u64) -> Self {
-        Wallet { signer, address, chain_id }
+        let mnemonic = None;
+        let private_key = None;
+        let public_key = None;
+        Wallet { signer, address, chain_id, mnemonic, private_key, public_key }
     }
 }
 

--- a/ethers-signers/src/wallet/private_key.rs
+++ b/ethers-signers/src/wallet/private_key.rs
@@ -67,8 +67,11 @@ impl Wallet<SigningKey> {
     {
         let (secret, uuid) = eth_keystore::new(dir, rng, password, name)?;
         let signer = SigningKey::from_bytes(secret.as_slice())?;
+        let mnemonic = None;
+        let private_key = Some(format!("0x{:02X?}", signer.to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
+        let public_key = Some(format!("0x{:02X?}", signer.verifying_key().to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
         let address = secret_key_to_address(&signer);
-        Ok((Self { signer, address, chain_id: 1 }, uuid))
+        Ok((Self { signer, address, chain_id: 1, mnemonic, private_key, public_key }, uuid))
     }
 
     /// Decrypts an encrypted JSON from the provided path to construct a Wallet instance
@@ -80,22 +83,31 @@ impl Wallet<SigningKey> {
     {
         let secret = eth_keystore::decrypt_key(keypath, password)?;
         let signer = SigningKey::from_bytes(secret.as_slice())?;
+        let mnemonic = None;
+        let private_key = Some(format!("0x{:02X?}", signer.to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
+        let public_key = Some(format!("0x{:02X?}", signer.verifying_key().to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
         let address = secret_key_to_address(&signer);
-        Ok(Self { signer, address, chain_id: 1 })
+        Ok(Self { signer, address, chain_id: 1, mnemonic, private_key, public_key })
     }
 
     /// Creates a new random keypair seeded with the provided RNG
     pub fn new<R: Rng + CryptoRng>(rng: &mut R) -> Self {
         let signer = SigningKey::random(rng);
+        let mnemonic = None;
+        let private_key = Some(format!("0x{:02X?}", signer.to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
+        let public_key = Some(format!("0x{:02X?}", signer.verifying_key().to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
         let address = secret_key_to_address(&signer);
-        Self { signer, address, chain_id: 1 }
+        Self { signer, address, chain_id: 1, mnemonic, private_key, public_key }
     }
 
     /// Creates a new Wallet instance from a raw scalar value (big endian).
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, WalletError> {
         let signer = SigningKey::from_bytes(bytes)?;
+        let mnemonic = None;
+        let private_key = Some(format!("0x{:02X?}", signer.to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
+        let public_key = Some(format!("0x{:02X?}", signer.verifying_key().to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
         let address = secret_key_to_address(&signer);
-        Ok(Self { signer, address, chain_id: 1 })
+        Ok(Self { signer, address, chain_id: 1, mnemonic, private_key, public_key })
     }
 }
 
@@ -110,8 +122,10 @@ impl PartialEq for Wallet<SigningKey> {
 impl From<SigningKey> for Wallet<SigningKey> {
     fn from(signer: SigningKey) -> Self {
         let address = secret_key_to_address(&signer);
-
-        Self { signer, address, chain_id: 1 }
+        let mnemonic = None;
+        let private_key = Some(format!("0x{:02X?}", signer.to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
+        let public_key = Some(format!("0x{:02X?}", signer.verifying_key().to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
+        Self { signer, address, chain_id: 1, mnemonic, private_key, public_key }
     }
 }
 
@@ -121,8 +135,10 @@ impl From<K256SecretKey> for Wallet<SigningKey> {
     fn from(key: K256SecretKey) -> Self {
         let signer = key.into();
         let address = secret_key_to_address(&signer);
-
-        Self { signer, address, chain_id: 1 }
+        let mnemonic = None;
+        let private_key = Some(format!("0x{:02X?}", signer.to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
+        let public_key = Some(format!("0x{:02X?}", signer.verifying_key().to_bytes()).replace(", ", "").replace("[", "").replace("]", ""));
+        Self { signer, address, chain_id: 1, mnemonic, private_key, public_key }
     }
 }
 


### PR DESCRIPTION
I have added the public key, private key and mnemonic to the Wallet struct so they are easily accessible by users. 

## Motivation

I think it is generally a good idea to give users access to these values so they can easily control their assets.

## Solution

This is fairly straight forward. I have added 3 option<string> to the wallet struct and populated them when a wallet is generated.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes

This is not a breaking change. I have added a changeling entry.