### PR TITLE
chore: make `abigen` offline by default, fix `ethers-solc` features

### DIFF
--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -50,8 +50,8 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 [features]
 default = ["abigen"]
 
-abigen-offline = ["ethers-contract-abigen", "ethers-contract-derive"]
-abigen = ["abigen-offline", "ethers-contract-abigen/online"]
+abigen = ["ethers-contract-abigen", "ethers-contract-derive"]
+abigen-online = ["abigen", "ethers-contract-abigen/online"]
 
 celo = ["legacy", "ethers-core/celo", "ethers-providers/celo"]
 legacy = []
@@ -59,5 +59,6 @@ legacy = []
 rustls = ["ethers-contract-abigen/rustls"]
 openssl = ["ethers-contract-abigen/openssl"]
 
-# Deprecated
+# Deprecated, enabled by default
+abigen-offline = []
 eip712 = []

--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -56,8 +56,8 @@ getrandom.workspace = true
 
 [features]
 online = ["reqwest", "ethers-etherscan", "url", "tokio"]
-openssl = ["online", "reqwest/native-tls", "ethers-etherscan/openssl"]
-rustls = ["online", "reqwest/rustls-tls", "ethers-etherscan/rustls"]
+rustls = ["reqwest?/rustls-tls", "ethers-etherscan?/rustls"]
+openssl = ["reqwest?/native-tls", "ethers-etherscan?/openssl"]
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/ethers-contract/ethers-contract-abigen/src/source/mod.rs
+++ b/ethers-contract/ethers-contract-abigen/src/source/mod.rs
@@ -107,7 +107,13 @@ impl Source {
         if let Ok(canonicalized) = dunce::canonicalize(&resolved) {
             resolved = canonicalized;
         } else {
-            return Err(eyre::eyre!("File does not exist: {}", resolved.display()))
+            let path = resolved.display().to_string();
+            let err = if path.contains(':') {
+                eyre::eyre!("File does not exist: {path}\nYou may need to enable the `online` feature to parse this source.")
+            } else {
+                eyre::eyre!("File does not exist: {path}")
+            };
+            return Err(err)
         }
 
         Ok(Source::Local(resolved))

--- a/ethers-contract/ethers-contract-abigen/src/source/online.rs
+++ b/ethers-contract/ethers-contract-abigen/src/source/online.rs
@@ -196,7 +196,7 @@ mod tests {
             let tests2 = tests2.collect::<Result<Vec<_>>>().unwrap();
 
             for slice in tests2.windows(2) {
-                let (a, b) = (&slice[0], &slice[1]);
+                let [a, b] = slice else { unreachable!() };
                 if a != b {
                     panic!("Expected: {expected:?}; Got: {a:?} | {b:?}");
                 }

--- a/ethers-contract/src/event.rs
+++ b/ethers-contract/src/event.rs
@@ -177,7 +177,6 @@ where
     ///  while let Some(Ok(approval)) = event_stream.next().await {
     ///      let Approval{token_owner,spender,tokens} = approval;
     /// }
-    ///
     /// # }
     /// ```
     pub async fn stream(

--- a/ethers-etherscan/Cargo.toml
+++ b/ethers-etherscan/Cargo.toml
@@ -52,5 +52,9 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 [features]
 default = ["rustls"]
-openssl = ["reqwest/native-tls"]
 rustls = ["reqwest/rustls-tls"]
+openssl = ["reqwest/native-tls"]
+
+ethers-solc = ["dep:ethers-solc"]
+solc-full = ["ethers-solc?/full"]
+solc-tests = ["ethers-solc?/tests"]

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -65,5 +65,5 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 [features]
 default = ["rustls"]
 celo = ["ethers-core/celo", "ethers-providers/celo", "ethers-signers/celo", "ethers-contract/celo"]
-openssl = ["reqwest/native-tls"]
 rustls = ["reqwest/rustls-tls"]
+openssl = ["reqwest/native-tls"]

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -85,10 +85,10 @@ ws = ["tokio-tungstenite", "futures-channel"]
 legacy-ws = ["ws"]
 ipc = ["tokio/io-util", "futures-channel", "winapi"]
 
-openssl = ["tokio-tungstenite/native-tls", "reqwest/native-tls"]
 # we use the webpki roots so we can build static binaries w/o any root cert dependencies
 # on the host
 rustls = ["tokio-tungstenite/rustls-tls-webpki-roots", "reqwest/rustls-tls"]
+openssl = ["tokio-tungstenite/native-tls", "reqwest/native-tls"]
 dev-rpc = []
 
 [dev-dependencies]

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -117,8 +117,8 @@ svm-solc = ["svm", "svm-builds", "sha2"]
 project-util = ["tempfile", "fs_extra", "rand"]
 
 tests = []
-openssl = ["svm?/openssl"]
 rustls = ["svm?/rustls"]
+openssl = ["svm?/openssl"]
 
 # Deprecated
 asm = []

--- a/ethers/Cargo.toml
+++ b/ethers/Cargo.toml
@@ -26,53 +26,56 @@ all-features = true
 [features]
 default = ["abigen", "rustls"]
 
+# workspace-wide features
+legacy = ["ethers-core/legacy", "ethers-contract/legacy"]
 celo = [
+    "ethers-contract/celo",
     "ethers-core/celo",
+    "ethers-middleware/celo",
     "ethers-providers/celo",
     "ethers-signers/celo",
-    "ethers-contract/celo",
-    "ethers-middleware/celo",
     "legacy",
 ]
 
-legacy = ["ethers-core/legacy", "ethers-contract/legacy"]
+rustls = [
+    "ethers-contract/rustls",
+    "ethers-etherscan/rustls",
+    "ethers-middleware/rustls",
+    "ethers-providers/rustls",
+    "ethers-solc?/rustls",
+]
+openssl = [
+    "ethers-contract/openssl",
+    "ethers-etherscan/openssl",
+    "ethers-middleware/openssl",
+    "ethers-providers/openssl",
+    "ethers-solc?/openssl",
+]
 
-# individual features per sub-crate
-## providers
+# ethers-providers
 ws = ["ethers-providers/ws"]
 legacy-ws = ["ethers-providers/legacy-ws"]
 ipc = ["ethers-providers/ipc"]
-rustls = [
-    "ethers-middleware/rustls",
-    "ethers-providers/rustls",
-    "ethers-etherscan/rustls",
-    "ethers-contract/rustls",
-    "ethers-solc/rustls",
-]
-openssl = [
-    "ethers-middleware/openssl",
-    "ethers-providers/openssl",
-    "ethers-etherscan/openssl",
-    "ethers-contract/openssl",
-    "ethers-solc/openssl",
-]
 dev-rpc = ["ethers-providers/dev-rpc"]
-## signers
+
+# ethers-signers
 ledger = ["ethers-signers/ledger"]
 trezor = ["ethers-signers/trezor"]
 yubi = ["ethers-signers/yubi"]
-## contracts
+
+# ethers-contracts
 abigen = ["ethers-contract/abigen"]
-### abigen without reqwest
-abigen-offline = ["ethers-contract/abigen-offline"]
-## solc
+abigen-online = ["ethers-contract/abigen-online"]
+
+# ethers-solc
 ethers-solc = ["dep:ethers-solc", "ethers-etherscan/ethers-solc"]
 solc-full = ["ethers-solc?/full"]
 solc-tests = ["ethers-solc?/tests"]
 
 # Deprecated
-solc-sha2-asm = []
+abigen-offline = ["abigen"]
 eip712 = []
+solc-sha2-asm = []
 
 [dependencies]
 ethers-addressbook.workspace = true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

- `Multicall` and other stuff gated by `#[cfg(feature = "abigen")]` in `ethers-contract` are not accessible with `abigen-offline`
- `ethers-contract-abigen` is online by default in `ethers-contract` and `ethers`. If there are both `ethers-contract-abigen` as a build script, and `ethers{-contract}` with the `abigen` feature, then it will be built twice: once without `online` for the build script, and once with `online`.
- forward `ethers-solc` features from `ethers-etherscan`

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
