### PR TITLE
Introduce the visitor implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "as-any"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3419eecc9f5967e6f0f29a0c3fefe22bda6ea34b15798f3c452cb81f2c3fa7"
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,11 +1445,13 @@ dependencies = [
 name = "ethers-solc"
 version = "2.0.3"
 dependencies = [
+ "as-any",
  "cfg-if",
  "criterion",
  "dunce",
  "env_logger",
  "ethers-core",
+ "eyre",
  "fs_extra",
  "futures-util",
  "getrandom",
@@ -1453,6 +1461,7 @@ dependencies = [
  "md-5 0.10.5",
  "num_cpus",
  "once_cell",
+ "paste",
  "path-slash",
  "pretty_assertions",
  "rand",
@@ -2805,6 +2814,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "path-slash"

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -435,9 +435,9 @@ pub fn parse_checksummed(addr: &str, chain_id: Option<u8>) -> Result<Address, Co
     let checksum_addr = to_checksum(&address, chain_id);
 
     if checksum_addr.strip_prefix("0x").unwrap_or(&checksum_addr) == addr {
-        return Ok(address)
+        Ok(address)
     } else {
-        return Err(ConversionError::InvalidAddressChecksum)
+        Err(ConversionError::InvalidAddressChecksum)
     }
 }
 

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -52,6 +52,9 @@ dunce.workspace = true
 rayon.workspace = true
 path-slash = "0.2.1"
 cfg-if = "1.0.0"
+eyre = "0.6.8"
+paste = "1.0.11"
+as-any = "0.3.0"
 
 tempfile = { version = "3.5.0", optional = true }
 fs_extra = { version = "1.3.0", optional = true }

--- a/ethers-solc/src/artifacts/ast/lowfidelity.rs
+++ b/ethers-solc/src/artifacts/ast/lowfidelity.rs
@@ -1,6 +1,6 @@
 //! Bindings for solc's `ast` output field
 
-use crate::artifacts::serde_helpers;
+use crate::artifacts::{serde_helpers, SourceUnit};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt, fmt::Write, str::FromStr};
 
@@ -22,6 +22,23 @@ pub struct Ast {
     /// Node attributes that were not deserialized.
     #[serde(flatten)]
     pub other: BTreeMap<String, serde_json::Value>,
+}
+
+/// Represents the AST field in the solc output
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TypedAst {
+    pub source_unit: SourceUnit,
+}
+
+impl Ast {
+    pub fn to_typed(self) -> TypedAst {
+        let data = serde_json::to_string_pretty(&self).unwrap();
+        let source_unit = serde_json::from_str(&data).unwrap_or_else(|e| {
+            panic!("Deserialization failed for {} file, error: {}", self.absolute_path, e)
+        });
+
+        TypedAst { source_unit }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/ethers-solc/src/artifacts/ast/mod.rs
+++ b/ethers-solc/src/artifacts/ast/mod.rs
@@ -1073,9 +1073,8 @@ ast_node!(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::artifacts::visitor::Visitable;
     use super::{visitor::Visitor, *};
+    use crate::artifacts::visitor::Visitable;
     use std::{fs, path::PathBuf};
 
     #[test]

--- a/ethers-solc/src/artifacts/ast/mod.rs
+++ b/ethers-solc/src/artifacts/ast/mod.rs
@@ -603,7 +603,7 @@ ast_node!(
 expr_node!(
     /// A tuple expression.
     struct TupleExpression {
-        components: Vec<Expression>,
+        components: Vec<Option<Expression>>,
         is_inline_array: bool,
     }
 );
@@ -940,7 +940,7 @@ ast_node!(
         block: Block,
         error_name: String,
         #[serde(default)]
-        parameters: Vec<ParameterList>,
+        parameters: Option<ParameterList>,
     }
 );
 
@@ -1074,6 +1074,8 @@ ast_node!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::artifacts::visitor::Visitable;
+    use super::{visitor::Visitor, *};
     use std::{fs, path::PathBuf};
 
     #[test]
@@ -1088,6 +1090,46 @@ mod tests {
                 let deserializer = &mut serde_json::Deserializer::from_str(&input);
                 let result: Result<SourceUnit, _> = serde_path_to_error::deserialize(deserializer);
                 match result {
+                    Err(e) => {
+                        println!("... {path_str} fail: {e}");
+                        panic!();
+                    }
+                    Ok(_) => {
+                        println!("... {path_str} ok");
+                    }
+                }
+            })
+    }
+
+    struct DummyState;
+
+    #[derive(Default)]
+    struct DummyVisitor;
+
+    impl Visitor<DummyState> for DummyVisitor {
+        fn shared_data(&mut self) -> &DummyState {
+            &DummyState {}
+        }
+    }
+
+    // Note: this implies that can_parse_ast works
+    #[test]
+    fn can_visit_ast() {
+        fs::read_dir(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test-data").join("ast"))
+            .unwrap()
+            .for_each(|path| {
+                let path = path.unwrap().path();
+                let path_str = path.to_string_lossy();
+
+                let input = fs::read_to_string(&path).unwrap();
+                let deserializer = &mut serde_json::Deserializer::from_str(&input);
+
+                let mut ast: SourceUnit = serde_path_to_error::deserialize(deserializer)
+                    .expect("Ast deserialization failed");
+
+                let mut visitor = DummyVisitor::default();
+
+                match ast.visit(&mut visitor) {
                     Err(e) => {
                         println!("... {path_str} fail: {e}");
                         panic!();

--- a/ethers-solc/src/artifacts/ast/mod.rs
+++ b/ethers-solc/src/artifacts/ast/mod.rs
@@ -18,7 +18,7 @@ pub mod util;
 pub mod visitor;
 
 /// A low fidelity representation of the AST.
-pub(crate) mod lowfidelity;
+pub mod lowfidelity;
 pub use lowfidelity::{Ast, Node, NodeType, SourceLocation as LowFidelitySourceLocation};
 
 /// Types for the Yul AST.

--- a/ethers-solc/src/artifacts/ast/visitor.rs
+++ b/ethers-solc/src/artifacts/ast/visitor.rs
@@ -1,1 +1,878 @@
+use super::{lowfidelity::TypedAst, yul::*, *};
+use as_any::AsAny;
+use eyre::Result;
+use thiserror::Error;
 
+#[derive(Error, Debug, Clone)]
+pub enum VisitError {
+    #[error("{0}")]
+    MsgError(String),
+    #[error("")]
+    Unknown,
+}
+
+macro_rules! impl_visitor {
+    ($type:ty) => {
+        paste::paste! {
+            fn [<visit_ $type:snake>](&mut self, node_type: &mut $type) -> Result<(), VisitError> {
+                node_type.visit(self)
+            }
+        }
+    };
+}
+
+pub trait Visitor<D>: AsAny {
+    fn shared_data(&mut self) -> &D;
+
+    impl_visitor!(SourceUnit);
+    impl_visitor!(PragmaDirective);
+    impl_visitor!(ImportDirective);
+    impl_visitor!(SourceUnitPart);
+    impl_visitor!(UsingForDirective);
+    impl_visitor!(FunctionIdentifierPath);
+    impl_visitor!(VariableDeclaration);
+    impl_visitor!(BinaryOperation);
+    impl_visitor!(Conditional);
+    impl_visitor!(ElementaryTypeName);
+    impl_visitor!(ElementaryTypeNameExpression);
+    impl_visitor!(FunctionCall);
+    impl_visitor!(UnaryOperation);
+    impl_visitor!(ParameterList);
+    impl_visitor!(EnumValue);
+    impl_visitor!(OverrideSpecifier);
+    impl_visitor!(TupleExpression);
+    impl_visitor!(NewExpression);
+    impl_visitor!(MemberAccess);
+    impl_visitor!(TypeDescriptions);
+    impl_visitor!(Literal);
+    impl_visitor!(BlockOrStatement);
+    impl_visitor!(IndexRangeAccess);
+    impl_visitor!(IndexAccess);
+    impl_visitor!(Identifier);
+    impl_visitor!(FunctionCallOptions);
+    impl_visitor!(EnumDefinition);
+    impl_visitor!(EventDefinition);
+    impl_visitor!(ModifierDefinition);
+    impl_visitor!(ModifierInvocation);
+    impl_visitor!(ErrorDefinition);
+    impl_visitor!(FunctionDefinition);
+    impl_visitor!(StructDefinition);
+    impl_visitor!(Expression);
+    impl_visitor!(Statement);
+    impl_visitor!(ContractDefinition);
+    impl_visitor!(ContractDefinitionPart);
+    impl_visitor!(TypeName);
+    impl_visitor!(UserDefinedValueTypeDefinition);
+    impl_visitor!(UserDefinedTypeNameOrIdentifierPath);
+    impl_visitor!(ExpressionOrVariableDeclarationStatement);
+    impl_visitor!(IdentifierOrIdentifierPath);
+    impl_visitor!(InheritanceSpecifier);
+    impl_visitor!(UserDefinedTypeName);
+    impl_visitor!(Mapping);
+    impl_visitor!(FunctionTypeName);
+    impl_visitor!(ArrayTypeName);
+    impl_visitor!(Assignment);
+    impl_visitor!(AssignmentOperator);
+    impl_visitor!(BinaryOperator);
+    impl_visitor!(PlaceholderStatement);
+    impl_visitor!(InlineAssembly);
+    impl_visitor!(IfStatement);
+    impl_visitor!(ForStatement);
+    impl_visitor!(ExpressionStatement);
+    impl_visitor!(EmitStatement);
+    impl_visitor!(DoWhileStatement);
+    impl_visitor!(Continue);
+    impl_visitor!(Break);
+    impl_visitor!(Block);
+    impl_visitor!(Return);
+    impl_visitor!(RevertStatement);
+    impl_visitor!(TryStatement);
+    impl_visitor!(UncheckedBlock);
+    impl_visitor!(VariableDeclarationStatement);
+    impl_visitor!(WhileStatement);
+    impl_visitor!(IdentifierPath);
+    impl_visitor!(StructuredDocumentation);
+    impl_visitor!(FunctionCallKind);
+    impl_visitor!(UnaryOperator);
+    impl_visitor!(ExternalInlineAssemblyReference);
+    impl_visitor!(AssemblyReferenceSuffix);
+    impl_visitor!(InlineAssemblyFlag);
+    impl_visitor!(TryCatchClause);
+    impl_visitor!(YulAssignment);
+    impl_visitor!(YulBlock);
+    impl_visitor!(YulBreak);
+    impl_visitor!(YulContinue);
+    impl_visitor!(YulStatement);
+    impl_visitor!(YulExpression);
+    impl_visitor!(YulExpressionStatement);
+    impl_visitor!(YulFunctionDefinition);
+    impl_visitor!(YulForLoop);
+    impl_visitor!(YulIf);
+    impl_visitor!(YulSwitch);
+    impl_visitor!(YulVariableDeclaration);
+    impl_visitor!(YulFunctionCall);
+    impl_visitor!(YulIdentifier);
+    impl_visitor!(YulLiteral);
+    impl_visitor!(YulLeave);
+}
+
+pub trait Visitable {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized;
+}
+
+/// Helper for nodes that don't need much implementation to traverse the childrens
+macro_rules! empty_visitable {
+    ($type:ty) => {
+        impl Visitable for $type {
+            fn visit<V, D>(&mut self, _: &mut V) -> Result<(), VisitError>
+            where
+                V: Visitor<D> + ?Sized,
+            {
+                Ok(())
+            }
+        }
+    };
+}
+
+empty_visitable!(PragmaDirective);
+empty_visitable!(ElementaryTypeName);
+empty_visitable!(ElementaryTypeNameExpression);
+empty_visitable!(EnumValue);
+empty_visitable!(Literal);
+empty_visitable!(Identifier);
+empty_visitable!(EventDefinition);
+empty_visitable!(ModifierDefinition);
+empty_visitable!(UserDefinedTypeName);
+empty_visitable!(Mapping);
+empty_visitable!(FunctionTypeName);
+empty_visitable!(AssignmentOperator);
+empty_visitable!(TypeDescriptions);
+empty_visitable!(BinaryOperator);
+empty_visitable!(PlaceholderStatement);
+empty_visitable!(Continue);
+empty_visitable!(Break);
+empty_visitable!(IdentifierPath);
+empty_visitable!(StructuredDocumentation);
+empty_visitable!(FunctionCallKind);
+empty_visitable!(UnaryOperator);
+empty_visitable!(AssemblyReferenceSuffix);
+empty_visitable!(InlineAssemblyFlag);
+empty_visitable!(YulBreak);
+empty_visitable!(YulExpressionStatement);
+empty_visitable!(YulFunctionDefinition);
+empty_visitable!(YulIf);
+empty_visitable!(YulSwitch);
+empty_visitable!(YulVariableDeclaration);
+empty_visitable!(YulIdentifier);
+empty_visitable!(YulLiteral);
+
+impl<T> Visitable for Vec<T>
+where
+    T: Visitable,
+{
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        for item in self.iter_mut() {
+            item.visit(v)?;
+        }
+        Ok(())
+    }
+}
+
+/// Main entry point of the ast
+impl Visitable for TypedAst {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_source_unit(&mut self.source_unit)
+    }
+}
+
+impl Visitable for SourceUnit {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.nodes.visit(v)
+    }
+}
+
+impl Visitable for SourceUnitPart {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        match self {
+            SourceUnitPart::PragmaDirective(e) => v.visit_pragma_directive(e),
+            SourceUnitPart::ImportDirective(e) => v.visit_import_directive(e),
+            SourceUnitPart::UsingForDirective(e) => v.visit_using_for_directive(e),
+            SourceUnitPart::VariableDeclaration(e) => v.visit_variable_declaration(e),
+            SourceUnitPart::EnumDefinition(e) => v.visit_enum_definition(e),
+            SourceUnitPart::ErrorDefinition(e) => v.visit_error_definition(e),
+            SourceUnitPart::FunctionDefinition(e) => v.visit_function_definition(e),
+            SourceUnitPart::StructDefinition(e) => v.visit_struct_definition(e),
+            SourceUnitPart::UserDefinedValueTypeDefinition(e) => {
+                v.visit_user_defined_value_type_definition(e)
+            }
+            SourceUnitPart::ContractDefinition(e) => v.visit_contract_definition(e),
+        }
+    }
+}
+
+impl Visitable for Expression {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        match self {
+            Expression::Assignment(e) => v.visit_assignment(e),
+            Expression::BinaryOperation(e) => v.visit_binary_operation(e),
+            Expression::Conditional(e) => v.visit_conditional(e),
+            Expression::ElementaryTypeNameExpression(e) => {
+                v.visit_elementary_type_name_expression(e)
+            }
+            Expression::FunctionCall(e) => v.visit_function_call(e),
+            Expression::FunctionCallOptions(e) => v.visit_function_call_options(e),
+            Expression::Identifier(e) => v.visit_identifier(e),
+            Expression::IndexAccess(e) => v.visit_index_access(e),
+            Expression::IndexRangeAccess(e) => v.visit_index_range_access(e),
+            Expression::Literal(e) => v.visit_literal(e),
+            Expression::MemberAccess(e) => v.visit_member_access(e),
+            Expression::NewExpression(e) => v.visit_new_expression(e),
+            Expression::TupleExpression(e) => v.visit_tuple_expression(e),
+            Expression::UnaryOperation(e) => v.visit_unary_operation(e),
+        }
+    }
+}
+
+impl Visitable for Statement {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        match self {
+            Statement::Block(e) => v.visit_block(e),
+            Statement::Break(e) => v.visit_break(e),
+            Statement::Continue(e) => v.visit_continue(e),
+            Statement::DoWhileStatement(e) => v.visit_do_while_statement(e),
+            Statement::EmitStatement(e) => v.visit_emit_statement(e),
+            Statement::ExpressionStatement(e) => v.visit_expression_statement(e),
+            Statement::ForStatement(e) => v.visit_for_statement(e),
+            Statement::IfStatement(e) => v.visit_if_statement(e),
+            Statement::InlineAssembly(e) => v.visit_inline_assembly(e),
+            Statement::PlaceholderStatement(e) => v.visit_placeholder_statement(e),
+            Statement::Return(e) => v.visit_return(e),
+            Statement::RevertStatement(e) => v.visit_revert_statement(e),
+            Statement::TryStatement(e) => v.visit_try_statement(e),
+            Statement::UncheckedBlock(e) => v.visit_unchecked_block(e),
+            Statement::VariableDeclarationStatement(e) => v.visit_variable_declaration_statement(e),
+            Statement::WhileStatement(e) => v.visit_while_statement(e),
+        }
+    }
+}
+
+impl Visitable for ContractDefinitionPart {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        match self {
+            ContractDefinitionPart::EnumDefinition(e) => v.visit_enum_definition(e),
+            ContractDefinitionPart::ErrorDefinition(e) => v.visit_error_definition(e),
+            ContractDefinitionPart::EventDefinition(e) => v.visit_event_definition(e),
+            ContractDefinitionPart::FunctionDefinition(e) => v.visit_function_definition(e),
+            ContractDefinitionPart::ModifierDefinition(e) => v.visit_modifier_definition(e),
+            ContractDefinitionPart::StructDefinition(e) => v.visit_struct_definition(e),
+            ContractDefinitionPart::UserDefinedValueTypeDefinition(e) => {
+                v.visit_user_defined_value_type_definition(e)
+            }
+            ContractDefinitionPart::UsingForDirective(e) => v.visit_using_for_directive(e),
+            ContractDefinitionPart::VariableDeclaration(e) => v.visit_variable_declaration(e),
+        }
+    }
+}
+
+impl Visitable for TypeName {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        match self {
+            TypeName::ArrayTypeName(e) => v.visit_array_type_name(e),
+            TypeName::ElementaryTypeName(e) => v.visit_elementary_type_name(e),
+            TypeName::FunctionTypeName(e) => v.visit_function_type_name(e),
+            TypeName::Mapping(e) => v.visit_mapping(e),
+            TypeName::UserDefinedTypeName(e) => v.visit_user_defined_type_name(e),
+        }
+    }
+}
+
+impl Visitable for UserDefinedTypeNameOrIdentifierPath {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        match self {
+            UserDefinedTypeNameOrIdentifierPath::UserDefinedTypeName(e) => {
+                v.visit_user_defined_type_name(e)
+            }
+            UserDefinedTypeNameOrIdentifierPath::IdentifierPath(e) => v.visit_identifier_path(e),
+        }
+    }
+}
+
+impl Visitable for ExpressionOrVariableDeclarationStatement {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        match self {
+            ExpressionOrVariableDeclarationStatement::ExpressionStatement(e) => {
+                v.visit_expression_statement(e)
+            }
+            ExpressionOrVariableDeclarationStatement::VariableDeclarationStatement(e) => {
+                v.visit_variable_declaration_statement(e)
+            }
+        }
+    }
+}
+
+impl Visitable for IdentifierOrIdentifierPath {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        match self {
+            IdentifierOrIdentifierPath::Identifier(e) => v.visit_identifier(e),
+            IdentifierOrIdentifierPath::IdentifierPath(e) => v.visit_identifier_path(e),
+        }
+    }
+}
+
+impl Visitable for YulStatement {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        match self {
+            YulStatement::YulAssignment(e) => v.visit_yul_assignment(e),
+            YulStatement::YulBlock(e) => v.visit_yul_block(e),
+            YulStatement::YulBreak(e) => v.visit_yul_break(e),
+            YulStatement::YulContinue(e) => v.visit_yul_continue(e),
+            YulStatement::YulExpressionStatement(e) => v.visit_yul_expression_statement(e),
+            YulStatement::YulLeave(e) => v.visit_yul_leave(e),
+            YulStatement::YulForLoop(e) => v.visit_yul_for_loop(e),
+            YulStatement::YulFunctionDefinition(e) => v.visit_yul_function_definition(e),
+            YulStatement::YulIf(e) => v.visit_yul_if(e),
+            YulStatement::YulSwitch(e) => v.visit_yul_switch(e),
+            YulStatement::YulVariableDeclaration(e) => v.visit_yul_variable_declaration(e),
+        }
+    }
+}
+
+impl Visitable for YulExpression {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        match self {
+            YulExpression::YulFunctionCall(e) => v.visit_yul_function_call(e),
+            YulExpression::YulIdentifier(e) => v.visit_yul_identifier(e),
+            YulExpression::YulLiteral(e) => v.visit_yul_literal(e),
+        }
+    }
+}
+
+/// Implement nodes that may have sub nodes
+impl Visitable for ImportDirective {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.symbol_aliases.iter_mut().try_for_each(|sa| {
+            let foreign = &mut sa.foreign;
+            v.visit_identifier(foreign)
+        })
+    }
+}
+
+impl Visitable for SymbolAlias {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_identifier(&mut self.foreign)
+    }
+}
+
+impl Visitable for UsingForDirective {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.function_list.iter_mut().try_for_each(|fd| v.visit_function_identifier_path(fd))?;
+        self.library_name
+            .as_mut()
+            .map_or_else(|| Ok(()), |e| v.visit_user_defined_type_name_or_identifier_path(e))?;
+        self.type_name.as_mut().map_or_else(|| Ok(()), |e| v.visit_type_name(e))
+    }
+}
+
+impl Visitable for FunctionIdentifierPath {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_identifier_path(&mut self.function)
+    }
+}
+
+impl Visitable for VariableDeclaration {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.overrides.as_mut().map_or_else(|| Ok(()), |e| v.visit_override_specifier(e))?;
+        self.type_name.as_mut().map_or_else(|| Ok(()), |e| v.visit_type_name(e))?;
+        self.value.as_mut().map_or_else(|| Ok(()), |e| v.visit_expression(e))
+    }
+}
+
+impl Visitable for EnumDefinition {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.members.iter_mut().try_for_each(|e| v.visit_enum_value(e))
+    }
+}
+
+impl Visitable for ErrorDefinition {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_parameter_list(&mut self.parameters)
+    }
+}
+
+impl Visitable for ModifierInvocation {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.arguments.iter_mut().try_for_each(|a| v.visit_expression(a))?;
+        v.visit_identifier_or_identifier_path(&mut self.modifier_name)
+    }
+}
+
+impl Visitable for Block {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.statements.iter_mut().try_for_each(|s| v.visit_statement(s))
+    }
+}
+
+impl Visitable for OverrideSpecifier {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.overrides
+            .iter_mut()
+            .try_for_each(|o| v.visit_user_defined_type_name_or_identifier_path(o))
+    }
+}
+
+impl Visitable for ParameterList {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.parameters.iter_mut().try_for_each(|p| v.visit_variable_declaration(p))
+    }
+}
+
+impl Visitable for FunctionDefinition {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.body.as_mut().map_or_else(|| Ok(()), |n| v.visit_block(n))?;
+        self.modifiers.iter_mut().try_for_each(|s| v.visit_modifier_invocation(s))?;
+        self.overrides.as_mut().map_or_else(|| Ok(()), |n| v.visit_override_specifier(n))?;
+        v.visit_parameter_list(&mut self.parameters)?;
+        v.visit_parameter_list(&mut self.return_parameters)
+    }
+}
+
+impl Visitable for StructDefinition {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.members.iter_mut().try_for_each(|s| v.visit_variable_declaration(s))
+    }
+}
+
+impl Visitable for UserDefinedValueTypeDefinition {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_type_name(&mut self.underlying_type)
+    }
+}
+
+impl Visitable for ArrayTypeName {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_type_descriptions(&mut self.type_descriptions)?;
+        v.visit_type_name(&mut self.base_type)?;
+        self.length.as_mut().map_or_else(|| Ok(()), |n| v.visit_expression(n))
+    }
+}
+
+impl Visitable for InheritanceSpecifier {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.arguments.iter_mut().try_for_each(|s| v.visit_expression(s))?;
+        v.visit_user_defined_type_name_or_identifier_path(&mut self.base_name)
+    }
+}
+
+impl Visitable for ContractDefinition {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.base_contracts.iter_mut().try_for_each(|s| v.visit_inheritance_specifier(s))?;
+        self.documentation
+            .as_mut()
+            .map_or_else(|| Ok(()), |n| v.visit_structured_documentation(n))?;
+        self.nodes.iter_mut().try_for_each(|s| v.visit_contract_definition_part(s))
+    }
+}
+
+impl Visitable for Assignment {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_expression(&mut self.lhs)?;
+        v.visit_assignment_operator(&mut self.operator)?;
+        v.visit_expression(&mut self.rhs)
+    }
+}
+
+impl Visitable for BinaryOperation {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_type_descriptions(&mut self.common_type)?;
+        v.visit_expression(&mut self.lhs)?;
+        v.visit_binary_operator(&mut self.operator)?;
+        v.visit_expression(&mut self.rhs)
+    }
+}
+
+impl Visitable for Conditional {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_expression(&mut self.condition)?;
+        v.visit_expression(&mut self.false_expression)?;
+        v.visit_expression(&mut self.true_expression)
+    }
+}
+
+impl Visitable for FunctionCall {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.arguments.iter_mut().try_for_each(|s| v.visit_expression(s))?;
+        v.visit_expression(&mut self.expression)?;
+        v.visit_function_call_kind(&mut self.kind)
+    }
+}
+
+impl Visitable for FunctionCallOptions {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_expression(&mut self.expression)?;
+        self.options.iter_mut().try_for_each(|s| v.visit_expression(s))
+    }
+}
+
+impl Visitable for IndexAccess {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_expression(&mut self.base_expression)?;
+        self.index_expression.as_mut().map_or_else(|| Ok(()), |n| v.visit_expression(n))
+    }
+}
+
+impl Visitable for IndexRangeAccess {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_expression(&mut self.base_expression)?;
+        self.start_expression.as_mut().map_or_else(|| Ok(()), |n| v.visit_expression(n))?;
+        self.end_expression.as_mut().map_or_else(|| Ok(()), |n| v.visit_expression(n))
+    }
+}
+
+impl Visitable for MemberAccess {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_expression(&mut self.expression)
+    }
+}
+
+impl Visitable for NewExpression {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_type_name(&mut self.type_name)
+    }
+}
+
+impl Visitable for TupleExpression {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.components
+            .iter_mut()
+            .try_for_each(|s| s.as_mut().map_or_else(|| Ok(()), |n| v.visit_expression(n)))
+    }
+}
+
+impl Visitable for UnaryOperation {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_unary_operator(&mut self.operator)?;
+        v.visit_expression(&mut self.sub_expression)
+    }
+}
+
+impl Visitable for DoWhileStatement {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_block(&mut self.block)?;
+        v.visit_expression(&mut self.condition)
+    }
+}
+
+impl Visitable for EmitStatement {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_function_call(&mut self.event_call)
+    }
+}
+
+impl Visitable for ExpressionStatement {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_expression(&mut self.expression)
+    }
+}
+
+impl Visitable for BlockOrStatement {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        match self {
+            BlockOrStatement::Block(e) => e.visit(v),
+            BlockOrStatement::Statement(e) => e.visit(v),
+        }
+    }
+}
+
+impl Visitable for ForStatement {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_block_or_statement(&mut self.body)?;
+        self.condition.as_mut().map_or_else(|| Ok(()), |n| v.visit_expression(n))?;
+        self.initialization_expression
+            .as_mut()
+            .map_or_else(|| Ok(()), |n| v.visit_expression_or_variable_declaration_statement(n))?;
+        self.loop_expression.as_mut().map_or_else(|| Ok(()), |n| v.visit_expression_statement(n))
+    }
+}
+
+impl Visitable for VariableDeclarationStatement {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.declarations.iter_mut().try_for_each(|s| {
+            s.as_mut().map_or_else(|| Ok(()), |n| v.visit_variable_declaration(n))
+        })?;
+        self.initial_value.as_mut().map_or_else(|| Ok(()), |n| v.visit_expression(n))
+    }
+}
+
+impl Visitable for IfStatement {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_expression(&mut self.condition)?;
+        self.false_body.as_mut().map_or_else(|| Ok(()), |n| v.visit_block_or_statement(n))?;
+        v.visit_block_or_statement(&mut self.true_body)
+    }
+}
+
+impl Visitable for YulBlock {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.statements.iter_mut().try_for_each(|s| v.visit_yul_statement(s))
+    }
+}
+
+impl Visitable for YulAssignment {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_yul_expression(&mut self.value)?;
+        self.variable_names.iter_mut().try_for_each(|s| v.visit_yul_identifier(s))
+    }
+}
+
+impl Visitable for YulForLoop {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_yul_block(&mut self.body)?;
+        v.visit_yul_expression(&mut self.condition)?;
+        v.visit_yul_block(&mut self.post)?;
+        v.visit_yul_block(&mut self.pre)
+    }
+}
+
+impl Visitable for YulFunctionCall {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.arguments.iter_mut().try_for_each(|s| v.visit_yul_expression(s))?;
+        v.visit_yul_identifier(&mut self.function_name)
+    }
+}
+
+impl Visitable for InlineAssembly {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_yul_block(&mut self.ast)?;
+        self.external_references
+            .iter_mut()
+            .try_for_each(|s| v.visit_external_inline_assembly_reference(s))?;
+        self.flags.iter_mut().try_for_each(|s| v.visit_inline_assembly_flag(s))
+    }
+}
+
+impl Visitable for Return {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.expression.as_mut().map_or_else(|| Ok(()), |n| v.visit_expression(n))
+    }
+}
+
+impl Visitable for RevertStatement {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_function_call(&mut self.error_call)
+    }
+}
+
+impl Visitable for TryCatchClause {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_block(&mut self.block)?;
+        self.parameters.as_mut().map_or_else(|| Ok(()), |n| v.visit_parameter_list(n))
+    }
+}
+
+impl Visitable for TryStatement {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.clauses.iter_mut().try_for_each(|s| v.visit_try_catch_clause(s))?;
+        v.visit_function_call(&mut self.external_call)
+    }
+}
+
+impl Visitable for UncheckedBlock {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.statements.iter_mut().try_for_each(|s| v.visit_statement(s))
+    }
+}
+
+impl Visitable for WhileStatement {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        v.visit_block_or_statement(&mut self.body)?;
+        v.visit_expression(&mut self.condition)
+    }
+}
+
+impl Visitable for ExternalInlineAssemblyReference {
+    fn visit<V, D>(&mut self, v: &mut V) -> Result<(), VisitError>
+    where
+        V: Visitor<D> + ?Sized,
+    {
+        self.suffix.as_mut().map_or_else(|| Ok(()), |n| v.visit_assembly_reference_suffix(n))
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This is just some tedious merging work with #1982 which introduces the AST visitor features. I simply confirm the test works and format the code. I'm glad to work further on this PR.

cc @iFrostizz 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

As proposed.

## PR Checklist

-   [ x ] Added Tests
-   [ x ] Added Documentation
-   [ ] Breaking changes

I notice that there are actually a few break changes to AST structures (see `mod.rs`). However, considering that the parsed AST is not useful without a visitor implementation, I think previous users won't actually use too much of them. Even if some users used the structures, it's trivial to switch to new implementation.
