### PR TITLE
feature: very permissive etherscan gwei deser

### DIFF
--- a/ethers-etherscan/tests/it/gas.rs
+++ b/ethers-etherscan/tests/it/gas.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use ethers_core::types::Chain;
+use ethers_core::types::{Chain, U256};
 use serial_test::serial;
 
 #[tokio::test]
@@ -34,11 +34,11 @@ async fn gas_oracle_success() {
 
         let oracle = result.unwrap();
 
-        assert!(oracle.safe_gas_price > 0f64);
-        assert!(oracle.propose_gas_price > 0f64);
-        assert!(oracle.fast_gas_price > 0f64);
+        assert!(oracle.safe_gas_price > U256::zero());
+        assert!(oracle.propose_gas_price > U256::zero());
+        assert!(oracle.fast_gas_price > U256::zero());
         assert!(oracle.last_block > 0);
-        assert!(oracle.suggested_base_fee > 0.0);
+        assert!(oracle.suggested_base_fee > U256::zero());
         assert!(!oracle.gas_used_ratio.is_empty());
     })
     .await

--- a/ethers-middleware/src/gas_oracle/etherscan.rs
+++ b/ethers-middleware/src/gas_oracle/etherscan.rs
@@ -44,8 +44,6 @@ impl GasOracle for Etherscan {
             GasCategory::Fast => result.fast_gas_price,
             _ => unreachable!(),
         };
-        // returned gas prices are f64 value in gwei
-        let gas_price = super::from_gwei_f64(gas_price);
         Ok(gas_price)
     }
 


### PR DESCRIPTION
Extremely permissive deserializer for etherscan gas units

## Motivation

More complete fix to #2326 #2325 

## Solution

Introduce a deser that performs the following in order:
- checks for a JSON number, and scales it by WEI_PER_GWEI
- checks for a string, then tries to parse it as a float number of gwei

change the etherscan response object to have `U256` responses that are ALWAYS in `wei` rather than in f64 gwei

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [x] Breaking changes
