### PR TITLE
perf: early return in EthCodec derive

### DIFF
--- a/ethers-contract/ethers-contract-derive/src/calllike.rs
+++ b/ethers-contract/ethers-contract-derive/src/calllike.rs
@@ -138,7 +138,7 @@ pub fn derive_codec_impls(
 
     let codec_impl = quote! {
         impl #ethers_core::abi::AbiDecode for #struct_name {
-            fn decode(bytes: impl AsRef<[u8]>) -> ::std::result::Result<Self, #ethers_core::abi::AbiError> {
+            fn decode(bytes: impl AsRef<[u8]>) -> ::core::result::Result<Self, #ethers_core::abi::AbiError> {
                 #decode_impl
             }
         }

--- a/ethers-contract/ethers-contract-derive/src/event.rs
+++ b/ethers-contract/ethers-contract-derive/src/event.rs
@@ -91,7 +91,7 @@ pub(crate) fn derive_eth_event_impl(input: DeriveInput) -> Result<TokenStream, E
                 #abi.into()
             }
 
-            fn decode_log(log: &#ethers_core::abi::RawLog) -> ::std::result::Result<Self, #ethers_core::abi::Error> where Self: Sized {
+            fn decode_log(log: &#ethers_core::abi::RawLog) -> ::core::result::Result<Self, #ethers_core::abi::Error> where Self: Sized {
                 #decode_log_impl
             }
 

--- a/ethers-contract/ethers-contract-derive/src/lib.rs
+++ b/ethers-contract/ethers-contract-derive/src/lib.rs
@@ -141,6 +141,10 @@ pub fn derive_abi_type(input: TokenStream) -> TokenStream {
 /// generalized codec traits used for types, calls, etc. However, encoding/decoding a call differs
 /// from the basic encoding/decoding, (`[selector + encode(self)]`)
 ///
+/// Note that this macro requires the `EthAbiType` macro to be derived or for the type to implement
+/// `AbiType` and `Tokenizable`. The type returned by the `AbiType` implementation must be a
+/// `Token::Tuple`, otherwise this macro's implementation of `AbiDecode` will panic at runtime.
+///
 /// # Example
 ///
 /// ```ignore

--- a/ethers-core/src/abi/tokens.rs
+++ b/ethers-core/src/abi/tokens.rs
@@ -84,15 +84,21 @@ macro_rules! impl_tuples {
         {
             fn from_token(token: Token) -> Result<Self, InvalidOutputType> {
                 match token {
-                    Token::Tuple(mut tokens) => {
-                        let mut it = tokens.drain(..);
-                        Ok(($(
-                            $ty::from_token(it.next().expect("All elements are in vector; qed"))?,
-                        )+))
+                    Token::Tuple(tokens) if tokens.len() == $num => {
+                        let mut it = tokens.into_iter();
+                        // SAFETY: length checked above
+                        unsafe {
+                            Ok(($(
+                                <$ty as Tokenizable>::from_token(it.next().unwrap_unchecked())?,
+                            )+))
+                        }
                     },
                     other => Err(InvalidOutputType(format!(
-                        "Expected `Tuple` of length {}, got {:?}",
-                        $num,
+                        concat!(
+                            "Expected `Tuple` of length ",
+                            stringify!($num),
+                            ", got {:?}",
+                        ),
                         other,
                     ))),
                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Currently we go straight into decoding which can become expensive when called continuously from a big enum, eg foundry HEVM or HardhatConsole. We have the ParamType to decode so we can calculate very cheaply a minimum bound in bytes to check against

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

- Add a minimum bound check for the given bytes to early return for in `derive(EthCodec)`
- (drive by) Fix tuple implementations of `Tokenizable`
  - these would panic if given a `Token::Tuple` of the wrong length
  - also we have ownership of the `Vec` so `into_iter` is better than `drain`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
