### PR TITLE
chore: update deny config

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -8,27 +8,14 @@ on:
         branches: [master]
         paths: [Cargo.lock]
 
-env:
-    RUSTFLAGS: -D warnings
-    CARGO_TERM_COLOR: always
-
 concurrency: deps-${{ github.head_ref || github.run_id }}
 
 jobs:
     deny:
-        name: deny (${{ matrix.checks }})
+        name: deny
         runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                checks:
-                    - advisories
-                    - bans licenses sources
-
-        continue-on-error: ${{ matrix.checks == 'advisories' }}
-
         steps:
             - uses: actions/checkout@v3
             - uses: EmbarkStudios/cargo-deny-action@v1
               with:
-                  command: check ${{ matrix.checks }}
+                  command: check all

--- a/deny.toml
+++ b/deny.toml
@@ -15,7 +15,7 @@ notice = "warn"
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
-wildcards = "allow"
+wildcards = "deny"
 highlight = "all"
 # List of crates to deny
 deny = [
@@ -33,6 +33,9 @@ skip-tree = []
 
 [licenses]
 unlicensed = "deny"
+confidence-threshold = 0.9
+# copyleft = "deny"
+
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
@@ -45,8 +48,12 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Unicode-DFS-2016",
-    "OpenSSL",
     "Unlicense",
+    "MPL-2.0",
+    # https://github.com/briansmith/ring/issues/902
+    "LicenseRef-ring",
+    # https://github.com/briansmith/webpki/issues/148
+    "LicenseRef-webpki",
 ]
 
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
@@ -55,26 +62,20 @@ exceptions = [
     # CC0 is a permissive license but somewhat unclear status for source code
     # so we prefer to not have dependencies using it
     # https://tldrlegal.com/license/creative-commons-cc0-1.0-universal
-    { allow = ["CC0-1.0"], name = "secp256k1" },
-    { allow = ["CC0-1.0"], name = "secp256k1-sys" },
     { allow = ["CC0-1.0"], name = "tiny-keccak" },
-    { allow = ["CC0-1.0"], name = "more-asserts" },
     { allow = ["CC0-1.0"], name = "trezor-client" },
     { allow = ["CC0-1.0"], name = "constant_time_eq" },
 ]
-#copyleft = "deny"
 
-# See note in unicode-ident's readme!
-[[licenses.clarify]]
-name = "unicode-ident"
-version = "*"
-expression = "(MIT OR Apache-2.0) AND Unicode-DFS-2016"
-license-files = [{ path = "LICENSE-UNICODE", hash = 0x3fb01745 }]
 [[licenses.clarify]]
 name = "ring"
-version = "*"
-expression = "OpenSSL"
+expression = "LicenseRef-ring"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[[licenses.clarify]]
+name = "webpki"
+expression = "LicenseRef-webpki"
+license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:
@@ -82,7 +83,7 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 [sources]
 # Lint level for what to happen when a crate from a crate registry that is not
 # in the allow list is encountered
-unknown-registry = "warn"
+unknown-registry = "deny"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
-unknown-git = "allow"
+unknown-git = "deny"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

- Remove outdated exceptions and `[[license.clarify]]`
- Make config more strict for wildcard and git dependencies
  - bad practice, git dependencies are not allowed when published so doesn't hurt adding an extra check
- Add `MPL-2.0` to license allow list since it generates a warning for being copy-left
  - Looked to other crates using the `webpki-roots` crate: <https://github.com/hyperium/tonic/blob/master/deny.toml>

The only remaining warnings are for duplicate crates


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
