### PR TITLE
fix: ethers_providers::is_local_endpoint with rust matching pattern on URL::parse

### DIFF
--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -1476,7 +1476,6 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
-
     use crate::Http;
     use ethers_core::{
         types::{

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -1447,7 +1447,7 @@ impl ProviderExt for Provider<HttpProvider> {
 /// assert!(is_local_endpoint("http://169.254.0.0:8545"));
 /// assert!(is_local_endpoint("http://127.0.0.1:8545"));
 /// assert!(!is_local_endpoint("http://206.71.50.230:8545"));
-/// assert!(!is_local_endpoint("blabla"));
+/// assert!(!is_local_endpoint("havenofearlucishere"));
 /// ```
 #[inline]
 pub fn is_local_endpoint(endpoint: &str) -> bool {

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -1455,7 +1455,12 @@ pub fn is_local_endpoint(endpoint: &str) -> bool {
         if let Some(host) = url.host() {
             match host {
                 Host::Domain("localhost") => return true,
-                Host::Ipv4(ipv4) => return ipv4 == Ipv4Addr::LOCALHOST || ipv4.is_link_local(),
+                Host::Ipv4(ipv4) => {
+                    return ipv4 == Ipv4Addr::LOCALHOST ||
+                        ipv4.is_link_local() ||
+                        ipv4.is_loopback() ||
+                        ipv4.is_private()
+                }
                 // skipping IPV6 check
                 _ => return false,
             }

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -1450,12 +1450,13 @@ impl ProviderExt for Provider<HttpProvider> {
 /// assert!(!is_local_endpoint("blabla"));
 /// ```
 #[inline]
-pub fn is_local_endpoint(host: &str) -> bool {
-    if let Ok(url) = Url::parse(host) {
+pub fn is_local_endpoint(endpoint: &str) -> bool {
+    if let Ok(url) = Url::parse(endpoint) {
         if let Some(host) = url.host() {
             match host {
                 Host::Domain("localhost") => return true,
                 Host::Ipv4(ipv4) => return ipv4 == Ipv4Addr::LOCALHOST || ipv4.is_link_local(),
+                // skipping IPV6 check
                 _ => return false,
             }
         }


### PR DESCRIPTION
Related to #2346 and foundry issue [#4658](https://github.com/foundry-rs/foundry/issues/4658)

## Motivation

`ethers_providers::is_local_endpoint` function would only work with `localhost` and `127.0.0.1` strings.

## Solution

From substring matching to rust pattern matching based on `URL::parse` result.

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
