### PR TITLE
Fix `wast` field is missing

### DIFF
--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -1779,6 +1779,7 @@ pub struct Creation {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Ewasm {
+    #[serde(default)]
     pub wast: String,
     pub wasm: String,
 }

--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -1779,8 +1779,8 @@ pub struct Creation {
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Ewasm {
-    #[serde(default)]
-    pub wast: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wast: Option<String>,
     pub wasm: String,
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

The `wast` field maybe missing in solc compiler output.

JSON input:

```json
{
    "language": "Solidity",
    "sources": {
        "src/tfuzz.sol": {
            "content": "contract T{}"
        }
    },
    "settings": {
        "optimizer": {
            "enabled": false,
            "runs": 200
        },
        "outputSelection": {
            "*": {
                "": [
                    "*"
                ],
                "*": [
                    "*"
                ]
            }
        },
        "evmVersion": "london",
        "libraries": {}
    }
}
```

Output:

```bash
/tmp $ solc --standard-json < compile.json | jq . | grep -C1 wasm
        },
        "ewasm": {
          "wasm": ""
        },
/tmp $
```

This is causing failure to deserialize compilers json outputs while the compilation is successful.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

As proposed.

## PR Checklist

-   [ ] Added Tests

No need for tests.

-   [ ] Added Documentation

No need for further docs.

-   [ ] Breaking changes

This shouldn't introduce any breaking changes.