### PR TITLE
feat(ethers-core): OP Bedrock Upgrade

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -315,8 +315,6 @@ impl Chain {
 
         match self {
             // Known legacy chains / non EIP-1559 compliant
-            Optimism |
-            OptimismGoerli |
             OptimismKovan |
             Fantom |
             FantomTestnet |
@@ -341,6 +339,8 @@ impl Chain {
             Mainnet |
             Goerli |
             Sepolia |
+            Optimism |
+            OptimismGoerli |
             Polygon |
             PolygonMumbai |
             Avalanche |

--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -545,7 +545,7 @@ mod tests {
         };
         let mut tx = TypedTransaction::Eip1559(eip1559);
 
-        let chain_id = 10u64; // optimism does not support EIP-1559
+        let chain_id = 324u64; // zksync does not support EIP-1559
 
         // Signer middlewares now rely on a working provider which it can query the chain id from,
         // so we make sure Anvil is started with the chain id that the expected tx was signed


### PR DESCRIPTION
## Overview

Sets Optimism Mainnet / Goerli as an EIP-1559 supporting chain in `chain.rs`.

## Motivation

Optimism Mainnet / Goerli both support EIP-1559 after the Bedrock upgrade.

## PR Checklist

-   [x] ~~Added Tests~~ Altered existing test
-   [x] ~~Added Documentation~~ n/a
-   [x] Breaking changes
