### PR TITLE
docs: update some doctest examples

### DIFF
--- a/ethers-etherscan/src/account.rs
+++ b/ethers-etherscan/src/account.rs
@@ -392,11 +392,11 @@ impl Display for Sort {
 /// Common optional arguments for the transaction or event list API endpoints
 #[derive(Clone, Copy, Debug)]
 pub struct TxListParams {
-    start_block: u64,
-    end_block: u64,
-    page: u64,
-    offset: u64,
-    sort: Sort,
+    pub start_block: u64,
+    pub end_block: u64,
+    pub page: u64,
+    pub offset: u64,
+    pub sort: Sort,
 }
 
 impl TxListParams {
@@ -480,17 +480,13 @@ impl Display for BlockType {
 impl Client {
     /// Returns the Ether balance of a given address.
     ///
-    /// ```no_run
-    /// # use ethers_etherscan::Client;
-    /// # use ethers_core::types::Chain;
+    /// # Examples
     ///
-    /// # #[tokio::main]
-    /// # async fn main() {
-    ///     let client = Client::new(Chain::Mainnet, "API_KEY").unwrap();
-    ///     let balance = client
-    ///         .get_ether_balance_single(&"0x58eB28A67731c570Ef827C365c89B5751F9E6b0a".parse().unwrap(),
-    ///         None).await.unwrap();
-    /// # }
+    /// ```no_run
+    /// # async fn foo(client: ethers_etherscan::Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let address = "0x58eB28A67731c570Ef827C365c89B5751F9E6b0a".parse()?;
+    /// let balance = client.get_ether_balance_single(&address, None).await?;
+    /// # Ok(()) }
     /// ```
     pub async fn get_ether_balance_single(
         &self,
@@ -515,21 +511,22 @@ impl Client {
 
     /// Returns the balance of the accounts from a list of addresses.
     ///
-    /// ```no_run
-    /// # use ethers_etherscan::Client;
-    /// # use ethers_core::types::Chain;
+    /// # Examples
     ///
-    /// # #[tokio::main]
-    /// # async fn main() {
-    ///     let client = Client::new(Chain::Mainnet, "API_KEY").unwrap();
-    ///     let balances = client
-    ///         .get_ether_balance_multi(&vec![&"0x58eB28A67731c570Ef827C365c89B5751F9E6b0a".parse().unwrap()],
-    ///         None).await.unwrap();
-    /// # }
+    /// ```no_run
+    /// # use ethers_core::types::Address;
+    /// # async fn foo(client: ethers_etherscan::Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let addresses = [
+    ///     "0x3E3c00494d0b306a0739E480DBB5DB91FFb5d4CB".parse::<Address>()?,
+    ///     "0x7e9996ef050a9Fa7A01248e63271F69086aaFc9D".parse::<Address>()?,
+    /// ];
+    /// let balances = client.get_ether_balance_multi(&addresses, None).await?;
+    /// assert_eq!(addresses.len(), balances.len());
+    /// # Ok(()) }
     /// ```
     pub async fn get_ether_balance_multi(
         &self,
-        addresses: &[&Address],
+        addresses: &[Address],
         tag: Option<Tag>,
     ) -> Result<Vec<AccountBalance>> {
         let tag_str = tag.unwrap_or_default().to_string();
@@ -550,17 +547,13 @@ impl Client {
 
     /// Returns the list of transactions performed by an address, with optional pagination.
     ///
-    /// ```no_run
-    /// # use ethers_etherscan::Client;
-    /// # use ethers_core::types::Chain;
+    /// # Examples
     ///
-    /// # #[tokio::main]
-    /// # async fn main() {
-    ///     let client = Client::new(Chain::Mainnet, "API_KEY").unwrap();
-    ///     let txs = client
-    ///         .get_transactions(&"0x58eB28A67731c570Ef827C365c89B5751F9E6b0a".parse().unwrap(),
-    ///         None).await.unwrap();
-    /// # }
+    /// ```no_run
+    /// # async fn foo(client: ethers_etherscan::Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let address = "0x1f162cf730564efD2Bb96eb27486A2801d76AFB6".parse()?;
+    /// let transactions = client.get_transactions(&address, None).await?;
+    /// # Ok(()) }
     /// ```
     pub async fn get_transactions(
         &self,
@@ -578,18 +571,16 @@ impl Client {
     /// Returns the list of internal transactions performed by an address or within a transaction,
     /// with optional pagination.
     ///
-    /// ```no_run
-    /// # use ethers_etherscan::{Client, account::InternalTxQueryOption};
-    /// # use ethers_core::types::Chain;
+    /// # Examples
     ///
-    /// # #[tokio::main]
-    /// # async fn main() {
-    ///     let client = Client::new(Chain::Mainnet, "API_KEY").unwrap();
-    ///     let txs = client
-    ///         .get_internal_transactions(
-    ///             InternalTxQueryOption::ByAddress(
-    ///                 "0x2c1ba59d6f58433fb1eaee7d20b26ed83bda51a3".parse().unwrap()), None).await.unwrap();
-    /// # }
+    /// ```no_run
+    /// use ethers_etherscan::account::InternalTxQueryOption;
+    ///
+    /// # async fn foo(client: ethers_etherscan::Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let address = "0x2c1ba59d6f58433fb1eaee7d20b26ed83bda51a3".parse()?;
+    /// let query = InternalTxQueryOption::ByAddress(address);
+    /// let internal_transactions = client.get_internal_transactions(query, None).await?;
+    /// # Ok(()) }
     /// ```
     pub async fn get_internal_transactions(
         &self,
@@ -615,18 +606,16 @@ impl Client {
     /// Returns the list of ERC-20 tokens transferred by an address, with optional filtering by
     /// token contract.
     ///
-    /// ```no_run
-    /// # use ethers_etherscan::{Client, account::TokenQueryOption};
-    /// # use ethers_core::types::Chain;
+    /// # Examples
     ///
-    /// # #[tokio::main]
-    /// # async fn main() {
-    ///     let client = Client::new(Chain::Mainnet, "API_KEY").unwrap();
-    ///     let txs = client
-    ///         .get_erc20_token_transfer_events(
-    ///             TokenQueryOption::ByAddress(
-    ///                 "0x4e83362442b8d1bec281594cea3050c8eb01311c".parse().unwrap()), None).await.unwrap();
-    /// # }
+    /// ```no_run
+    /// use ethers_etherscan::account::TokenQueryOption;
+    ///
+    /// # async fn foo(client: ethers_etherscan::Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let address = "0x4e83362442b8d1bec281594cea3050c8eb01311c".parse()?;
+    /// let query = TokenQueryOption::ByAddress(address);
+    /// let events = client.get_erc20_token_transfer_events(query, None).await?;
+    /// # Ok(()) }
     /// ```
     pub async fn get_erc20_token_transfer_events(
         &self,
@@ -643,20 +632,16 @@ impl Client {
     /// Returns the list of ERC-721 ( NFT ) tokens transferred by an address, with optional
     /// filtering by token contract.
     ///
-    /// ```no_run
-    /// # use ethers_etherscan::{Client, account::TokenQueryOption};
-    /// # use ethers_core::types::Chain;
+    /// # Examples
     ///
-    /// # #[tokio::main]
-    /// # async fn main() {
-    ///     let client = Client::new(Chain::Mainnet, "API_KEY").unwrap();
-    ///     let txs = client
-    ///         .get_erc721_token_transfer_events(
-    ///             TokenQueryOption::ByAddressAndContract(
-    ///                 "0x6975be450864c02b4613023c2152ee0743572325".parse().unwrap(),
-    ///                 "0x06012c8cf97bead5deae237070f9587f8e7a266d".parse().unwrap(),
-    ///          ), None).await.unwrap();
-    /// # }
+    /// ```no_run
+    /// use ethers_etherscan::account::TokenQueryOption;
+    ///
+    /// # async fn foo(client: ethers_etherscan::Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let contract = "0x06012c8cf97bead5deae237070f9587f8e7a266d".parse()?;
+    /// let query = TokenQueryOption::ByContract(contract);
+    /// let events = client.get_erc721_token_transfer_events(query, None).await?;
+    /// # Ok(()) }
     /// ```
     pub async fn get_erc721_token_transfer_events(
         &self,
@@ -673,20 +658,17 @@ impl Client {
     /// Returns the list of ERC-1155 ( NFT ) tokens transferred by an address, with optional
     /// filtering by token contract.
     ///
-    /// ```no_run
-    /// # use ethers_etherscan::{Client, account::TokenQueryOption};
-    /// # use ethers_core::types::Chain;
+    /// # Examples
     ///
-    /// # #[tokio::main]
-    /// # async fn main() {
-    ///     let client = Client::new(Chain::Mainnet, "API_KEY").unwrap();
-    ///     let txs = client
-    ///         .get_erc1155_token_transfer_events(
-    ///             TokenQueryOption::ByAddressAndContract(
-    ///                 "0x216CD350a4044e7016f14936663e2880Dd2A39d7".parse().unwrap(),
-    ///                 "0x495f947276749ce646f68ac8c248420045cb7b5e".parse().unwrap(),
-    ///          ), None).await.unwrap();
-    /// # }
+    /// ```no_run
+    /// use ethers_etherscan::account::TokenQueryOption;
+    ///
+    /// # async fn foo(client: ethers_etherscan::Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let address = "0x216CD350a4044e7016f14936663e2880Dd2A39d7".parse()?;
+    /// let contract = "0x495f947276749ce646f68ac8c248420045cb7b5e".parse()?;
+    /// let query = TokenQueryOption::ByAddressAndContract(address, contract);
+    /// let events = client.get_erc1155_token_transfer_events(query, None).await?;
+    /// # Ok(()) }
     /// ```
     pub async fn get_erc1155_token_transfer_events(
         &self,
@@ -702,17 +684,13 @@ impl Client {
 
     /// Returns the list of blocks mined by an address.
     ///
-    /// ```no_run
-    /// # use ethers_etherscan::Client;
-    /// # use ethers_core::types::Chain;
+    /// # Examples
     ///
-    /// # #[tokio::main]
-    /// # async fn main() {
-    ///     let client = Client::new(Chain::Mainnet, "API_KEY").unwrap();
-    ///     let blocks = client
-    ///         .get_mined_blocks(&"0x9dd134d14d1e65f84b706d6f205cd5b1cd03a46b".parse().unwrap(), None, None)
-    ///         .await.unwrap();
-    /// # }
+    /// ```no_run
+    /// # async fn foo(client: ethers_etherscan::Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let address = "0x9dd134d14d1e65f84b706d6f205cd5b1cd03a46b".parse()?;
+    /// let blocks = client.get_mined_blocks(&address, None, None).await?;
+    /// # Ok(()) }
     /// ```
     pub async fn get_mined_blocks(
         &self,

--- a/ethers-etherscan/src/contract.rs
+++ b/ethers-etherscan/src/contract.rs
@@ -312,16 +312,10 @@ impl Client {
     /// # Example
     ///
     /// ```no_run
-    /// # use ethers_etherscan::Client;
-    /// # use ethers_core::types::Chain;
-    ///
-    /// # #[tokio::main]
-    /// # async fn main() {
-    ///     let client = Client::new(Chain::Mainnet, "API_KEY").unwrap();
-    ///     let abi = client
-    ///         .contract_abi("0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413".parse().unwrap())
-    ///         .await.unwrap();
-    /// # }
+    /// # async fn foo(client: ethers_etherscan::Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let address = "0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413".parse()?;
+    /// let abi = client.contract_abi(address).await?;
+    /// # Ok(()) }
     /// ```
     pub async fn contract_abi(&self, address: Address) -> Result<Abi> {
         // apply caching
@@ -361,15 +355,11 @@ impl Client {
     /// # Example
     ///
     /// ```no_run
-    /// # use ethers_etherscan::Client;
-    /// # use ethers_core::types::Chain;
-    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new(Chain::Mainnet, "<your_api_key>")?;
+    /// # async fn foo(client: ethers_etherscan::Client) -> Result<(), Box<dyn std::error::Error>> {
     /// let address = "0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413".parse()?;
     /// let metadata = client.contract_source_code(address).await?;
     /// assert_eq!(metadata.items[0].contract_name, "DAO");
-    /// # Ok(())
-    /// # }
+    /// # Ok(()) }
     /// ```
     pub async fn contract_source_code(&self, address: Address) -> Result<ContractMetadata> {
         // apply caching

--- a/ethers-etherscan/tests/it/account.rs
+++ b/ethers-etherscan/tests/it/account.rs
@@ -23,7 +23,7 @@ async fn get_ether_balance_multi_success() {
     run_with_client(Chain::Mainnet, |client| async move {
         let balances = client
             .get_ether_balance_multi(
-                &[&"0x58eB28A67731c570Ef827C365c89B5751F9E6b0a".parse().unwrap()],
+                &["0x58eB28A67731c570Ef827C365c89B5751F9E6b0a".parse().unwrap()],
                 None,
             )
             .await;

--- a/ethers-providers/src/ext/dev_rpc.rs
+++ b/ethers-providers/src/ext/dev_rpc.rs
@@ -2,21 +2,19 @@
 //!
 //! # Example
 //!
-//!```
+//! ```no_run
 //! use ethers_providers::{Provider, Http, Middleware, DevRpcMiddleware};
 //! use ethers_core::types::TransactionRequest;
 //! use ethers_core::utils::Anvil;
-//! use std::convert::TryFrom;
 //!
-//! # #[tokio::main(flavor = "current_thread")]
-//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
 //! let anvil = Anvil::new().spawn();
-//! let provider = Provider::<Http>::try_from(anvil.endpoint()).unwrap();
+//! let provider = Provider::<Http>::try_from(anvil.endpoint())?;
 //! let client = DevRpcMiddleware::new(provider);
 //!
 //! // snapshot the initial state
-//! let block0 = client.get_block_number().await.unwrap();
-//! let snap_id = client.snapshot().await.unwrap();
+//! let block0 = client.get_block_number().await?;
+//! let snap_id = client.snapshot().await?;
 //!
 //! // send a transaction
 //! let accounts = client.get_accounts().await?;
@@ -29,12 +27,12 @@
 //! assert_eq!(balance_after, balance_before + 1000);
 //!
 //! // revert to snapshot
-//! client.revert_to_snapshot(snap_id).await.unwrap();
+//! client.revert_to_snapshot(snap_id).await?;
 //! let balance_after_revert = client.get_balance(to, None).await?;
 //! assert_eq!(balance_after_revert, balance_before);
-//! # Ok(())
-//! # }
+//! # Ok(()) }
 //! ```
+
 use crate::{Middleware, MiddlewareError, ProviderError};
 use async_trait::async_trait;
 use ethers_core::types::U256;

--- a/ethers-providers/src/middleware.rs
+++ b/ethers-providers/src/middleware.rs
@@ -225,6 +225,7 @@ pub trait Middleware: Sync + Send + Debug {
     }
 
     /// Returns the ENS name the `address` resolves to (or None if not configured).
+    ///
     /// # Panics
     ///
     /// If the bytes returned from the ENS registrar/resolver cannot be interpreted as
@@ -236,16 +237,14 @@ pub trait Middleware: Sync + Send + Debug {
     /// Returns the avatar HTTP link of the avatar that the `ens_name` resolves to (or None
     /// if not configured)
     ///
-    /// # Example
+    /// # Examples
+    ///
     /// ```no_run
-    /// # use ethers_providers::{Provider, Http as HttpProvider, Middleware};
-    /// # use std::convert::TryFrom;
-    /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() {
-    /// # let provider = Provider::<HttpProvider>::try_from("https://eth.llamarpc.com").unwrap();
-    /// let avatar = provider.resolve_avatar("parishilton.eth").await.unwrap();
+    /// # use ethers_providers::{Provider, Http, Middleware};
+    /// # async fn foo(provider: Provider<Http>) -> Result<(), Box<dyn std::error::Error>> {
+    /// let avatar = provider.resolve_avatar("parishilton.eth").await?;
     /// assert_eq!(avatar.to_string(), "https://i.imgur.com/YW3Hzph.jpg");
-    /// # }
+    /// # Ok(()) }
     /// ```
     ///
     /// # Panics
@@ -260,15 +259,16 @@ pub trait Middleware: Sync + Send + Debug {
     ///
     /// # Example
     /// ```no_run
-    /// # use ethers_providers::{Provider, Http as HttpProvider, Middleware};
-    /// # use std::{str::FromStr, convert::TryFrom};
-    /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() {
-    /// # let provider = Provider::<HttpProvider>::try_from("https://eth.llamarpc.com").unwrap();
-    /// let token = ethers_providers::erc::ERCNFT::from_str("erc721:0xc92ceddfb8dd984a89fb494c376f9a48b999aafc/9018").unwrap();
-    /// let token_image = provider.resolve_nft(token).await.unwrap();
-    /// assert_eq!(token_image.to_string(), "https://creature.mypinata.cloud/ipfs/QmNwj3aUzXfG4twV3no7hJRYxLLAWNPk6RrfQaqJ6nVJFa/9018.jpg");
-    /// # }
+    /// # use ethers_providers::{Provider, Http, Middleware};
+    /// use ethers_providers::erc::ERCNFT;
+    /// # async fn foo(provider: Provider<Http>) -> Result<(), Box<dyn std::error::Error>> {
+    /// let token = "erc721:0xc92ceddfb8dd984a89fb494c376f9a48b999aafc/9018".parse()?;
+    /// let token_image = provider.resolve_nft(token).await?;
+    /// assert_eq!(
+    ///     token_image.to_string(),
+    ///     "https://creature.mypinata.cloud/ipfs/QmNwj3aUzXfG4twV3no7hJRYxLLAWNPk6RrfQaqJ6nVJFa/9018.jpg"
+    /// );
+    /// # Ok(()) }
     /// ```
     ///
     /// # Panics

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -211,16 +211,14 @@ impl<P: JsonRpcClient> Provider<P> {
     /// [`call_raw::spoof`]: crate::call_raw::spoof
     ///
     /// # Example
+    ///
     /// ```no_run
     /// # use ethers_core::{
     /// #     types::{Address, TransactionRequest, H256},
     /// #     utils::{parse_ether, Geth},
     /// # };
     /// # use ethers_providers::{Provider, Http, Middleware, call_raw::{RawCall, spoof}};
-    /// # use std::convert::TryFrom;
-    /// #
-    /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
     /// let geth = Geth::new().spawn();
     /// let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
     ///
@@ -234,8 +232,7 @@ impl<P: JsonRpcClient> Provider<P> {
     /// // override the sender's balance for the call
     /// let mut state = spoof::balance(adr1, pay_amt * 2);
     /// provider.call_raw(&tx).state(&state).await?;
-    /// # Ok(())
-    /// # }
+    /// # Ok(()) }
     /// ```
     pub fn call_raw<'a>(&'a self, tx: &'a TypedTransaction) -> CallBuilder<'a, P> {
         CallBuilder::new(self, tx)

--- a/ethers-providers/src/toolbox/call_raw.rs
+++ b/ethers-providers/src/toolbox/call_raw.rs
@@ -329,21 +329,19 @@ pub mod spoof {
     /// Returns an empty state override set.
     ///
     /// # Example
+    ///
     /// ```no_run
     /// # use ethers_core::{
     /// #     types::{Address, TransactionRequest, H256},
     /// #     utils::{parse_ether, Geth},
     /// # };
     /// # use ethers_providers::{Provider, Http, Middleware, call_raw::{spoof, RawCall}};
-    /// # use std::convert::TryFrom;
-    /// #
-    /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
     /// let geth = Geth::new().spawn();
     /// let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
     ///
-    /// let adr1: Address = "0x6fC21092DA55B392b045eD78F4732bff3C580e2c".parse().unwrap();
-    /// let adr2: Address = "0x295a70b2de5e3953354a6a8344e616ed314d7251".parse().unwrap();
+    /// let adr1: Address = "0x6fC21092DA55B392b045eD78F4732bff3C580e2c".parse()?;
+    /// let adr2: Address = "0x295a70b2de5e3953354a6a8344e616ed314d7251".parse()?;
     /// let key = H256::from_low_u64_be(1);
     /// let val = H256::from_low_u64_be(17);
     ///
@@ -356,7 +354,7 @@ pub mod spoof {
     /// // override the nonce at `adr1`
     /// state.account(adr1).nonce(2.into());
     ///
-    /// provider.call_raw(&tx).state(&state).await.unwrap();
+    /// provider.call_raw(&tx).state(&state).await?;
     /// # Ok(())
     /// # }
     /// ```
@@ -373,10 +371,7 @@ pub mod spoof {
     /// #     utils::{parse_ether, Geth},
     /// # };
     /// # use ethers_providers::{Provider, Http, Middleware, call_raw::{RawCall, spoof}};
-    /// # use std::convert::TryFrom;
-    /// #
-    /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
     /// let geth = Geth::new().spawn();
     /// let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
     ///
@@ -408,10 +403,7 @@ pub mod spoof {
     /// #     utils::{parse_ether, Geth},
     /// # };
     /// # use ethers_providers::{Provider, Http, Middleware, call_raw::{RawCall, spoof}};
-    /// # use std::convert::TryFrom;
-    /// #
-    /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
     /// let geth = Geth::new().spawn();
     /// let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
     ///
@@ -441,10 +433,7 @@ pub mod spoof {
     /// #     utils::{parse_ether, Geth},
     /// # };
     /// # use ethers_providers::{Provider, Http, Middleware, call_raw::{RawCall, spoof}};
-    /// # use std::convert::TryFrom;
-    /// #
-    /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
     /// let geth = Geth::new().spawn();
     /// let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
     ///
@@ -469,16 +458,14 @@ pub mod spoof {
     /// and key.
     ///
     /// # Example
+    ///
     /// ```no_run
     /// # use ethers_core::{
     /// #     types::{Address, TransactionRequest, H256},
     /// #     utils::{parse_ether, Geth},
     /// # };
     /// # use ethers_providers::{Provider, Http, Middleware, call_raw::{RawCall, spoof}};
-    /// # use std::convert::TryFrom;
-    /// #
-    /// # #[tokio::main(flavor = "current_thread")]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
     /// let geth = Geth::new().spawn();
     /// let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
     ///

--- a/ethers-providers/src/toolbox/pending_transaction.rs
+++ b/ethers-providers/src/toolbox/pending_transaction.rs
@@ -24,32 +24,15 @@ use std::{
 ///
 /// # Example
 ///
-///```
-/// # use ethers_providers::{Provider, Http};
-/// # use ethers_core::utils::Anvil;
-/// # use std::convert::TryFrom;
-/// use ethers_providers::Middleware;
+/// ```ignore
 /// use ethers_core::types::TransactionRequest;
 ///
-/// # #[tokio::main(flavor = "current_thread")]
-/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// # let anvil = Anvil::new().spawn();
-/// # let client = Provider::<Http>::try_from(anvil.endpoint()).unwrap();
-/// # let accounts = client.get_accounts().await?;
-/// # let from = accounts[0];
-/// # let to = accounts[1];
-/// # let balance_before = client.get_balance(to, None).await?;
 /// let tx = TransactionRequest::new().to(to).value(1000).from(from);
 /// let receipt = client
 ///     .send_transaction(tx, None)
 ///     .await?                           // PendingTransaction<_>
 ///     .log_msg("Pending transfer hash") // print pending tx hash with message
 ///     .await?;                          // Result<Option<TransactionReceipt>, _>
-/// # let _ = receipt;
-/// # let balance_after = client.get_balance(to, None).await?;
-/// # assert_eq!(balance_after, balance_before + 1000);
-/// # Ok(())
-/// # }
 /// ```
 #[pin_project]
 pub struct PendingTransaction<'a, P> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Cleaned up doctests with `tokio::main` and `no_run`, and etherscan tests which all had redundant client initializations which are not the focus of the example

I don't believe running async tests in doctests is a great practice

Breaking change in `etherscan::Client::get_ether_balance_multi` because slice of references is not good

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
