### PR TITLE
feat(solc): color when formatting Error and OutputDiagnostics

### DIFF
--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -2060,9 +2060,9 @@ impl FromStr for Severity {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "error" => Ok(Self::Error),
-            "warning" => Ok(Self::Warning),
-            "info" => Ok(Self::Info),
+            "Error" | "error" => Ok(Self::Error),
+            "Warning" | "warning" => Ok(Self::Warning),
+            "Info" | "info" => Ok(Self::Info),
             s => Err(format!("Invalid severity: {s}")),
         }
     }

--- a/ethers-solc/src/compile/output/mod.rs
+++ b/ethers-solc/src/compile/output/mod.rs
@@ -752,13 +752,10 @@ impl<'a> OutputDiagnostics<'a> {
 
 impl<'a> fmt::Display for OutputDiagnostics<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let has_error = self.has_error();
-        let has_warning = self.has_warning();
-
         f.write_str("Compiler run ")?;
-        if has_error {
+        if self.has_error() {
             Paint::red("failed:")
-        } else if has_warning {
+        } else if self.has_warning() {
             Paint::yellow("successful with warnings:")
         } else {
             Paint::green("successful!")

--- a/ethers-solc/src/compile/output/mod.rs
+++ b/ethers-solc/src/compile/output/mod.rs
@@ -402,7 +402,7 @@ impl<T: ArtifactOutput> fmt::Display for ProjectCompileOutput<T> {
             f.write_str("Nothing to compile")
         } else {
             self.compiler_output
-                .diagnostics(&self.ignored_error_codes, self.compiler_severity_filter.clone())
+                .diagnostics(&self.ignored_error_codes, self.compiler_severity_filter)
                 .fmt(f)
         }
     }

--- a/ethers-solc/src/compile/output/mod.rs
+++ b/ethers-solc/src/compile/output/mod.rs
@@ -14,6 +14,7 @@ use contracts::{VersionedContract, VersionedContracts};
 use semver::Version;
 use std::{collections::BTreeMap, fmt, path::Path};
 use tracing::trace;
+use yansi::Paint;
 
 pub mod contracts;
 pub mod info;
@@ -751,35 +752,41 @@ impl<'a> OutputDiagnostics<'a> {
 
 impl<'a> fmt::Display for OutputDiagnostics<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.has_error() {
-            f.write_str("Compiler run failed")?;
-        } else if self.has_warning() {
-            f.write_str("Compiler run successful (with warnings)")?;
+        let has_error = self.has_error();
+        let has_warning = self.has_warning();
+
+        f.write_str("Compiler run ")?;
+        if has_error {
+            Paint::red("failed:")
+        } else if has_warning {
+            Paint::yellow("successful with warnings:")
         } else {
-            f.write_str("Compiler run successful")?;
+            Paint::green("successful!")
         }
+        .fmt(f)?;
+
         for err in &self.compiler_output.errors {
+            let mut ignored = false;
             if err.severity.is_warning() {
-                let is_ignored = err.error_code.as_ref().map_or(false, |code| {
+                if let Some(code) = err.error_code {
                     if let Some(source_location) = &err.source_location {
                         // we ignore spdx and contract size warnings in test
                         // files. if we are looking at one of these warnings
                         // from a test file we skip
-                        if self.is_test(&source_location.file) && (*code == 1878 || *code == 5574) {
-                            return true
-                        }
+                        ignored =
+                            self.is_test(&source_location.file) && (code == 1878 || code == 5574);
                     }
 
-                    self.ignored_error_codes.contains(code)
-                });
-
-                if !is_ignored {
-                    writeln!(f, "\n{err}")?;
+                    ignored |= self.ignored_error_codes.contains(&code);
                 }
-            } else {
-                writeln!(f, "\n{err}")?;
+            }
+
+            if !ignored {
+                f.write_str("\n")?;
+                err.fmt(f)?;
             }
         }
+
         Ok(())
     }
 }

--- a/ethers-solc/src/compile/project.rs
+++ b/ethers-solc/src/compile/project.rs
@@ -361,7 +361,7 @@ impl<'a, T: ArtifactOutput> ArtifactsState<'a, T> {
         let ArtifactsState { output, cache, compiled_artifacts } = self;
         let project = cache.project();
         let ignored_error_codes = project.ignored_error_codes.clone();
-        let compiler_severity_filter = project.compiler_severity_filter.clone();
+        let compiler_severity_filter = project.compiler_severity_filter;
         let has_error = output.has_error(&ignored_error_codes, &compiler_severity_filter);
         let skip_write_to_disk = project.no_artifacts || has_error;
         trace!(has_error, project.no_artifacts, skip_write_to_disk, cache_path=?project.cache_path(),"prepare writing cache file");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Monotone color ugly and bad. More colors good.

Tried as much as possible to use the same format as [Solc's formatter](https://github.com/ethereum/solidity/blob/a297a687261a1c634551b1dac0e36d4573c19afe/liblangutil/SourceReferenceFormatter.cpp#L105).

Before:

![image](https://user-images.githubusercontent.com/57450786/233617639-cfbd3f68-fe0e-43d7-9175-05a07e3319b1.png)

After (left: `solc --error-codes`, right: this):

![2023-04-21_11-55-32](https://user-images.githubusercontent.com/57450786/233612864-b8b9539d-433a-43a9-85e4-343796205d1b.png)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->


## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
