### PR TITLE
chore: dont retain errors

### DIFF
--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -1489,12 +1489,6 @@ impl CompilerOutput {
         let files: HashSet<_> = files.into_iter().map(|s| s.to_lowercase()).collect();
         self.contracts.retain(|f, _| files.contains(f.to_lowercase().as_str()));
         self.sources.retain(|f, _| files.contains(f.to_lowercase().as_str()));
-        self.errors.retain(|err| {
-            err.source_location
-                .as_ref()
-                .map(|s| files.contains(s.file.to_lowercase().as_str()))
-                .unwrap_or(true)
-        });
     }
 
     pub fn merge(&mut self, other: CompilerOutput) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
if we `compile_exact(file)` we should not filter errors because this obfuscates failed compile runs
discovered via:
https://github.com/foundry-rs/foundry/issues/4467
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
