### PR TITLE
feat: add revert data field to create result struct

### DIFF
--- a/ethers-core/src/types/trace/filter.rs
+++ b/ethers-core/src/types/trace/filter.rs
@@ -169,7 +169,11 @@ pub struct CreateResult {
     #[serde(rename = "gasUsed")]
     pub gas_used: U256,
     /// Code
-    pub code: Bytes,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub code: Option<Bytes>,
+    /// Revert data
+    #[serde(rename = "revertData", skip_serializing_if = "Option::is_none")]
+    pub revert_data: Option<Bytes>,
     /// Assigned address
     pub address: Address,
 }


### PR DESCRIPTION
## Motivation

Until now, there was no way to set revert data for CREATE traces. For example, for sub-trace creating this contract

```solidity
contract Foo {
    constructor() {
        revert("aaa");
    }
}
```

it was not possible to store the revert data (`0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000036161610000000000000000000000000000000000000000000000000000000000` in this case) in the trace object. For non-CREATE traces, there is the `output` field that can be used both for storing the return value and the revert data, depending on the context.

## Solution

Added a new field named `revert_data` to the `CreateResult` struct. Both `revert_data` and `code` are now optional and should be mutually exclusive.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
