### PR TITLE
fix(ethers-solc): Error instead of panic when checking if the checksum was found

### DIFF
--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -480,7 +480,10 @@ impl Solc {
         hasher.update(content);
         let checksum_calc = &hasher.finalize()[..];
 
-        let checksum_found = &RELEASES.0.get_checksum(&version).ok_or_else(|| SolcError::ChecksumNotFound { version: version.clone() } )?;
+        let checksum_found = &RELEASES
+            .0
+            .get_checksum(&version)
+            .ok_or_else(|| SolcError::ChecksumNotFound { version: version.clone() })?;
 
         if checksum_calc == checksum_found {
             Ok(())

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -480,7 +480,7 @@ impl Solc {
         hasher.update(content);
         let checksum_calc = &hasher.finalize()[..];
 
-        let checksum_found = &RELEASES.0.get_checksum(&version).expect("checksum not found");
+        let checksum_found = &RELEASES.0.get_checksum(&version).ok_or_else(|| SolcError::ChecksumNotFound { version: version.clone() } )?;
 
         if checksum_calc == checksum_found {
             Ok(())

--- a/ethers-solc/src/error.rs
+++ b/ethers-solc/src/error.rs
@@ -19,6 +19,8 @@ pub enum SolcError {
     VersionNotFound,
     #[error("Checksum mismatch for {file}: expected {expected} found {detected} for {version}")]
     ChecksumMismatch { version: Version, expected: String, detected: String, file: PathBuf },
+    #[error("Checksum not found for {version}")]
+    ChecksumNotFound { version: Version },
     #[error(transparent)]
     SemverError(#[from] semver::Error),
     /// Deserialization error


### PR DESCRIPTION
## Motivation

Ran this while debugging an unrelated issue—I had installed 0.8.20 through an SVM fork and was running into this panic when running foundry. While this is correct and should error due to an unfound checksum (as i wasn't using the canonical svm-rs), this panic should probably be an error cc @mattsse 

## Solution

Turn this panic into an error, and add a `ChecksumNotFound` variant to `SolcError`.