### PR TITLE
fix: specify sum type in abigen to avoid ambiguity

### DIFF
--- a/ethers-contract/ethers-contract-derive/src/codec.rs
+++ b/ethers-contract/ethers-contract-derive/src/codec.rs
@@ -15,7 +15,7 @@ pub fn derive_codec_impl(input: &DeriveInput) -> proc_macro2::TokenStream {
                 fn _decode(bytes: &[u8]) -> ::core::result::Result<#name, #ethers_core::abi::AbiError> {
                     let #ethers_core::abi::ParamType::Tuple(params) =
                         <#name as #ethers_core::abi::AbiType>::param_type() else { unreachable!() };
-                    let min_len = params.iter().map(#ethers_core::abi::minimum_size).sum();
+                    let min_len: usize = params.iter().map(#ethers_core::abi::minimum_size).sum();
                     if bytes.len() < min_len {
                         Err(#ethers_core::abi::AbiError::DecodingError(#ethers_core::abi::ethabi::Error::InvalidData))
                     } else {


### PR DESCRIPTION

## Motivation

https://github.com/grantweii/ethers-macro-bug

## Solution

Specify the output of the sum to avoid ambiguity when other types implementing `Sum<usize>` are in scope

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
