### PR TITLE
fix: dont poll stream again if done

### DIFF
--- a/ethers-providers/src/stream/tx_stream.rs
+++ b/ethers-providers/src/stream/tx_stream.rs
@@ -56,6 +56,8 @@ pub struct TransactionStream<'a, P, St> {
     pub(crate) provider: &'a Provider<P>,
     /// A stream of transaction hashes.
     pub(crate) stream: St,
+    /// Marks if the stream is done
+    stream_done: bool,
     /// max allowed futures to execute at once.
     pub(crate) max_concurrent: usize,
 }
@@ -68,6 +70,7 @@ impl<'a, P: JsonRpcClient, St> TransactionStream<'a, P, St> {
             buffered: Default::default(),
             provider,
             stream,
+            stream_done: false,
             max_concurrent,
         }
     }
@@ -102,21 +105,22 @@ where
             }
         }
 
-        let mut stream_done = false;
-        loop {
-            match Stream::poll_next(Pin::new(&mut this.stream), cx) {
-                Poll::Ready(Some(tx)) => {
-                    if this.pending.len() < this.max_concurrent {
-                        this.push_tx(tx);
-                    } else {
-                        this.buffered.push_back(tx);
+        if !this.stream_done {
+            loop {
+                match Stream::poll_next(Pin::new(&mut this.stream), cx) {
+                    Poll::Ready(Some(tx)) => {
+                        if this.pending.len() < this.max_concurrent {
+                            this.push_tx(tx);
+                        } else {
+                            this.buffered.push_back(tx);
+                        }
                     }
+                    Poll::Ready(None) => {
+                        this.stream_done = true;
+                        break
+                    }
+                    _ => break,
                 }
-                Poll::Ready(None) => {
-                    stream_done = true;
-                    break
-                }
-                _ => break,
             }
         }
 
@@ -125,7 +129,7 @@ where
             return tx
         }
 
-        if stream_done && this.pending.is_empty() {
+        if this.stream_done && this.pending.is_empty() {
             // all done
             return Poll::Ready(None)
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
polling a stream after it finished is usually bad.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
only poll if not done
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
