### PR TITLE
add subscribe_full_pending_txs()

### DIFF
--- a/ethers-middleware/src/timelag/mod.rs
+++ b/ethers-middleware/src/timelag/mod.rs
@@ -380,6 +380,15 @@ where
         Err(TimeLagError::Unsupported)
     }
 
+    async fn subscribe_full_pending_txs(
+        &self,
+    ) -> Result<ethers_providers::SubscriptionStream<'_, Self::Provider, Transaction>, Self::Error>
+    where
+        Self::Provider: ethers_providers::PubsubClient,
+    {
+        Err(TimeLagError::Unsupported)
+    }
+
     async fn subscribe_logs<'a>(
         &'a self,
         _filter: &ethers_core::types::Filter,

--- a/ethers-providers/src/middleware.rs
+++ b/ethers-providers/src/middleware.rs
@@ -926,6 +926,8 @@ pub trait Middleware: Sync + Send + Debug {
     /// or IPC. For a polling alternative available over HTTP, use
     /// [`Middleware::watch_pending_transactions`]. However, be aware that
     /// polling increases RPC usage drastically.
+    ///
+    /// Note: This endpoint is compatible only with Geth client version 1.11.0 or later.
     async fn subscribe_full_pending_txs(
         &self,
     ) -> Result<SubscriptionStream<'_, Self::Provider, Transaction>, Self::Error>

--- a/ethers-providers/src/middleware.rs
+++ b/ethers-providers/src/middleware.rs
@@ -905,7 +905,7 @@ pub trait Middleware: Sync + Send + Debug {
         self.inner().subscribe_blocks().await.map_err(MiddlewareError::from_err)
     }
 
-    /// Subscribe to a stream of pending transactions.
+    /// Subscribe to a stream of pending transaction hashes.
     ///
     /// This function is only available on pubsub clients, such as Websockets
     /// or IPC. For a polling alternative available over HTTP, use
@@ -918,6 +918,21 @@ pub trait Middleware: Sync + Send + Debug {
         <Self as Middleware>::Provider: PubsubClient,
     {
         self.inner().subscribe_pending_txs().await.map_err(MiddlewareError::from_err)
+    }
+
+    /// Subscribe to a stream of pending transaction bodies.
+    ///
+    /// This function is only available on pubsub clients, such as Websockets
+    /// or IPC. For a polling alternative available over HTTP, use
+    /// [`Middleware::watch_pending_transactions`]. However, be aware that
+    /// polling increases RPC usage drastically.
+    async fn subscribe_full_pending_txs(
+        &self,
+    ) -> Result<SubscriptionStream<'_, Self::Provider, Transaction>, Self::Error>
+    where
+        <Self as Middleware>::Provider: PubsubClient,
+    {
+        self.inner().subscribe_full_pending_txs().await.map_err(MiddlewareError::from_err)
     }
 
     /// Subscribe to a stream of event logs matchin the provided [`Filter`].

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -1049,6 +1049,15 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.subscribe(["newPendingTransactions"]).await
     }
 
+    async fn subscribe_full_pending_txs(
+        &self,
+    ) -> Result<SubscriptionStream<'_, P, Transaction>, ProviderError>
+    where
+        P: PubsubClient,
+    {
+        self.subscribe([utils::serialize(&"newPendingTransactions"), utils::serialize(&true)]).await
+    }
+
     async fn subscribe_logs<'a>(
         &'a self,
         filter: &Filter,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
geth recently added [SubscribeFullPendingTransactions](https://github.com/ethereum/go-ethereum/blob/73697529994e14996b7740730481e926d5ec3e40/ethclient/gethclient/gethclient.go#L196)

this PR just adds a new method called ```subscribe_full_pending_txs()```, which instead of streaming hashes, streams
whole tx bodies. the only edit was adding ```true``` as a additional parameter, so ```subscribe([utils::serialize(&"newPendingTransactions"), utils::serialize(&true)])```.
 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
