### PR TITLE
 fix(core): add from_x_or_hex to remaining genesis fields 

### DIFF
--- a/ethers-core/src/types/fee.rs
+++ b/ethers-core/src/types/fee.rs
@@ -1,4 +1,4 @@
-use crate::{types::U256, utils::from_int_or_hex};
+use crate::types::{serde_helpers::deserialize_stringified_numeric, U256};
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub struct FeeHistory {
     pub base_fee_per_gas: Vec<U256>,
     pub gas_used_ratio: Vec<f64>,
-    #[serde(deserialize_with = "from_int_or_hex")]
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     /// oldestBlock is returned as an unsigned integer up to geth v1.10.6. From
     /// geth v1.10.7, this has been updated to return in the hex encoded form.
     /// The custom deserializer allows backward compatibility for those clients

--- a/ethers-core/src/types/serde_helpers.rs
+++ b/ethers-core/src/types/serde_helpers.rs
@@ -44,7 +44,7 @@ impl FromStr for Numeric {
 pub enum StringifiedNumeric {
     String(String),
     U256(U256),
-    Num(u64),
+    Num(serde_json::Number),
 }
 
 impl TryFrom<StringifiedNumeric> for U256 {
@@ -53,7 +53,9 @@ impl TryFrom<StringifiedNumeric> for U256 {
     fn try_from(value: StringifiedNumeric) -> Result<Self, Self::Error> {
         match value {
             StringifiedNumeric::U256(n) => Ok(n),
-            StringifiedNumeric::Num(n) => Ok(U256::from(n)),
+            StringifiedNumeric::Num(n) => {
+                Ok(U256::from_dec_str(&n.to_string()).map_err(|err| err.to_string())?)
+            }
             StringifiedNumeric::String(s) => {
                 if let Ok(val) = s.parse::<u128>() {
                     Ok(val.into())

--- a/ethers-core/src/types/serde_helpers.rs
+++ b/ethers-core/src/types/serde_helpers.rs
@@ -119,7 +119,7 @@ where
     num.try_into().map_err(serde::de::Error::custom)
 }
 
-/// Supports parsing ethereum-types Option<U64>
+/// Supports parsing ethereum-types `Option<U64>`
 ///
 /// See <https://github.com/gakonst/ethers-rs/issues/1507>
 pub fn deserialize_stringified_eth_u64_opt<'de, D>(deserializer: D) -> Result<Option<U64>, D::Error>

--- a/ethers-core/src/types/trace/geth.rs
+++ b/ethers-core/src/types/trace/geth.rs
@@ -9,10 +9,7 @@ pub use self::{
     noop::NoopFrame,
     pre_state::{PreStateConfig, PreStateFrame},
 };
-use crate::{
-    types::{Bytes, H256, U256},
-    utils::from_int_or_hex,
-};
+use crate::types::{serde_helpers::deserialize_stringified_numeric, Bytes, H256, U256};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -21,7 +18,7 @@ use std::collections::BTreeMap;
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DefaultFrame {
     pub failed: bool,
-    #[serde(deserialize_with = "from_int_or_hex")]
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub gas: U256,
     #[serde(rename = "returnValue")]
     pub return_value: Bytes,

--- a/ethers-core/src/types/trace/geth/call.rs
+++ b/ethers-core/src/types/trace/geth/call.rs
@@ -1,6 +1,6 @@
-use crate::{
-    types::{Address, Bytes, NameOrAddress, H256, U256},
-    utils::from_int_or_hex,
+use crate::types::{
+    serde_helpers::{deserialize_stringified_numeric, deserialize_stringified_numeric_opt},
+    Address, Bytes, NameOrAddress, H256, U256,
 };
 use serde::{Deserialize, Serialize};
 
@@ -12,11 +12,15 @@ pub struct CallFrame {
     pub from: Address,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub to: Option<NameOrAddress>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_stringified_numeric_opt",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub value: Option<U256>,
-    #[serde(default, deserialize_with = "from_int_or_hex")]
+    #[serde(default, deserialize_with = "deserialize_stringified_numeric")]
     pub gas: U256,
-    #[serde(default, deserialize_with = "from_int_or_hex", rename = "gasUsed")]
+    #[serde(default, deserialize_with = "deserialize_stringified_numeric", rename = "gasUsed")]
     pub gas_used: U256,
     pub input: Bytes,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/ethers-core/src/types/trace/geth/pre_state.rs
+++ b/ethers-core/src/types/trace/geth/pre_state.rs
@@ -1,7 +1,4 @@
-use crate::{
-    types::{Address, H256, U256},
-    utils::from_int_or_hex_opt,
-};
+use crate::types::{serde_helpers::deserialize_stringified_numeric_opt, Address, H256, U256};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -26,7 +23,7 @@ pub struct DiffMode {
 pub struct AccountState {
     #[serde(
         default,
-        deserialize_with = "from_int_or_hex_opt",
+        deserialize_with = "deserialize_stringified_numeric_opt",
         skip_serializing_if = "Option::is_none"
     )]
     pub balance: Option<U256>,
@@ -34,7 +31,7 @@ pub struct AccountState {
     pub code: Option<String>,
     #[serde(
         default,
-        deserialize_with = "from_int_or_hex_opt",
+        deserialize_with = "deserialize_stringified_numeric_opt",
         skip_serializing_if = "Option::is_none"
     )]
     pub nonce: Option<U256>,

--- a/ethers-core/src/utils/genesis.rs
+++ b/ethers-core/src/utils/genesis.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use crate::{
     types::{Address, Bytes, H256, U256, U64},
-    utils::{from_int_or_hex, from_int_or_hex_opt, from_u64_or_hex_opt, from_unformatted_hex_map},
+    utils::{
+        from_int_or_hex, from_int_or_hex_opt, from_u64_or_hex, from_u64_or_hex_opt,
+        from_unformatted_hex_map,
+    },
 };
 use serde::{Deserialize, Serialize};
 
@@ -16,11 +19,11 @@ pub struct Genesis {
     pub config: ChainConfig,
 
     /// The genesis header nonce.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "from_u64_or_hex")]
     pub nonce: U64,
 
     /// The genesis header timestamp.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "from_u64_or_hex")]
     pub timestamp: U64,
 
     /// The genesis header extra data.
@@ -28,6 +31,7 @@ pub struct Genesis {
     pub extra_data: Bytes,
 
     /// The genesis header gas limit.
+    #[serde(default, deserialize_with = "from_u64_or_hex")]
     pub gas_limit: U64,
 
     /// The genesis header difficulty.
@@ -48,11 +52,19 @@ pub struct Genesis {
     // The following fields are only included for tests, and should not be used in real genesis
     // blocks.
     /// The block number
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "from_u64_or_hex_opt",
+        default
+    )]
     pub number: Option<U64>,
 
     /// The block gas gasUsed
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "from_u64_or_hex_opt",
+        default
+    )]
     pub gas_used: Option<U64>,
 
     /// The block parent hash
@@ -60,7 +72,11 @@ pub struct Genesis {
     pub parent_hash: Option<H256>,
 
     /// The base fee
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "from_int_or_hex_opt",
+        default
+    )]
     pub base_fee_per_gas: Option<U256>,
 }
 

--- a/ethers-core/src/utils/genesis.rs
+++ b/ethers-core/src/utils/genesis.rs
@@ -1,11 +1,15 @@
 use std::collections::HashMap;
 
 use crate::{
-    types::{Address, Bytes, H256, U256, U64},
-    utils::{
-        from_int_or_hex, from_int_or_hex_opt, from_u64_or_hex, from_u64_or_hex_opt,
-        from_unformatted_hex_map,
+    types::{
+        serde_helpers::{
+            deserialize_stringified_eth_u64, deserialize_stringified_eth_u64_opt,
+            deserialize_stringified_numeric, deserialize_stringified_numeric_opt,
+            deserialize_stringified_u64_opt,
+        },
+        Address, Bytes, H256, U256, U64,
     },
+    utils::from_unformatted_hex_map,
 };
 use serde::{Deserialize, Serialize};
 
@@ -19,11 +23,11 @@ pub struct Genesis {
     pub config: ChainConfig,
 
     /// The genesis header nonce.
-    #[serde(default, deserialize_with = "from_u64_or_hex")]
+    #[serde(default, deserialize_with = "deserialize_stringified_eth_u64")]
     pub nonce: U64,
 
     /// The genesis header timestamp.
-    #[serde(default, deserialize_with = "from_u64_or_hex")]
+    #[serde(default, deserialize_with = "deserialize_stringified_eth_u64")]
     pub timestamp: U64,
 
     /// The genesis header extra data.
@@ -31,11 +35,11 @@ pub struct Genesis {
     pub extra_data: Bytes,
 
     /// The genesis header gas limit.
-    #[serde(default, deserialize_with = "from_u64_or_hex")]
+    #[serde(default, deserialize_with = "deserialize_stringified_eth_u64")]
     pub gas_limit: U64,
 
     /// The genesis header difficulty.
-    #[serde(deserialize_with = "from_int_or_hex")]
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub difficulty: U256,
 
     /// The genesis header mix hash.
@@ -54,7 +58,7 @@ pub struct Genesis {
     /// The block number
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "from_u64_or_hex_opt",
+        deserialize_with = "deserialize_stringified_eth_u64_opt",
         default
     )]
     pub number: Option<U64>,
@@ -62,7 +66,7 @@ pub struct Genesis {
     /// The block gas gasUsed
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "from_u64_or_hex_opt",
+        deserialize_with = "deserialize_stringified_eth_u64_opt",
         default
     )]
     pub gas_used: Option<U64>,
@@ -74,7 +78,7 @@ pub struct Genesis {
     /// The base fee
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "from_int_or_hex_opt",
+        deserialize_with = "deserialize_stringified_numeric_opt",
         default
     )]
     pub base_fee_per_gas: Option<U256>,
@@ -142,11 +146,11 @@ impl Genesis {
 pub struct GenesisAccount {
     #[serde(
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "from_u64_or_hex_opt",
+        deserialize_with = "deserialize_stringified_u64_opt",
         default
     )]
     pub nonce: Option<u64>,
-    #[serde(deserialize_with = "from_int_or_hex")]
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub balance: U256,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub code: Option<Bytes>,
@@ -171,18 +175,27 @@ pub struct ChainConfig {
     pub chain_id: u64,
 
     /// The homestead switch block (None = no fork, 0 = already homestead).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub homestead_block: Option<u64>,
 
     /// The DAO fork switch block (None = no fork).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub dao_fork_block: Option<u64>,
 
     /// Whether or not the node supports the DAO hard-fork.
     pub dao_fork_support: bool,
 
     /// The EIP-150 hard fork block (None = no fork).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub eip150_block: Option<u64>,
 
     /// The EIP-150 hard fork hash.
@@ -190,63 +203,108 @@ pub struct ChainConfig {
     pub eip150_hash: Option<H256>,
 
     /// The EIP-155 hard fork block.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub eip155_block: Option<u64>,
 
     /// The EIP-158 hard fork block.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub eip158_block: Option<u64>,
 
     /// The Byzantium hard fork block.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub byzantium_block: Option<u64>,
 
     /// The Constantinople hard fork block.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub constantinople_block: Option<u64>,
 
     /// The Petersburg hard fork block.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub petersburg_block: Option<u64>,
 
     /// The Istanbul hard fork block.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub istanbul_block: Option<u64>,
 
     /// The Muir Glacier hard fork block.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub muir_glacier_block: Option<u64>,
 
     /// The Berlin hard fork block.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub berlin_block: Option<u64>,
 
     /// The London hard fork block.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub london_block: Option<u64>,
 
     /// The Arrow Glacier hard fork block.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub arrow_glacier_block: Option<u64>,
 
     /// The Gray Glacier hard fork block.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub gray_glacier_block: Option<u64>,
 
     /// Virtual fork after the merge to use as a network splitter.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub merge_netsplit_block: Option<u64>,
 
     /// Shanghai switch time.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub shanghai_time: Option<u64>,
 
     /// Cancun switch time.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub cancun_time: Option<u64>,
 
     /// Total difficulty reached that triggers the merge consensus upgrade.
-    #[serde(skip_serializing_if = "Option::is_none", deserialize_with = "from_int_or_hex_opt")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_numeric_opt"
+    )]
     pub terminal_total_difficulty: Option<U256>,
 
     /// A flag specifying that the network already passed the terminal total difficulty. Its
@@ -276,11 +334,19 @@ pub struct EthashConfig {}
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct CliqueConfig {
     /// Number of seconds between blocks to enforce.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub period: Option<u64>,
 
     /// Epoch length to reset votes and checkpoints.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_stringified_u64_opt"
+    )]
     pub epoch: Option<u64>,
 }
 

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -525,6 +525,7 @@ where
             if s.starts_with("0x") {
                 U256::from_str(s.as_str()).map_err(serde::de::Error::custom)
             } else {
+                // if there is no 0x prefix, this is a decimal string
                 U256::from_dec_str(&s).map_err(serde::de::Error::custom)
             }
         }
@@ -540,20 +541,21 @@ where
 {
     #[derive(Deserialize)]
     #[serde(untagged)]
-    enum IntOrHex {
+    enum IntOrString {
         Int(serde_json::Number),
-        Hex(String),
+        JsonString(String),
     }
 
-    match IntOrHex::deserialize(deserializer)? {
-        IntOrHex::Hex(s) => {
+    match IntOrString::deserialize(deserializer)? {
+        IntOrString::JsonString(s) => {
             if s.starts_with("0x") {
                 U64::from_str(s.as_str()).map_err(serde::de::Error::custom)
             } else {
+                // if there is no 0x prefix, this is a decimal string
                 U64::from_dec_str(&s).map_err(serde::de::Error::custom)
             }
         }
-        IntOrHex::Int(n) => U64::from_dec_str(&n.to_string()).map_err(serde::de::Error::custom),
+        IntOrString::Int(n) => U64::from_dec_str(&n.to_string()).map_err(serde::de::Error::custom),
     }
 }
 

--- a/ethers-providers/src/ext/admin.rs
+++ b/ethers-providers/src/ext/admin.rs
@@ -1,7 +1,7 @@
 use enr::{k256::ecdsa::SigningKey, Enr};
 use ethers_core::{
-    types::{H256, U256},
-    utils::{from_int_or_hex, ChainConfig},
+    types::{serde_helpers::deserialize_stringified_numeric, H256, U256},
+    utils::ChainConfig,
 };
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, SocketAddr};
@@ -71,7 +71,7 @@ pub struct EthProtocolInfo {
     pub network: u64,
 
     /// The total difficulty of the host's blockchain.
-    #[serde(deserialize_with = "from_int_or_hex")]
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub difficulty: U256,
 
     /// The Keccak hash of the host's genesis block.
@@ -131,7 +131,7 @@ pub struct EthInfo {
     pub version: u64,
 
     /// The total difficulty of the peer's blockchain.
-    #[serde(deserialize_with = "from_int_or_hex")]
+    #[serde(deserialize_with = "deserialize_stringified_numeric")]
     pub difficulty: U256,
 
     /// The hash of the peer's best known block.


### PR DESCRIPTION
## Motivation

Some fields were missed for `Genesis` decimal string deserialization.

## Solution

Followup to #2359, adding remaining deserializers to `Genesis` fields.

This changes usages of `from_int_or_hex` to `deserialize_stringified_numeric`, and removes the `from_int_or_hex` methods.

Modifies `StringifiedNumeric` to support arbitrary precision.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
