### PR TITLE
fix(`verify`): make verification result an option to handle blockscout's format

### DIFF
--- a/ethers-etherscan/src/contract.rs
+++ b/ethers-etherscan/src/contract.rs
@@ -10,7 +10,6 @@ use ethers_core::{
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path};
-use tracing::trace;
 
 #[cfg(feature = "ethers-solc")]
 use ethers_solc::{artifacts::Settings, EvmVersion, Project, ProjectBuilder, SolcConfig};

--- a/ethers-etherscan/src/contract.rs
+++ b/ethers-etherscan/src/contract.rs
@@ -9,8 +9,8 @@ use ethers_core::{
 };
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use tracing::trace;
 use std::{collections::HashMap, path::Path};
+use tracing::trace;
 
 #[cfg(feature = "ethers-solc")]
 use ethers_solc::{artifacts::Settings, EvmVersion, Project, ProjectBuilder, SolcConfig};
@@ -340,7 +340,9 @@ impl Client {
             return Err(EtherscanError::RateLimitExceeded)
         }
 
-        if result.starts_with("Contract source code not verified") || resp.message.starts_with("Contract source code not verified") {
+        if result.starts_with("Contract source code not verified") ||
+            resp.message.starts_with("Contract source code not verified")
+        {
             if let Some(ref cache) = self.cache {
                 cache.set_abi(address, None);
             }

--- a/ethers-etherscan/src/contract.rs
+++ b/ethers-etherscan/src/contract.rs
@@ -333,7 +333,15 @@ impl Client {
         let query = self.create_query("contract", "getabi", HashMap::from([("address", address)]));
         let resp: Response<Option<String>> = self.get_json(&query).await?;
 
-        let result = resp.result.unwrap_or("".to_string());
+        let result = match resp.result {
+            Some(result) => result,
+            None => {
+                return Err(EtherscanError::EmptyResult {
+                    message: resp.message,
+                    status: resp.status,
+                })
+            }
+        };
 
         if result.starts_with("Max rate limit reached") {
             return Err(EtherscanError::RateLimitExceeded)

--- a/ethers-etherscan/src/errors.rs
+++ b/ethers-etherscan/src/errors.rs
@@ -23,7 +23,7 @@ pub enum EtherscanError {
     Serde(#[from] serde_json::Error),
     #[error("Contract source code not verified: {0}")]
     ContractCodeNotVerified(Address),
-    #[error("Response result is unexpectedly empty")]
+    #[error("Response result is unexpectedly empty: status={status}, message={message}")]
     EmptyResult { status: String, message: String },
     #[error("Rate limit exceeded")]
     RateLimitExceeded,

--- a/ethers-etherscan/src/errors.rs
+++ b/ethers-etherscan/src/errors.rs
@@ -23,6 +23,8 @@ pub enum EtherscanError {
     Serde(#[from] serde_json::Error),
     #[error("Contract source code not verified: {0}")]
     ContractCodeNotVerified(Address),
+    #[error("Response result is unexpectedly empty")]
+    EmptyResult { status: String, message: String },
     #[error("Rate limit exceeded")]
     RateLimitExceeded,
     #[error(transparent)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

I've been investigating verification issues due to https://github.com/foundry-rs/foundry/issues/4909 — and it turns out that blockscout, unlike etherscan, likes to return `null` on the `result` field sometimes, instead of an empty string on `message` and the actual message on the `result` field, like etherscan. This in turn introduced a bug when detecting if a contract was already verified as it expects that the blockscout format is identical to etherscan's. 

To be a bit more specifc, this format is returned by blockscout when a contract is not verified, and this is _not_ what etherscan returns (see the `null` in result):

```
{
  "message": "Contract source code not verified",
  "result": null,
  "status": "0"
}
```

While making a blockscout verification client might be the "best" fix, this is a slight difference in formats and I opted for this solution instead. We can handle separating blockscout & etherscan verification later.

## Solution

Parses the `result` field from the API response as an Option instead of just a string, to handle cases where result is `null`.
