### PR TITLE
feat(solc): `0.8.20` support & set Shanghai as default EVM Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3944,9 +3944,8 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "svm-rs"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01afefe60c02f4a2271fb15d1965c37856712cebb338330b06649d12afec42df"
+version = "0.2.23"
+source = "git+https://github.com/Evalir/svm-rs.git#bbc15c3b1f3e6d03e68b9b49525fe5fa2f5bffca"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3975,9 +3974,8 @@ dependencies = [
 
 [[package]]
 name = "svm-rs-builds"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e69c19996b709c881de264a6ce64609ff305ef0bf59fc45243ac5a67291afd1"
+version = "0.1.15"
+source = "git+https://github.com/Evalir/svm-rs.git#bbc15c3b1f3e6d03e68b9b49525fe5fa2f5bffca"
 dependencies = [
  "build_const",
  "hex",

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -60,10 +60,10 @@ futures-util = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 home.workspace = true
-svm = { package = "svm-rs", version = "0.2", default-features = false, features = [
+svm = { package = "svm-rs", git = "https://github.com/Evalir/svm-rs.git", default-features = false, features = [
     "blocking",
 ], optional = true }
-svm-builds = { package = "svm-rs-builds", version = "0.1", optional = true }
+svm-builds = { package = "svm-rs-builds", git = "https://github.com/Evalir/svm-rs.git", optional = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -749,7 +749,7 @@ pub enum EvmVersion {
     Berlin,
     London,
     Paris,
-    #[default] 
+    #[default]
     Shanghai,
 }
 
@@ -760,9 +760,7 @@ impl EvmVersion {
         if *version >= BYZANTIUM_SOLC {
             // If the Solc is at least at Shanghai, it supports all EVM versions.
             // For all other cases, cap at the at-the-time highest possible fork.
-            let normalized = if self >= Self::Shanghai &&
-                *version >= SHANGHAI_SOLC
-            {
+            let normalized = if self >= Self::Shanghai && *version >= SHANGHAI_SOLC {
                 self
             } else if self >= Self::Paris && *version >= PARIS_SOLC {
                 Self::Paris

--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -748,8 +748,8 @@ pub enum EvmVersion {
     Istanbul,
     Berlin,
     London,
-    #[default] // TODO: Move to Shanghai once Solc 0.8.20 is released
     Paris,
+    #[default] 
     Shanghai,
 }
 
@@ -761,8 +761,7 @@ impl EvmVersion {
             // If the Solc is at least at Shanghai, it supports all EVM versions.
             // For all other cases, cap at the at-the-time highest possible fork.
             let normalized = if self >= Self::Shanghai &&
-                // TODO: Remove once Solc 0.8.20 is released
-                SUPPORTS_SHANGHAI.matches(version)
+                *version >= SHANGHAI_SOLC
             {
                 self
             } else if self >= Self::Paris && *version >= PARIS_SOLC {
@@ -2402,22 +2401,6 @@ mod tests {
             ("0.8.20", EvmVersion::Homestead, Some(EvmVersion::Homestead)),
             ("0.8.20", EvmVersion::Paris, Some(EvmVersion::Paris)),
             ("0.8.20", EvmVersion::Shanghai, Some(EvmVersion::Shanghai)),
-            // TODO: Remove once Solc 0.8.20 is released
-            (
-                "0.8.20-nightly.2023.4.12+commit.f0c0df2d",
-                EvmVersion::Shanghai,
-                Some(EvmVersion::Paris),
-            ),
-            (
-                "0.8.20-nightly.2023.4.13+commit.5d42bb5e",
-                EvmVersion::Shanghai,
-                Some(EvmVersion::Shanghai),
-            ),
-            (
-                "0.8.20-nightly.2023.4.14+commit.e1a9446f",
-                EvmVersion::Shanghai,
-                Some(EvmVersion::Shanghai),
-            ),
         ] {
             assert_eq!(
                 &evm_version.normalize_version(&Version::from_str(solc_version).unwrap()),

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -50,15 +50,8 @@ pub const LONDON_SOLC: Version = Version::new(0, 8, 7);
 pub const PARIS_SOLC: Version = Version::new(0, 8, 18);
 
 /// Shanghai support
-// TODO: Solc blogpost link
+// <https://blog.soliditylang.org/2023/05/10/solidity-0.8.20-release-announcement/>
 pub const SHANGHAI_SOLC: Version = Version::new(0, 8, 20);
-
-/// This will be removed once 0.8.20 is released.
-///
-/// Shanghai support was added in [ethereum/solidity#14107](https://github.com/ethereum/solidity/pull/14107),
-/// which was released in `nightly.2023.4.13`.
-pub(crate) static SUPPORTS_SHANGHAI: Lazy<VersionReq> =
-    Lazy::new(|| VersionReq::parse(">=0.8.20-nightly.2023.4.13").unwrap());
 
 // `--base-path` was introduced in 0.6.9 <https://github.com/ethereum/solidity/releases/tag/v0.6.9>
 pub static SUPPORTS_BASE_PATH: Lazy<VersionReq> =


### PR DESCRIPTION
## Motivation

Currently SVM is blocking ethers from being bumped so we can soon cut a Foundry 1.0 release. While we deal with transferring repos, I went ahead and forked the necessary repos and updated everything.

## Solution

Sets svm-rs to use the forked repo in the meanwhile, and implements all the necessary changes to use shanghai and 0.8.20.

cc @DaniPopes looping you in for if i missed anything—edits by maintainers should be enabled

