### PR TITLE
fix(`ethers-etherscan`): make typo on verify constructor arguments an alias

### DIFF
--- a/ethers-etherscan/src/verify.rs
+++ b/ethers-etherscan/src/verify.rs
@@ -24,8 +24,13 @@ pub struct VerifyContract {
     /// applicable when codeformat=solidity-single-file
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runs: Option<String>,
-    /// NOTE: there is a typo in the etherscan API `constructorArguements`
-    #[serde(rename = "constructorArguements", skip_serializing_if = "Option::is_none")]
+    /// NOTE: the alias with a typo is due to an old typo in the etherscan API
+    /// `constructorArguements`, but blockscout requires that it's spelled correctly.
+    #[serde(
+        rename = "constructorArguments",
+        alias = "constructorArguements",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub constructor_arguments: Option<String>,
     /// applicable when codeformat=solidity-single-file
     #[serde(rename = "evmversion", skip_serializing_if = "Option::is_none")]

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -311,7 +311,7 @@ impl Solc {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(all(not(target_arch = "wasm32"), all(feature = "svm-solc")))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "svm-solc"))]
     pub fn find_or_install_svm_version(version: impl AsRef<str>) -> Result<Self> {
         let version = version.as_ref();
         if let Some(solc) = Solc::find_svm_installed_version(version)? {


### PR DESCRIPTION
This has to do with https://github.com/foundry-rs/foundry/issues/4909 — the typo on the `constructor_arguments` rename (required due to etherscan) is making blockscout complain. This sets the correct name as a rename and aliases the typo.
