### PR TITLE
chore: accept v0.8.20

### DIFF
--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -853,7 +853,7 @@ mod tests {
             // update this test whenever there's a new sol
             // version. that's ok! good reminder to check the
             // patch notes.
-            (">=0.5.0", "0.8.19"),
+            (">=0.5.0", "0.8.20"),
             // range
             (">=0.4.0 <0.5.0", "0.4.26"),
         ]


### PR DESCRIPTION
Bumping the max detection range to 0.8.20 now that svm-rs has been bumped.