### PR TITLE
fix: document FilecoinMainnet as EIP-1559 compatible

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -321,13 +321,13 @@ impl Chain {
             PolygonMumbai |
             Avalanche |
             AvalancheFuji |
+            FilecoinMainnet |
             FilecoinHyperspaceTestnet => false,
 
             // Unknown / not applicable, default to false for backwards compatibility
             Dev | AnvilHardhat | Morden | Ropsten | Rinkeby | Cronos | CronosTestnet | Kovan |
             Sokol | Poa | XDai | Moonbeam | MoonbeamDev | Moonriver | Moonbase | Evmos |
-            EvmosTestnet | Chiado | Aurora | AuroraTestnet | Canto | CantoTestnet |
-            FilecoinMainnet => false,
+            EvmosTestnet | Chiado | Aurora | AuroraTestnet | Canto | CantoTestnet => false,
         }
     }
 


### PR DESCRIPTION
## Motivation

I've noticed reading the source code that in the `Chain::is_legacy` method `FilecoinHyperspaceTestnet` was listed as known EIP-1559 compatible while `FilecoinMainnet` as unknown. 

I've restructured the code to reflect that `FilecoinMainnet` is known to be EIP-1559 compatible as well. This is just a documentation change, since the value returned is `false` in both cases.

Source official [Filecoin blog:](https://filecoin.io/blog/posts/eip-1559-in-filecoin/) "EIP-1559 is implemented and live on the Filecoin mainnet."

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests (n/a)
-   [ ] Added Documentation (n/a)
-   [ ] Breaking changes (n/a)
