### PR TITLE
feat: add geth debug_traceBlock methods

### DIFF
--- a/ethers-core/src/types/trace/geth.rs
+++ b/ethers-core/src/types/trace/geth.rs
@@ -90,9 +90,30 @@ impl From<NoopFrame> for GethTraceFrame {
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
+pub enum GethTraceResult {
+    ResultKnown{result: GethTraceFrame},
+    ResultUnknown{result: Value},
+    DefaultKnown(GethTraceFrame),
+    DefaultUnknown(Value),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
+#[serde(from = "GethTraceResult")]
+#[serde(untagged)]
 pub enum GethTrace {
     Known(GethTraceFrame),
     Unknown(Value),
+}
+
+impl From<GethTraceResult> for GethTrace {
+    fn from(value: GethTraceResult) -> Self {
+        match value {
+            GethTraceResult::DefaultKnown(t) => GethTrace::Known(t),
+            GethTraceResult::DefaultUnknown(v) => GethTrace::Unknown(v),
+            GethTraceResult::ResultKnown{result} => GethTrace::Known(result),
+            GethTraceResult::ResultUnknown{result} => GethTrace::Unknown(result),
+        }
+    }
 }
 
 impl From<GethTraceFrame> for GethTrace {

--- a/ethers-core/src/types/trace/geth.rs
+++ b/ethers-core/src/types/trace/geth.rs
@@ -90,7 +90,7 @@ impl From<NoopFrame> for GethTraceFrame {
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum GethTraceResult {
+enum GethTraceResult {
     ResultKnown { result: GethTraceFrame },
     ResultUnknown { result: Value },
     DefaultKnown(GethTraceFrame),

--- a/ethers-core/src/types/trace/geth.rs
+++ b/ethers-core/src/types/trace/geth.rs
@@ -91,8 +91,8 @@ impl From<NoopFrame> for GethTraceFrame {
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GethTraceResult {
-    ResultKnown{result: GethTraceFrame},
-    ResultUnknown{result: Value},
+    ResultKnown { result: GethTraceFrame },
+    ResultUnknown { result: Value },
     DefaultKnown(GethTraceFrame),
     DefaultUnknown(Value),
 }
@@ -110,8 +110,8 @@ impl From<GethTraceResult> for GethTrace {
         match value {
             GethTraceResult::DefaultKnown(t) => GethTrace::Known(t),
             GethTraceResult::DefaultUnknown(v) => GethTrace::Unknown(v),
-            GethTraceResult::ResultKnown{result} => GethTrace::Known(result),
-            GethTraceResult::ResultUnknown{result} => GethTrace::Unknown(result),
+            GethTraceResult::ResultKnown { result } => GethTrace::Known(result),
+            GethTraceResult::ResultUnknown { result } => GethTrace::Unknown(result),
         }
     }
 }

--- a/ethers-providers/src/middleware.rs
+++ b/ethers-providers/src/middleware.rs
@@ -738,6 +738,36 @@ pub trait Middleware: Sync + Send + Debug {
             .map_err(MiddlewareError::from_err)
     }
 
+    /// Replays all transactions in a given block (specified by block number) and returns the traces
+    /// configured with passed options
+    /// Ref:
+    /// [Here](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debugtraceblockbynumber)
+    async fn debug_trace_block_by_number(
+        &self,
+        block: Option<BlockNumber>,
+        trace_options: GethDebugTracingOptions,
+    ) -> Result<Vec<GethTrace>, Self::Error> {
+        self.inner()
+            .debug_trace_block_by_number(block, trace_options)
+            .await
+            .map_err(MiddlewareError::from_err)
+    }
+
+    /// Replays all transactions in a given block (specified by block hash) and returns the traces
+    /// configured with passed options
+    /// Ref:
+    /// [Here](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debugtraceblockbyhash)
+    async fn debug_trace_block_by_hash(
+        &self,
+        block: H256,
+        trace_options: GethDebugTracingOptions,
+    ) -> Result<Vec<GethTrace>, Self::Error> {
+        self.inner()
+            .debug_trace_block_by_hash(block, trace_options)
+            .await
+            .map_err(MiddlewareError::from_err)
+    }
+
     // Parity `trace` support
 
     /// Executes the given call and returns a number of possible traces for it

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -908,6 +908,26 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.request("debug_traceCall", [req, block, trace_options]).await
     }
 
+    async fn debug_trace_block_by_number(
+        &self,
+        block: Option<BlockNumber>,
+        trace_options: GethDebugTracingOptions,
+    ) -> Result<Vec<GethTrace>, ProviderError> {
+        let block = utils::serialize(&block.unwrap_or(BlockNumber::Latest));
+        let trace_options = utils::serialize(&trace_options);
+        self.request("debug_traceBlockByNumber", [block, trace_options]).await
+    }
+
+    async fn debug_trace_block_by_hash(
+        &self,
+        block: H256,
+        trace_options: GethDebugTracingOptions,
+    ) -> Result<Vec<GethTrace>, ProviderError> {
+        let block = utils::serialize(&block);
+        let trace_options = utils::serialize(&trace_options);
+        self.request("debug_traceBlockByHash", [block, trace_options]).await
+    }
+
     async fn trace_call<T: Into<TypedTransaction> + Send + Sync>(
         &self,
         req: T,
@@ -1457,7 +1477,9 @@ mod tests {
     use crate::Http;
     use ethers_core::{
         types::{
-            transaction::eip2930::AccessList, Eip1559TransactionRequest, TransactionRequest, H256,
+            transaction::eip2930::AccessList, Eip1559TransactionRequest,
+            GethDebugBuiltInTracerConfig, GethDebugBuiltInTracerType, GethDebugTracerConfig,
+            GethDebugTracerType, PreStateConfig, TransactionRequest, H256,
         },
         utils::{Anvil, Genesis, Geth, GethInstance},
     };
@@ -1633,6 +1655,41 @@ mod tests {
         let provider = Provider::<Http>::try_from(url.as_str()).unwrap();
         let receipts = provider.parity_block_receipts(10657200).await.unwrap();
         assert!(!receipts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn debug_trace_block() {
+        let provider = Provider::<Http>::try_from("https://eth.llamarpc.com").unwrap();
+
+        let mut opts = GethDebugTracingOptions::default();
+        opts.disable_storage = Some(false);
+        opts.tracer =
+            Some(GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::PreStateTracer));
+        opts.tracer_config = Some(GethDebugTracerConfig::BuiltInTracer(
+            GethDebugBuiltInTracerConfig::PreStateTracer(PreStateConfig { diff_mode: Some(true) }),
+        ));
+
+        let latest_block = provider.get_block(BlockNumber::Latest).await.unwrap().unwrap();
+
+        // debug_traceBlockByNumber
+        let latest_block_num = BlockNumber::Number(latest_block.number.unwrap());
+        let traces_by_num = provider
+            .debug_trace_block_by_number(Some(latest_block_num), opts.clone())
+            .await
+            .unwrap();
+        for trace in &traces_by_num {
+            assert!(matches!(trace, GethTrace::Known(..)));
+        }
+
+        // debug_traceBlockByHash
+        let latest_block_hash = latest_block.hash.unwrap();
+        let traces_by_hash =
+            provider.debug_trace_block_by_hash(latest_block_hash, opts).await.unwrap();
+        for trace in &traces_by_hash {
+            assert!(matches!(trace, GethTrace::Known(..)));
+        }
+
+        assert_eq!(traces_by_num, traces_by_hash);
     }
 
     #[tokio::test]

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -1658,18 +1658,28 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(feature = "celo", ignore)]
     async fn debug_trace_block() {
         let provider = Provider::<Http>::try_from("https://eth.llamarpc.com").unwrap();
 
-        let mut opts = GethDebugTracingOptions::default();
-        opts.disable_storage = Some(false);
-        opts.tracer =
-            Some(GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::PreStateTracer));
-        opts.tracer_config = Some(GethDebugTracerConfig::BuiltInTracer(
-            GethDebugBuiltInTracerConfig::PreStateTracer(PreStateConfig { diff_mode: Some(true) }),
-        ));
+        let opts = GethDebugTracingOptions {
+            disable_storage: Some(false),
+            tracer: Some(GethDebugTracerType::BuiltInTracer(
+                GethDebugBuiltInTracerType::PreStateTracer,
+            )),
+            tracer_config: Some(GethDebugTracerConfig::BuiltInTracer(
+                GethDebugBuiltInTracerConfig::PreStateTracer(PreStateConfig {
+                    diff_mode: Some(true),
+                }),
+            )),
+            ..Default::default()
+        };
 
-        let latest_block = provider.get_block(BlockNumber::Latest).await.unwrap().unwrap();
+        let latest_block = provider
+            .get_block(BlockNumber::Latest)
+            .await
+            .expect("Failed to fetch latest block.")
+            .expect("Latest block is none.");
 
         // debug_traceBlockByNumber
         let latest_block_num = BlockNumber::Number(latest_block.number.unwrap());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Support for more Geth `debug` methods.

## Solution

Adds [`debug_traceBlockByNumber`](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debugtraceblockbynumber) and [`debug_traceBlockByHash`](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debugtraceblockbyhash) RPC methods.

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
