### PR TITLE
fix: broken eip155 logic in aws signer

### DIFF
--- a/ethers-signers/src/aws/utils.rs
+++ b/ethers-signers/src/aws/utils.rs
@@ -51,7 +51,7 @@ pub(super) fn sig_from_digest_bytes_trial_recovery(
 
 /// Modify the v value of a signature to conform to eip155
 pub(super) fn apply_eip155(sig: &mut EthSig, chain_id: u64) {
-    let v = (chain_id * 2 + 35) + ((sig.v - 1) % 2);
+    let v = (chain_id * 2 + 35) + sig.v;
     sig.v = v;
 }
 


### PR DESCRIPTION
## Motivation

A recent PR (https://github.com/gakonst/ethers-rs/pull/2260) broke the AWS KMS signer. With the latest version, using the signer would either result in a panic (in debug mode, for subtraction overflow), or simply wrong signatures. Relevant code:

https://github.com/gakonst/ethers-rs/blob/16f9fab75cb43e2d9e4c2b74b68afde7577f0e2f/ethers-signers/src/aws/utils.rs#L43-L56

Note that `v` is already the recovery ID. There's no need to subtract it by 1 (doing so when `v` is 0 panics). `v` can also only be `0` or `1`, so there's also no need to mod by 2.

## Solution

Just use `v` directly in `apply_eip155`.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
