### PR TITLE
fix: use to_string in mainnet chain variant

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -616,4 +616,13 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn serde_to_string_match() {
+        for chain in Chain::iter() {
+            let chain_serde = serde_json::to_string(&chain).unwrap();
+            let chain_string = format!("\"{}\"", chain.to_string());
+            assert_eq!(chain_serde, chain_string);
+        }
+    }
 }

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -53,7 +53,8 @@ pub type ParseChainError = TryFromPrimitiveError<Chain>;
 #[strum(serialize_all = "kebab-case")]
 #[repr(u64)]
 pub enum Chain {
-    #[strum(serialize = "ethlive", serialize = "mainnet")]
+    #[strum(to_string = "mainnet", serialize = "ethlive")]
+    #[serde(alias = "ethlive")]
     Mainnet = 1,
     Morden = 2,
     Ropsten = 3,
@@ -598,6 +599,7 @@ mod tests {
 
         // kebab-case
         const ALIASES: &[(Chain, &[&str])] = &[
+            (Mainnet, &["ethlive"]),
             (BinanceSmartChain, &["bsc", "binance-smart-chain"]),
             (BinanceSmartChainTestnet, &["bsc-testnet", "binance-smart-chain-testnet"]),
             (XDai, &["xdai", "gnosis", "gnosis-chain"]),


### PR DESCRIPTION
## Motivation

A followup of https://github.com/gakonst/ethers-rs/pull/2268 in the context of https://github.com/gakonst/ethers-rs/pull/2270. I didn't trust myself with the serde and strum configurations so I've added a test checking if they match.

## Solution

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Updated the changelog
-   [ ] Breaking changes
