### PR TITLE
fix(types): make Arbitrum, Arbitrum Goerli, Arbitrum Nova EIP1559 comp

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -320,10 +320,7 @@ impl Chain {
             FantomTestnet |
             BinanceSmartChain |
             BinanceSmartChainTestnet |
-            Arbitrum |
             ArbitrumTestnet |
-            ArbitrumGoerli |
-            ArbitrumNova |
             Rsk |
             Oasis |
             Emerald |
@@ -346,6 +343,9 @@ impl Chain {
             PolygonMumbai |
             Avalanche |
             AvalancheFuji |
+            Arbitrum |
+            ArbitrumGoerli |
+            ArbitrumNova |
             FilecoinMainnet |
             FilecoinHyperspaceTestnet => false,
 


### PR DESCRIPTION
## Motivation

Arbitrum mainnet, Arbitrum Goerli and Arbitrum Nova recently switched to EIP1559 as can be seen from those example transactions:

- https://arbiscan.io/tx/0x379eea89ec6c41ad8df678bbb49cd51e30aa444ed9d8c69a2c3bc522ced1155b
- https://goerli.arbiscan.io/tx/0xaf9263c706c05cc024410fc6745ccf096ce5b56cd8ebb837f9b0cb21274628cf
- https://nova.arbiscan.io/tx/0x38956afabf59ce8dc99c3a82ebff760ad1e78df0e3cd25f69d43adbf4276d30f

This PR updates ethers to indicate all of the chains above as non legacy.

## Solution

Change the `is_legacy` function to return `false` for Arbitrum mainnet, Arbitrum Goerli and Arbitrum Nova.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
