### PR TITLE
feat: add nonce helper function

### DIFF
--- a/ethers-contract/src/call.rs
+++ b/ethers-contract/src/call.rs
@@ -256,6 +256,12 @@ where
         self.block = Some(block.into());
         self
     }
+
+    /// Sets the `nonce` field in the transaction to the provided value
+    pub fn nonce<T: Into<U256>>(mut self, nonce: T) -> Self {
+        self.tx.set_nonce(nonce);
+        self
+    }
 }
 
 impl<B, M, D> FunctionCall<B, M, D>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->
Add a helper function to override nonce in contact `FunctionCall`

## Motivation

Currently, there is no way to override nonce from the contract `FunctionCall` struct. It would be useful to make it easier to override nonce too as it is with value, gas and gas price 

## Solution

I added a helper function to set the nonce, so it can be overridden before a transaction is submitted.

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
