### PR TITLE
feat(ws): add methods taking in a tungstenite config

### DIFF
--- a/ethers-providers/src/rpc/transports/ws/backend.rs
+++ b/ethers-providers/src/rpc/transports/ws/backend.rs
@@ -69,6 +69,15 @@ impl WsBackend {
         Ok(Self::new(ws))
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    pub async fn connect_with_config(
+        details: ConnectionDetails,
+        config: WebSocketConfig,
+    ) -> Result<(Self, BackendDriver), WsClientError> {
+        let ws = connect_async_with_config(details, Some(config)).await?.0.fuse();
+        Ok(Self::new(ws))
+    }
+
     pub fn new(server: InternalStream) -> (Self, BackendDriver) {
         let (handler, to_handle) = mpsc::unbounded();
         let (dispatcher, to_dispatch) = mpsc::unbounded();

--- a/ethers-providers/src/rpc/transports/ws/manager.rs
+++ b/ethers-providers/src/rpc/transports/ws/manager.rs
@@ -241,10 +241,10 @@ impl RequestManager {
         Self::connect_with_reconnects_and_config(conn, DEFAULT_RECONNECTS, config).await
     }
 
-    pub async fn connect_with_reconnects_and_config(
+    pub async fn connect_with_config_and_reconnects(
         conn: ConnectionDetails,
-        reconnects: usize,
         config: WebSocketConfig,
+        reconnects: usize,
     ) -> Result<(Self, WsClient), WsClientError> {
         let (ws, backend) = WsBackend::connect_with_config(conn.clone(), config).await?;
 

--- a/ethers-providers/src/rpc/transports/ws/mod.rs
+++ b/ethers-providers/src/rpc/transports/ws/mod.rs
@@ -50,6 +50,34 @@ impl WsClient {
         Ok(this)
     }
 
+    /// Establishes a new websocket connection. This method allows specifying a custom websocket
+    /// configuration.
+    pub async fn connect_with_config(
+        conn: impl Into<ConnectionDetails>,
+        config: impl Into<WebSocketConfig>,
+    ) -> Result<Self, WsClientError> {
+        let (man, this) = RequestManager::connect_with_config(conn.into(), config.into()).await?;
+        man.spawn();
+        Ok(this)
+    }
+
+    /// Establishes a new websocket connection with auto-reconnects. This method allows specifying a
+    /// custom websocket configuration.
+    pub async fn connect_with_reconnects_and_config(
+        conn: impl Into<ConnectionDetails>,
+        reconnects: usize,
+        config: impl Into<WebSocketConfig>,
+    ) -> Result<Self, WsClientError> {
+        let (man, this) = RequestManager::connect_with_reconnects_and_config(
+            conn.into(),
+            reconnects,
+            config.into(),
+        )
+        .await?;
+        man.spawn();
+        Ok(this)
+    }
+
     #[tracing::instrument(skip(self, params), err)]
     async fn make_request<R>(&self, method: &str, params: Box<RawValue>) -> Result<R, WsClientError>
     where

--- a/ethers-providers/src/rpc/transports/ws/mod.rs
+++ b/ethers-providers/src/rpc/transports/ws/mod.rs
@@ -50,6 +50,7 @@ impl WsClient {
         Ok(this)
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     /// Establishes a new websocket connection. This method allows specifying a custom websocket
     /// configuration, see the [tungstenite docs](https://docs.rs/tungstenite/latest/tungstenite/protocol/struct.WebSocketConfig.html) for all avaible options.
     pub async fn connect_with_config(
@@ -61,6 +62,7 @@ impl WsClient {
         Ok(this)
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     /// Establishes a new websocket connection with auto-reconnects. This method allows specifying a
     /// custom websocket configuration, see the [tungstenite docs](https://docs.rs/tungstenite/latest/tungstenite/protocol/struct.WebSocketConfig.html) for all avaible options.
     pub async fn connect_with_config_and_reconnects(

--- a/ethers-providers/src/rpc/transports/ws/mod.rs
+++ b/ethers-providers/src/rpc/transports/ws/mod.rs
@@ -51,7 +51,7 @@ impl WsClient {
     }
 
     /// Establishes a new websocket connection. This method allows specifying a custom websocket
-    /// configuration.
+    /// configuration, see the [tungstenite docs](https://docs.rs/tungstenite/latest/tungstenite/protocol/struct.WebSocketConfig.html) for all avaible options.
     pub async fn connect_with_config(
         conn: impl Into<ConnectionDetails>,
         config: impl Into<WebSocketConfig>,
@@ -62,16 +62,16 @@ impl WsClient {
     }
 
     /// Establishes a new websocket connection with auto-reconnects. This method allows specifying a
-    /// custom websocket configuration.
-    pub async fn connect_with_reconnects_and_config(
+    /// custom websocket configuration, see the [tungstenite docs](https://docs.rs/tungstenite/latest/tungstenite/protocol/struct.WebSocketConfig.html) for all avaible options.
+    pub async fn connect_with_config_and_reconnects(
         conn: impl Into<ConnectionDetails>,
-        reconnects: usize,
         config: impl Into<WebSocketConfig>,
+        reconnects: usize,
     ) -> Result<Self, WsClientError> {
-        let (man, this) = RequestManager::connect_with_reconnects_and_config(
+        let (man, this) = RequestManager::connect_with_config_and_reconnects(
             conn.into(),
-            reconnects,
             config.into(),
+            reconnects,
         )
         .await?;
         man.spawn();

--- a/ethers-providers/src/rpc/transports/ws/types.rs
+++ b/ethers-providers/src/rpc/transports/ws/types.rs
@@ -257,10 +257,11 @@ mod aliases {
 #[cfg(not(target_arch = "wasm32"))]
 mod aliases {
     pub use tokio_tungstenite::{
-        connect_async,
+        connect_async, connect_async_with_config,
         tungstenite::{self, protocol::CloseFrame},
     };
     use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+    pub type WebSocketConfig = tungstenite::protocol::WebSocketConfig;
     pub type Message = tungstenite::protocol::Message;
     pub type WsError = tungstenite::Error;
     pub type WsStreamItem = Result<Message, WsError>;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Currently the websocket implementation does not allow to pass in a custom Tungestenite config. For example, its not possible to increase the default msg size over the Tungestenite default, which can lead to `Message Too Long` errors if fetching a lot of events with a lot of fields in them, one case where I've seen this failure in practice is when fetching around 8k events like this one:
```solidity
    event TradeRequested(
        address indexed tokenIn,
        address tokenOut,
        uint256 amountIn,
        uint256 minAmountOut,
        address recipient,
        uint256 indexed tradeIndex,
        address indexed trader
    );
```

## Solution

This PR adds 2 new methods to the `WsClient` and the `WsManager`:
- `connect_with_config` which is the same as `connect`, but allows taking in a Tungstenite config object
- `connect_with_config_and_reconnects` which is the same as `connect_with_reconnects`, but allows taking in a Tungstenite config object.

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
