### PR TITLE
feat: implement CCIP Read as eth_call middleware

### DIFF
--- a/ethers-middleware/src/ccip_read.rs
+++ b/ethers-middleware/src/ccip_read.rs
@@ -47,20 +47,30 @@ impl OffchainLookup {
     }
 
     async fn fetch(&self) -> Option<CCIPReadResult> {
+        // 6. Construct a request URL by replacing sender with the lowercase 0x-prefixed hexadecimal formatted sender parameter, and replacing data with the the 0x-prefixed hexadecimal formatted callData parameter. The client may choose which URLs to try in which order, but SHOULD prioritise URLs earlier in the list over those later in the list.
         let mut urls = self.urls.iter().map(|url| self.templatize(url));
-
         // TODO: try all urls
         let url = urls.next().unwrap();
+
+        // 7. Make an HTTP GET request to the request URL.
         let response = reqwest::get(&url).await;
 
         match response {
             Ok(response) => {
-                let result = response.json::<CCIPReadResult>().await;
-                match result {
-                    Ok(result) => Some(result),
-                    Err(e) => {
-                        eprintln!("Error parsing response: {:?}", e);
-                        return None
+                match response.status().as_u16() {
+                    // 8. If the response code from step (5) is in the range 400-499, return an error to the caller and stop.
+                    400..=499 => todo!(),
+                    // 9. If the response code from step (5) is in the range 500-599, go back to step (5) and pick a different URL, or stop if there are no further URLs to try.
+                    500..=599 => todo!(),
+                    _ => {
+                        let result = response.json::<CCIPReadResult>().await;
+                        match result {
+                            Ok(result) => Some(result),
+                            Err(e) => {
+                                eprintln!("Error parsing response: {:?}", e);
+                                return None
+                            }
+                        }
                     }
                 }
             }
@@ -109,23 +119,6 @@ impl<M: Middleware> MiddlewareError for CCIPReadError<M> {
     }
 }
 
-///     Client Lookup Protocol
-/// A client that supports CCIP read MUST make contract calls using the following process:
-
-/// 4. Otherwise, decode the sender, urls, callData, callbackFunction and extraData arguments from
-/// the OffchainLookup error. 5. If the sender field does not match the address of the contract that
-/// was called, return an error to the caller and stop. 6. Construct a request URL by replacing
-/// sender with the lowercase 0x-prefixed hexadecimal formatted sender parameter, and replacing data
-/// with the the 0x-prefixed hexadecimal formatted callData parameter. The client may choose which
-/// URLs to try in which order, but SHOULD prioritise URLs earlier in the list over those later in
-/// the list. 7. Make an HTTP GET request to the request URL.
-/// 8. If the response code from step (5) is in the range 400-499, return an error to the caller and
-/// stop. 9. If the response code from step (5) is in the range 500-599, go back to step (5) and
-/// pick a different URL, or stop if there are no further URLs to try. 10. Otherwise, replace data
-/// with an ABI-encoded call to the contract function specified by the 4-byte selector
-/// callbackFunction, supplying the data returned from step (7) and extraData from step (4), and
-/// return to step (1).
-
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl<M> Middleware for CCIPReadMiddleware<M>
@@ -145,16 +138,32 @@ where
         tx: &TypedTransaction,
         block: Option<BlockId>,
     ) -> Result<Bytes, Self::Error> {
+        // 1. Set data to the call data to supply to the contract, and to to the address of the contract to call.
         let call_result = self.inner.call(tx, block).await;
 
         match call_result {
+
+            // 2. Call the contract at address to function normally, supplying data as the input data. If the function returns a successful result, return it to the caller and stop.
             Ok(bytes) => Ok(bytes),
+
             Err(e) => {
                 match e.as_error_response().and_then(|e| OffchainLookup::from_rpc_response(e)) {
+
+                    // 3. If the function returns an error other than OffchainLookup, return it to the caller in the usual fashion.
                     None => return Err(CCIPReadError::MiddlewareError(e)),
+
+                    // 4. Otherwise, decode the sender, urls, callData, callbackFunction and extraData arguments from the OffchainLookup error.
                     Some(lookup) => {
+
+                        // 5. If the sender field does not match the address of the contract that was called, return an error to the caller and stop.
+                        if &lookup.sender != tx.to().unwrap().as_address().unwrap() {
+                            return Err(CCIPReadError::MiddlewareError(e))
+                        }
+
+                        // see fetch for steps 6 - 9
                         let lookup_result = lookup.fetch().await;
                         match lookup_result {
+                            // 10. Otherwise, replace data with an ABI-encoded call to the contract function specified by the 4-byte selector callbackFunction, supplying the data returned from step (7) and extraData from step (4), and return to step (1).
                             Some(lookup_result) => {
                                 let mut new_tx = tx.clone();
                                 new_tx.set_data(lookup.encode_callback_data(lookup_result));

--- a/ethers-middleware/src/ccip_read.rs
+++ b/ethers-middleware/src/ccip_read.rs
@@ -1,0 +1,170 @@
+use async_trait::async_trait;
+use ethers_contract::{EthAbiCodec, EthAbiType, EthError};
+use ethers_core::{
+    abi::AbiEncode,
+    types::{transaction::eip2718::TypedTransaction, *},
+};
+use ethers_providers::{Middleware, MiddlewareError};
+
+use serde::Deserialize;
+use thiserror::Error;
+
+#[derive(Debug)]
+/// Middleware used for doing offchain data retrieval
+/// See https://eips.ethereum.org/EIPS/eip-3668
+pub struct CCIPReadMiddleware<M> {
+    inner: M,
+}
+
+#[derive(Debug, Clone, EthError)]
+#[etherror(
+    name = "OffchainLookup",
+    abi = "OffchainLookup(address, string[], bytes, bytes4, bytes)"
+)]
+struct OffchainLookup {
+    sender: Address,
+    urls: Vec<String>,
+    call_data: Bytes,
+    callback_function: [u8; 4], // Bytes4
+    extra_data: Bytes,
+}
+
+#[derive(Deserialize)]
+struct CCIPReadResult {
+    data: Bytes,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, EthAbiType, EthAbiCodec)]
+struct Callback {
+    call_data: Bytes,
+    extra_data: Bytes,
+}
+
+impl OffchainLookup {
+    fn templatize(&self, url: &String) -> String {
+        url.replace("{data}", &self.call_data.to_string())
+            .replace("{sender}", &self.sender.to_string())
+    }
+
+    async fn fetch(&self) -> Option<CCIPReadResult> {
+        let mut urls = self.urls.iter().map(|url| self.templatize(url));
+
+        // TODO: try all urls
+        let url = urls.next().unwrap();
+        let response = reqwest::get(&url).await;
+
+        match response {
+            Ok(response) => {
+                let result = response.json::<CCIPReadResult>().await;
+                match result {
+                    Ok(result) => Some(result),
+                    Err(e) => {
+                        eprintln!("Error parsing response: {:?}", e);
+                        return None
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("Error fetching data: {:?}", e);
+                return None
+            }
+        }
+    }
+
+    fn encode_callback_data(&self, result: CCIPReadResult) -> Bytes {
+        let callback = Callback { call_data: result.data, extra_data: self.extra_data.clone() };
+
+        return Bytes::from([self.callback_function.to_vec(), callback.encode()].concat())
+    }
+}
+
+impl<M> CCIPReadMiddleware<M>
+where
+    M: Middleware,
+{
+    pub fn new(inner: M) -> Self {
+        Self { inner }
+    }
+}
+
+#[derive(Error, Debug)]
+/// Thrown when an error happens at the CCIP Read
+pub enum CCIPReadError<M: Middleware> {
+    /// Thrown when the internal middleware errors
+    #[error("{0}")]
+    MiddlewareError(M::Error),
+}
+
+impl<M: Middleware> MiddlewareError for CCIPReadError<M> {
+    type Inner = M::Error;
+
+    fn from_err(src: M::Error) -> Self {
+        CCIPReadError::MiddlewareError(src)
+    }
+
+    fn as_inner(&self) -> Option<&Self::Inner> {
+        match self {
+            CCIPReadError::MiddlewareError(e) => Some(e),
+        }
+    }
+}
+
+///     Client Lookup Protocol
+/// A client that supports CCIP read MUST make contract calls using the following process:
+
+/// 4. Otherwise, decode the sender, urls, callData, callbackFunction and extraData arguments from
+/// the OffchainLookup error. 5. If the sender field does not match the address of the contract that
+/// was called, return an error to the caller and stop. 6. Construct a request URL by replacing
+/// sender with the lowercase 0x-prefixed hexadecimal formatted sender parameter, and replacing data
+/// with the the 0x-prefixed hexadecimal formatted callData parameter. The client may choose which
+/// URLs to try in which order, but SHOULD prioritise URLs earlier in the list over those later in
+/// the list. 7. Make an HTTP GET request to the request URL.
+/// 8. If the response code from step (5) is in the range 400-499, return an error to the caller and
+/// stop. 9. If the response code from step (5) is in the range 500-599, go back to step (5) and
+/// pick a different URL, or stop if there are no further URLs to try. 10. Otherwise, replace data
+/// with an ABI-encoded call to the contract function specified by the 4-byte selector
+/// callbackFunction, supplying the data returned from step (7) and extraData from step (4), and
+/// return to step (1).
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl<M> Middleware for CCIPReadMiddleware<M>
+where
+    M: Middleware,
+{
+    type Error = CCIPReadError<M>;
+    type Provider = M::Provider;
+    type Inner = M;
+
+    fn inner(&self) -> &M {
+        &self.inner
+    }
+
+    async fn call(
+        &self,
+        tx: &TypedTransaction,
+        block: Option<BlockId>,
+    ) -> Result<Bytes, Self::Error> {
+        let call_result = self.inner.call(tx, block).await;
+
+        match call_result {
+            Ok(bytes) => Ok(bytes),
+            Err(e) => {
+                match e.as_error_response().and_then(|e| OffchainLookup::from_rpc_response(e)) {
+                    None => return Err(CCIPReadError::MiddlewareError(e)),
+                    Some(lookup) => {
+                        let lookup_result = lookup.fetch().await;
+                        match lookup_result {
+                            Some(lookup_result) => {
+                                let mut new_tx = tx.clone();
+                                new_tx.set_data(lookup.encode_callback_data(lookup_result));
+                                return self.call(&new_tx, block).await
+                            }
+                            None => return Err(CCIPReadError::MiddlewareError(e)),
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ethers-middleware/src/lib.rs
+++ b/ethers-middleware/src/lib.rs
@@ -17,8 +17,8 @@ pub mod gas_oracle;
 pub mod nonce_manager;
 pub use nonce_manager::NonceManagerMiddleware;
 
-/// The [CCIP Read](crate::CCIPReadMiddleware) is used to locally calculate nonces instead
-/// of using eth_getTransactionCount
+/// The [CCIP Read](crate::CCIPReadMiddleware) is used to catch CCIP Read revert errors, perform
+/// corresponding offchain lookups, and make specified callbacks.
 pub mod ccip_read;
 pub use ccip_read::CCIPReadMiddleware;
 

--- a/ethers-middleware/src/lib.rs
+++ b/ethers-middleware/src/lib.rs
@@ -17,6 +17,11 @@ pub mod gas_oracle;
 pub mod nonce_manager;
 pub use nonce_manager::NonceManagerMiddleware;
 
+/// The [CCIP Read](crate::CCIPReadMiddleware) is used to locally calculate nonces instead
+/// of using eth_getTransactionCount
+pub mod ccip_read;
+pub use ccip_read::CCIPReadMiddleware;
+
 /// The [Transformer](crate::transformer::TransformerMiddleware) is used to intercept transactions
 /// and transform them to be sent via various supported transformers, e.g.,
 /// [DSProxy](crate::transformer::DsProxy)


### PR DESCRIPTION
Implement [CCIP Read spec](https://eips.ethereum.org/EIPS/eip-3668) as optional provider middleware.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes https://github.com/gakonst/ethers-rs/issues/2143

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

See [ethers-js implementation](https://github.com/ethers-io/ethers.js/blob/f2fb8b5ede48f8e7a3af76f71cc01c22753d2ca5/src.ts/providers/abstract-provider.ts#L757)

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
