### PR TITLE
fix: ambiguous_glob_reexports rustc lint

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -621,7 +621,7 @@ mod tests {
     fn serde_to_string_match() {
         for chain in Chain::iter() {
             let chain_serde = serde_json::to_string(&chain).unwrap();
-            let chain_string = format!("\"{}\"", chain.to_string());
+            let chain_string = format!("\"{}\"", chain);
             assert_eq!(chain_serde, chain_string);
         }
     }

--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -24,7 +24,7 @@ pub mod contract;
 pub mod errors;
 pub mod gas;
 pub mod source_tree;
-pub mod transaction;
+mod transaction;
 pub mod utils;
 pub mod verify;
 

--- a/ethers/src/lib.rs
+++ b/ethers/src/lib.rs
@@ -106,8 +106,9 @@ pub use ethers_core::{abi, types, utils};
 
 /// Easy imports of frequently used type definitions and traits.
 #[doc(hidden)]
+#[allow(ambiguous_glob_reexports)]
 pub mod prelude {
-    pub use super::addressbook::*;
+    pub use super::addressbook::contract;
 
     pub use super::contract::*;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

new rustc lint dropped, warn level by default

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
