### PR TITLE
fix(core): re-export CallLogFrame from geth types

### DIFF
--- a/ethers-core/src/types/trace/geth.rs
+++ b/ethers-core/src/types/trace/geth.rs
@@ -4,7 +4,7 @@ mod noop;
 mod pre_state;
 
 pub use self::{
-    call::{CallConfig, CallFrame},
+    call::{CallConfig, CallFrame, CallLogFrame},
     four_byte::FourByteFrame,
     noop::NoopFrame,
     pre_state::{PreStateConfig, PreStateFrame},

--- a/ethers-core/src/types/trace/geth/call.rs
+++ b/ethers-core/src/types/trace/geth/call.rs
@@ -32,11 +32,11 @@ pub struct CallFrame {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CallLogFrame {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    address: Option<Address>,
+    pub address: Option<Address>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    topics: Option<Vec<H256>>,
+    pub topics: Option<Vec<H256>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    data: Option<Bytes>,
+    pub data: Option<Bytes>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Motivation

The CallLogFrame was not being exported from geth which made it
difficult to store all the logs using the ethers type.

## Solution

Export CallLogFrame so it's accessible publicly via `ethers::types`.
Also export the internal fields.
