### PR TITLE
fix: remove deprecated mining threads arg

### DIFF
--- a/ethers-providers/src/middleware.rs
+++ b/ethers-providers/src/middleware.rs
@@ -673,12 +673,9 @@ pub trait Middleware: Sync + Send + Debug {
 
     // Miner namespace
 
-    /// Starts the miner with the given number of threads. If threads is nil, the number of workers
-    /// started is equal to the number of logical CPUs that are usable by this process. If mining
-    /// is already running, this method adjust the number of threads allowed to use and updates the
-    /// minimum price required by the transaction pool.
-    async fn start_mining(&self, threads: Option<usize>) -> Result<(), Self::Error> {
-        self.inner().start_mining(threads).await.map_err(MiddlewareError::from_err)
+    /// Starts the miner.
+    async fn start_mining(&self) -> Result<(), Self::Error> {
+        self.inner().start_mining().await.map_err(MiddlewareError::from_err)
     }
 
     /// Stop terminates the miner, both at the consensus engine level as well as at

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -763,9 +763,8 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.request("admin_removeTrustedPeer", [enode_url]).await
     }
 
-    async fn start_mining(&self, threads: Option<usize>) -> Result<(), Self::Error> {
-        let threads = utils::serialize(&threads);
-        self.request("miner_start", [threads]).await
+    async fn start_mining(&self) -> Result<(), Self::Error> {
+        self.request("miner_start", ()).await
     }
 
     async fn stop_mining(&self) -> Result<(), Self::Error> {


### PR DESCRIPTION
## Motivation
Geth removed the `threads` arg from `miner_start`, in 1.12.0 with https://github.com/ethereum/go-ethereum/pull/27178 so we remove it as well. The endpoint is still necessary for clique block production.

## Solution
Remove the argument from `miner_start`

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
