### PR TITLE
feat: move `spoof` module to `ethers_core`, add stateoverrides to `GethDebugTracingCallOptions`

### DIFF
--- a/book/providers/advanced_usage.md
+++ b/book/providers/advanced_usage.md
@@ -75,7 +75,7 @@ Let's look at how to use the state override set. In short, the state override se
 ```rust
 use ethers::{
     providers::{
-        call_raw::{spoof::State, RawCall},
+        call_raw::RawCall,
         Http, Provider,
     },
     types::{TransactionRequest, H160, U256, U64},

--- a/ethers-core/src/types/trace/geth.rs
+++ b/ethers-core/src/types/trace/geth.rs
@@ -9,7 +9,9 @@ pub use self::{
     noop::NoopFrame,
     pre_state::{AccountState, DiffMode, PreStateConfig, PreStateFrame, PreStateMode},
 };
-use crate::types::{serde_helpers::deserialize_stringified_numeric, Bytes, H256, U256};
+use crate::types::{
+    serde_helpers::deserialize_stringified_numeric, Address, Bytes, H256, U256, U64,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -205,5 +207,265 @@ pub struct GethDebugTracingOptions {
 pub struct GethDebugTracingCallOptions {
     #[serde(flatten)]
     pub tracing_options: GethDebugTracingOptions,
-    // TODO: Add stateoverrides and blockoverrides options
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state_overrides: Option<spoof::State>,
+    // TODO: Add blockoverrides options
+}
+
+/// Provides types and methods for constructing an `eth_call`
+/// [state override set](https://geth.ethereum.org/docs/rpc/ns-eth#3-object---state-override-set)
+pub mod spoof {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// The state elements to override for a particular account.
+    #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct Account {
+        /// Account nonce
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub nonce: Option<U64>,
+        /// Account balance
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub balance: Option<U256>,
+        /// Account code
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub code: Option<Bytes>,
+        /// Account storage
+        #[serde(flatten, skip_serializing_if = "Option::is_none")]
+        pub storage: Option<Storage>,
+    }
+
+    impl Account {
+        /// Override the account nonce
+        pub fn nonce(&mut self, nonce: U64) -> &mut Self {
+            self.nonce = Some(nonce);
+            self
+        }
+        /// Override the account balance
+        pub fn balance(&mut self, bal: U256) -> &mut Self {
+            self.balance = Some(bal);
+            self
+        }
+        /// Override the code at the account
+        pub fn code(&mut self, code: Bytes) -> &mut Self {
+            self.code = Some(code);
+            self
+        }
+        /// Override the value of the account storage at the given storage `key`
+        pub fn store(&mut self, key: H256, val: H256) -> &mut Self {
+            self.storage.get_or_insert_with(Default::default).insert(key, val);
+            self
+        }
+    }
+
+    /// Wraps a map from storage slot to the overriden value.
+    ///
+    /// Storage overrides can either replace the existing state of an account or they can be treated
+    /// as a diff on the existing state.
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    pub enum Storage {
+        /// State Diff
+        #[serde(rename = "stateDiff")]
+        Diff(HashMap<H256, H256>),
+        /// State override
+        #[serde(rename = "state")]
+        Replace(HashMap<H256, H256>),
+    }
+
+    /// The default storage override is a diff on the existing state of the account.
+    impl Default for Storage {
+        fn default() -> Self {
+            Self::Diff(Default::default())
+        }
+    }
+    impl std::ops::Deref for Storage {
+        type Target = HashMap<H256, H256>;
+        fn deref(&self) -> &Self::Target {
+            match self {
+                Self::Diff(map) => map,
+                Self::Replace(map) => map,
+            }
+        }
+    }
+    impl std::ops::DerefMut for Storage {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            match self {
+                Self::Diff(map) => map,
+                Self::Replace(map) => map,
+            }
+        }
+    }
+
+    /// A wrapper type that holds a complete state override set.
+    #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct State(#[serde(skip_serializing_if = "HashMap::is_empty")] HashMap<Address, Account>);
+
+    impl State {
+        /// Returns a mutable reference to the [`Account`] in the map.
+        pub fn account(&mut self, adr: Address) -> &mut Account {
+            self.0.entry(adr).or_default()
+        }
+    }
+
+    /// Returns an empty state override set.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use ethers_core::{
+    /// #     types::{Address, TransactionRequest, H256, spoof},
+    /// #     utils::{parse_ether, Geth},
+    /// # };
+    /// # use ethers_providers::{Provider, Http, Middleware, call_raw::RawCall};
+    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
+    /// let geth = Geth::new().spawn();
+    /// let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
+    ///
+    /// let adr1: Address = "0x6fC21092DA55B392b045eD78F4732bff3C580e2c".parse()?;
+    /// let adr2: Address = "0x295a70b2de5e3953354a6a8344e616ed314d7251".parse()?;
+    /// let key = H256::from_low_u64_be(1);
+    /// let val = H256::from_low_u64_be(17);
+    ///
+    /// let tx = TransactionRequest::default().to(adr2).from(adr1).into();
+    ///
+    /// // override the storage at `adr2`
+    /// let mut state = spoof::state();
+    /// state.account(adr2).store(key, val);
+    ///
+    /// // override the nonce at `adr1`
+    /// state.account(adr1).nonce(2.into());
+    ///
+    /// provider.call_raw(&tx).state(&state).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn state() -> State {
+        Default::default()
+    }
+
+    /// Returns a state override set with a single element setting the balance of the address.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use ethers_core::{
+    /// #     types::{Address, TransactionRequest, H256},
+    /// #     utils::{parse_ether, Geth},
+    /// # };
+    /// # use ethers_providers::{Provider, Http, Middleware, call_raw::{RawCall, spoof}};
+    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
+    /// let geth = Geth::new().spawn();
+    /// let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
+    ///
+    /// let adr1: Address = "0x6fC21092DA55B392b045eD78F4732bff3C580e2c".parse()?;
+    /// let adr2: Address = "0x295a70b2de5e3953354a6a8344e616ed314d7251".parse()?;
+    /// let pay_amt = parse_ether(1u64)?;
+    ///
+    /// // Not enough ether to pay for the transaction
+    /// let tx = TransactionRequest::pay(adr2, pay_amt).from(adr1).into();
+    ///
+    /// // override the sender's balance for the call
+    /// let state = spoof::balance(adr1, pay_amt * 2);
+    /// provider.call_raw(&tx).state(&state).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn balance(adr: Address, bal: U256) -> State {
+        let mut state = State::default();
+        state.account(adr).balance(bal);
+        state
+    }
+
+    /// Returns a state override set with a single element setting the nonce of the address.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use ethers_core::{
+    /// #     types::{Address, TransactionRequest, H256},
+    /// #     utils::{parse_ether, Geth},
+    /// # };
+    /// # use ethers_providers::{Provider, Http, Middleware, call_raw::{RawCall, spoof}};
+    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
+    /// let geth = Geth::new().spawn();
+    /// let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
+    ///
+    /// let adr: Address = "0x6fC21092DA55B392b045eD78F4732bff3C580e2c".parse()?;
+    /// let pay_amt = parse_ether(1u64)?;
+    ///
+    /// let tx = TransactionRequest::default().from(adr).into();
+    ///
+    /// // override the sender's nonce for the call
+    /// let state = spoof::nonce(adr, 72.into());
+    /// provider.call_raw(&tx).state(&state).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn nonce(adr: Address, nonce: U64) -> State {
+        let mut state = State::default();
+        state.account(adr).nonce(nonce);
+        state
+    }
+
+    /// Returns a state override set with a single element setting the code at the address.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use ethers_core::{
+    /// #     types::{Address, TransactionRequest, H256},
+    /// #     utils::{parse_ether, Geth},
+    /// # };
+    /// # use ethers_providers::{Provider, Http, Middleware, call_raw::{RawCall, spoof}};
+    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
+    /// let geth = Geth::new().spawn();
+    /// let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
+    ///
+    /// let adr: Address = "0x6fC21092DA55B392b045eD78F4732bff3C580e2c".parse()?;
+    /// let pay_amt = parse_ether(1u64)?;
+    ///
+    /// let tx = TransactionRequest::default().to(adr).into();
+    ///
+    /// // override the code at the target address
+    /// let state = spoof::code(adr, "0x00".parse()?);
+    /// provider.call_raw(&tx).state(&state).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn code(adr: Address, code: Bytes) -> State {
+        let mut state = State::default();
+        state.account(adr).code(code);
+        state
+    }
+
+    /// Returns a state override set with a single element setting the storage at the given address
+    /// and key.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use ethers_core::{
+    /// #     types::{Address, TransactionRequest, H256},
+    /// #     utils::{parse_ether, Geth},
+    /// # };
+    /// # use ethers_providers::{Provider, Http, Middleware, call_raw::{RawCall, spoof}};
+    /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
+    /// let geth = Geth::new().spawn();
+    /// let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();
+    ///
+    /// let adr: Address = "0x6fC21092DA55B392b045eD78F4732bff3C580e2c".parse()?;
+    /// let key = H256::from_low_u64_be(1);
+    /// let val = H256::from_low_u64_be(17);
+    ///
+    /// let tx = TransactionRequest::default().to(adr).into();
+    ///
+    /// // override the storage slot `key` at `adr`
+    /// let state = spoof::storage(adr, key, val);
+    /// provider.call_raw(&tx).state(&state).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn storage(adr: Address, key: H256, val: H256) -> State {
+        let mut state = State::default();
+        state.account(adr).store(key, val);
+        state
+    }
 }

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -205,20 +205,21 @@ impl<P: JsonRpcClient> Provider<P> {
     /// Analogous to [`Middleware::call`], but returns a [`CallBuilder`] that can either be
     /// `.await`d or used to override the parameters sent to `eth_call`.
     ///
-    /// See the [`call_raw::spoof`] for functions to construct state override parameters.
+    /// See the [`ethers_core::types::spoof`] for functions to construct state override
+    /// parameters.
     ///
     /// Note: this method _does not_ send a transaction from your account
     ///
-    /// [`call_raw::spoof`]: crate::call_raw::spoof
+    /// [`ethers_core::types::spoof`]: ethers_core::types::spoof
     ///
     /// # Example
     ///
     /// ```no_run
     /// # use ethers_core::{
