### PR TITLE
feat(solc): add support for Paris and Shanghai EVM versions

### DIFF
--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -748,7 +748,7 @@ pub enum EvmVersion {
     Istanbul,
     Berlin,
     London,
-    #[default]
+    #[default] // TODO: Move to Shanghai once Solc 0.8.20 is released
     Paris,
     Shanghai,
 }
@@ -758,11 +758,10 @@ impl EvmVersion {
     pub fn normalize_version(self, version: &Version) -> Option<Self> {
         // The EVM version flag was only added in 0.4.21; we work our way backwards
         if *version >= BYZANTIUM_SOLC {
-            // If the Solc is at least at Paris, it supports all EVM versions.
+            // If the Solc is at least at Shanghai, it supports all EVM versions.
             // For all other cases, cap at the at-the-time highest possible fork.
             let normalized = if self >= Self::Shanghai &&
-                // TODO: Replace with the following once Solc 0.8.20 is released:
-                // *version >= SHANGHAI_SOLC
+                // TODO: Remove once Solc 0.8.20 is released
                 SUPPORTS_SHANGHAI.matches(version)
             {
                 self
@@ -2402,7 +2401,7 @@ mod tests {
             ("0.8.20", EvmVersion::Homestead, Some(EvmVersion::Homestead)),
             ("0.8.20", EvmVersion::Paris, Some(EvmVersion::Paris)),
             ("0.8.20", EvmVersion::Shanghai, Some(EvmVersion::Shanghai)),
-            // TODO: Remove when 0.8.20 is released
+            // TODO: Remove once Solc 0.8.20 is released
             (
                 "0.8.20-nightly.2023.4.12+commit.f0c0df2d",
                 EvmVersion::Shanghai,

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     error::{Result, SolcError},
     utils, CompilerInput, CompilerOutput,
 };
+use once_cell::sync::Lazy;
 use semver::{Version, VersionReq};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
@@ -44,20 +45,35 @@ pub const BERLIN_SOLC: Version = Version::new(0, 8, 5);
 /// <https://blog.soliditylang.org/2021/08/11/solidity-0.8.7-release-announcement/>
 pub const LONDON_SOLC: Version = Version::new(0, 8, 7);
 
+/// Paris support
+/// https://blog.soliditylang.org/2023/02/01/solidity-0.8.18-release-announcement/
+pub const PARIS_SOLC: Version = Version::new(0, 8, 18);
+
+/// Shanghai support
+// TODO: Solc blogpost link
+pub const SHANGHAI_SOLC: Version = Version::new(0, 8, 20);
+
+/// This will be removed once 0.8.20 is released.
+///
+/// Shanghai support was added in [ethereum/solidity#14107](https://github.com/ethereum/solidity/pull/14107),
+/// which was released in `nightly.2023.4.13`.
+pub(crate) static SUPPORTS_SHANGHAI: Lazy<VersionReq> =
+    Lazy::new(|| VersionReq::parse(">=0.8.20-nightly.2023.4.13").unwrap());
+
 // `--base-path` was introduced in 0.6.9 <https://github.com/ethereum/solidity/releases/tag/v0.6.9>
-pub static SUPPORTS_BASE_PATH: once_cell::sync::Lazy<VersionReq> =
-    once_cell::sync::Lazy::new(|| VersionReq::parse(">=0.6.9").unwrap());
+pub static SUPPORTS_BASE_PATH: Lazy<VersionReq> =
+    Lazy::new(|| VersionReq::parse(">=0.6.9").unwrap());
 
 // `--include-path` was introduced in 0.8.8 <https://github.com/ethereum/solidity/releases/tag/v0.8.8>
-pub static SUPPORTS_INCLUDE_PATH: once_cell::sync::Lazy<VersionReq> =
-    once_cell::sync::Lazy::new(|| VersionReq::parse(">=0.8.8").unwrap());
+pub static SUPPORTS_INCLUDE_PATH: Lazy<VersionReq> =
+    Lazy::new(|| VersionReq::parse(">=0.8.8").unwrap());
 
 #[cfg(any(test, feature = "tests"))]
 use std::sync::Mutex;
 
 #[cfg(any(test, feature = "tests"))]
 #[allow(unused)]
-static LOCK: once_cell::sync::Lazy<Mutex<()>> = once_cell::sync::Lazy::new(|| Mutex::new(()));
+static LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 /// take the lock in tests, we use this to enforce that
 /// a test does not run while a compiler version is being installed

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -46,7 +46,7 @@ pub const BERLIN_SOLC: Version = Version::new(0, 8, 5);
 pub const LONDON_SOLC: Version = Version::new(0, 8, 7);
 
 /// Paris support
-/// https://blog.soliditylang.org/2023/02/01/solidity-0.8.18-release-announcement/
+/// <https://blog.soliditylang.org/2023/02/01/solidity-0.8.18-release-announcement/>
 pub const PARIS_SOLC: Version = Version::new(0, 8, 18);
 
 /// Shanghai support


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Paris support was added in [0.8.18](https://blog.soliditylang.org/2023/02/01/solidity-0.8.18-release-announcement/), and Shanghai support is on track to be released with [0.8.20](https://github.com/ethereum/solidity/pull/14107).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
