### PR TITLE
feat(core): Utility to detect Shanghai-enabled chains

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -360,6 +360,13 @@ impl Chain {
         }
     }
 
+    pub const fn is_shanghai(&self) -> bool {
+        match self {
+            Chain::Mainnet | Chain::Goerli | Chain::Sepolia => true,
+            _ => false,
+        }
+    }
+
     /// Returns the chain's blockchain explorer and its API (Etherscan and Etherscan-like) URLs.
     ///
     /// Returns `(API_URL, BASE_URL)`

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -363,7 +363,7 @@ impl Chain {
     /// Returns whether the chain supports the `PUSH0` opcode or not.
     ///
     /// For more information, see EIP-3855:
-    /// https://eips.ethereum.org/EIPS/eip-3855
+    /// `<https://eips.ethereum.org/EIPS/eip-3855>`
     pub const fn supports_push0(&self) -> bool {
         match self {
             Chain::Mainnet | Chain::Goerli | Chain::Sepolia => true,

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -360,7 +360,11 @@ impl Chain {
         }
     }
 
-    pub const fn is_shanghai(&self) -> bool {
+    /// Returns whether the chain supports the `PUSH0` opcode or not.
+    ///
+    /// For more information, see EIP-3855:
+    /// https://eips.ethereum.org/EIPS/eip-3855
+    pub const fn supports_push0(&self) -> bool {
         match self {
             Chain::Mainnet | Chain::Goerli | Chain::Sepolia => true,
             _ => false,


### PR DESCRIPTION
## Motivation

We want to better handle EVM discrepancies between different chains (see https://github.com/foundry-rs/foundry/issues/748). One of these things would be a little utility on the `Chain` type to quickly detect if a chain is Shanghai-enabled or not.

## Solution

Adds the utility

## PR Checklist

-   [n/a] Added Tests
-   [n/a] Added Documentation
-   [n/a] Breaking changes