-    /// #     types::{Address, TransactionRequest, H256},
+    /// #     types::{Address, TransactionRequest, H256, spoof},
     /// #     utils::{parse_ether, Geth},
     /// # };
-    /// # use ethers_providers::{Provider, Http, Middleware, call_raw::{RawCall, spoof}};
+    /// # use ethers_providers::{Provider, Http, Middleware, call_raw::RawCall};
     /// # async fn foo() -> Result<(), Box<dyn std::error::Error>> {
     /// let geth = Geth::new().spawn();
     /// let provider = Provider::<Http>::try_from(geth.endpoint()).unwrap();

--- a/examples/transactions/examples/call_override.rs
+++ b/examples/transactions/examples/call_override.rs
@@ -1,13 +1,10 @@
 use ethers::{
     contract::abigen,
     core::{
-        types::{Address, TransactionRequest, H256},
+        types::{spoof, Address, TransactionRequest, H256},
         utils::{parse_ether, Geth},
     },
-    providers::{
-        call_raw::{self, RawCall},
-        Http, Provider,
-    },
+    providers::{call_raw::RawCall, Http, Provider},
 };
 use eyre::Result;
 use std::{
@@ -42,7 +39,7 @@ async fn main() -> Result<()> {
     // Override the sender's balance for the call
     let pay_amt = parse_ether(1u64)?;
     let tx = TransactionRequest::pay(target, pay_amt).from(from);
-    let state = call_raw::balance(from, pay_amt * 2);
+    let state = spoof::balance(from, pay_amt * 2);
 
     // The call succeeds as if the sender had sufficient balance
     client.call_raw(&tx.into()).state(&state).await.expect("balance override");
@@ -57,7 +54,7 @@ async fn main() -> Result<()> {
 
     // Override the target account's code, simulating a call to Greeter.greet()
     // as if the Greeter contract was deployed at the target address
-    let state = call_raw::code(target, runtime_bytecode.clone());
+    let state = spoof::code(target, runtime_bytecode.clone());
     let res = greeter.greet().call_raw().state(&state).await?;
 
     // greet() returns the empty string, because the target account's storage is empty
@@ -69,7 +66,7 @@ async fn main() -> Result<()> {
     let greet_val = encode_string_for_storage(greeting);
 
     // Override the target account's code and storage
-    let mut state = call_raw::state();
+    let mut state = spoof::state();
     state.account(target).code(runtime_bytecode.clone()).store(greet_slot, greet_val);
     let res = greeter.greet().call_raw().state(&state).await?;
 

--- a/examples/transactions/examples/trace_call.rs
+++ b/examples/transactions/examples/trace_call.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<()> {
                 )),
                 ..Default::default()
             },
+            state_overrides: None,
         };
         let traces = client.debug_trace_call(tx, Some(block), options).await?;
         println!("{traces:?}");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
i want to use `stateoverrides` in `debug_traceCall`

## Solution
as described in #2298
- move `ethers_providers::types::geth::spoof` module to `ethers_core`
- add `state_overrides` to `GethDebugTracingCallOptions`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
