### PR TITLE
feat: allow for Authorization header override with raw parameter

### DIFF
--- a/ethers-providers/src/rpc/transports/common.rs
+++ b/ethers-providers/src/rpc/transports/common.rs
@@ -236,6 +236,8 @@ pub enum Authorization {
     Basic(String),
     /// Bearer Auth
     Bearer(String),
+    /// If you need to override the Authorization header value
+    Raw(String),
 }
 
 impl Authorization {
@@ -251,6 +253,11 @@ impl Authorization {
     pub fn bearer(token: impl Into<String>) -> Self {
         Self::Bearer(token.into())
     }
+
+    /// Override the Authorization header with your own string
+    pub fn raw(token: impl Into<String>) -> Self {
+        Self::Raw(token.into())
+    }
 }
 
 impl fmt::Display for Authorization {
@@ -258,6 +265,7 @@ impl fmt::Display for Authorization {
         match self {
             Authorization::Basic(auth_secret) => write!(f, "Basic {auth_secret}"),
             Authorization::Bearer(token) => write!(f, "Bearer {token}"),
+            Authorization::Raw(s) => write!(f, "{s}"),
         }
     }
 }


### PR DESCRIPTION
This PR creates a Raw Authorization type which allows the user to set the full Authorization header in a websocket request if the server they are connecting to does not conform to Bearer or Basic auth.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [trivial change ] Added Tests
-   [x ] Added Documentation
-   [ no] Breaking changes
