### PR TITLE
fix(middleware): no need to multiply again with `GWEI_TO_WEI_U256`

### DIFF
--- a/ethers-middleware/src/gas_oracle/etherscan.rs
+++ b/ethers-middleware/src/gas_oracle/etherscan.rs
@@ -45,8 +45,8 @@ impl GasOracle for Etherscan {
             _ => unreachable!(),
         };
         // returned gas prices are f64 value in gwei
-        let gas_price = parse_units(gas_price, "gwei")?;
-        Ok(gas_price.into())
+        let gas_price = super::from_gwei_f64(gas_price);
+        Ok(gas_price)
     }
 
     async fn estimate_eip1559_fees(&self) -> Result<(U256, U256)> {

--- a/ethers-middleware/src/gas_oracle/etherscan.rs
+++ b/ethers-middleware/src/gas_oracle/etherscan.rs
@@ -1,6 +1,6 @@
 use super::{GasCategory, GasOracle, GasOracleError, Result};
 use async_trait::async_trait;
-use ethers_core::{types::U256, utils::parse_units};
+use ethers_core::types::U256;
 use ethers_etherscan::Client;
 use std::ops::{Deref, DerefMut};
 

--- a/ethers-middleware/src/gas_oracle/etherscan.rs
+++ b/ethers-middleware/src/gas_oracle/etherscan.rs
@@ -1,4 +1,4 @@
-use super::{GasCategory, GasOracle, GasOracleError, Result, GWEI_TO_WEI_U256};
+use super::{GasCategory, GasOracle, GasOracleError, Result};
 use async_trait::async_trait;
 use ethers_core::{types::U256, utils::parse_units};
 use ethers_etherscan::Client;
@@ -46,7 +46,7 @@ impl GasOracle for Etherscan {
         };
         // returned gas prices are f64 value in gwei
         let gas_price = parse_units(gas_price, "gwei")?;
-        Ok(U256::from(gas_price) * GWEI_TO_WEI_U256)
+        Ok(gas_price.into())
     }
 
     async fn estimate_eip1559_fees(&self) -> Result<(U256, U256)> {

--- a/ethers-middleware/src/gas_oracle/mod.rs
+++ b/ethers-middleware/src/gas_oracle/mod.rs
@@ -36,6 +36,9 @@ use reqwest::Error as ReqwestError;
 use std::{error::Error, fmt::Debug};
 use thiserror::Error;
 
+pub(crate) const GWEI_TO_WEI: u64 = 1_000_000_000;
+pub(crate) const GWEI_TO_WEI_U256: U256 = U256([GWEI_TO_WEI, 0, 0, 0]);
+
 pub type Result<T, E = GasOracleError> = std::result::Result<T, E>;
 
 /// Generic [`GasOracle`] gas price categories.

--- a/ethers-middleware/src/gas_oracle/mod.rs
+++ b/ethers-middleware/src/gas_oracle/mod.rs
@@ -36,9 +36,6 @@ use reqwest::Error as ReqwestError;
 use std::{error::Error, fmt::Debug};
 use thiserror::Error;
 
-pub(crate) const GWEI_TO_WEI: u64 = 1_000_000_000;
-pub(crate) const GWEI_TO_WEI_U256: U256 = U256([GWEI_TO_WEI, 0, 0, 0]);
-
 pub type Result<T, E = GasOracleError> = std::result::Result<T, E>;
 
 /// Generic [`GasOracle`] gas price categories.

--- a/ethers-middleware/tests/it/gas_oracle.rs
+++ b/ethers-middleware/tests/it/gas_oracle.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
-use ethers_core::{types::*, utils::Anvil};
+use ethers_core::{
+    types::*,
+    utils::{parse_ether, Anvil},
+};
 use ethers_etherscan::Client;
 use ethers_middleware::gas_oracle::{
     BlockNative, Etherchain, Etherscan, GasCategory, GasNow, GasOracle, GasOracleError,
@@ -102,6 +105,8 @@ async fn etherscan() {
 
     let gas_price = etherscan_oracle.fetch().await.unwrap();
     assert!(gas_price > U256::zero());
+    let ten_ethers = parse_ether(10).unwrap();
+    assert!(gas_price < ten_ethers, "gas calculation is wrong (too high)");
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

While working on #2325 I did not notice that `parse_units` will return the correct value and will be no need to multiply the result again with `GWEI_TO_WEI_U256` (`1_000_000_000`) extra zeros! which makes the gas calculations insanely incorrect!

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Removing the multiplication process solves that issue.

Edit: actually, there was a method called `from_gwei_f64` that we can use for that.

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
