### PR TITLE
fix: allow arrays in abigen 'methods'

### DIFF
--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -25,6 +25,7 @@ all-features = true
 [dependencies]
 ethers-providers.workspace = true
 ethers-core.workspace = true
+ethers-signers.workspace = true
 
 serde.workspace = true
 serde_json.workspace = true

--- a/ethers-contract/ethers-contract-derive/src/abigen.rs
+++ b/ethers-contract/ethers-contract-derive/src/abigen.rs
@@ -3,7 +3,7 @@
 
 use crate::spanned::Spanned;
 use ethers_contract_abigen::{multi::MultiExpansion, Abigen};
-use proc_macro2::{TokenStream, TokenTree};
+use proc_macro2::TokenStream;
 use std::collections::HashSet;
 use syn::{
     braced,
@@ -11,7 +11,7 @@ use syn::{
     parenthesized,
     parse::{Error, Parse, ParseStream, Result},
     punctuated::Punctuated,
-    Ident, LitStr, Path, Token,
+    Ident, LitInt, LitStr, Path, Token,
 };
 
 /// A series of `ContractArgs` separated by `;`
@@ -175,8 +175,8 @@ impl Parse for Method {
             let mut s = param.ident.to_string();
             if let Some((_, inside_brackets)) = param.bracket {
                 s.push_str("[");
-                if let Some(TokenTree::Literal(lit)) = inside_brackets.into_iter().next() {
-                    s.push_str(&lit.to_string());
+                if let Some(lit) = inside_brackets {
+                    s.push_str(lit.base10_digits());
                 }
                 s.push_str("]");
             }
@@ -200,7 +200,7 @@ impl Parse for Method {
 
 pub struct IdentBracket {
     pub ident: syn::Ident,
-    pub bracket: Option<(syn::token::Bracket, TokenStream)>,
+    pub bracket: Option<(syn::token::Bracket, Option<LitInt>)>,
 }
 
 impl Parse for IdentBracket {

--- a/ethers-contract/ethers-contract-derive/src/abigen.rs
+++ b/ethers-contract/ethers-contract-derive/src/abigen.rs
@@ -9,7 +9,7 @@ use syn::{
     braced,
     ext::IdentExt,
     parenthesized,
-    parse::{Error, Parse, ParseStream, Result},
+    parse::{Error, Nothing, Parse, ParseStream, Result},
     punctuated::Punctuated,
     Ident, LitStr, Path, Token,
 };
@@ -167,15 +167,18 @@ impl Parse for Method {
         // function params
         let content;
         parenthesized!(content in input);
-        let params = content.parse_terminated(Ident::parse, Token![,])?;
+        let params = content.parse_terminated(IdentBracket::parse, Token![,])?;
         let last_i = params.len().saturating_sub(1);
 
         signature.push('(');
         for (i, param) in params.into_iter().enumerate() {
-            let s = param.to_string();
+            let mut s = param.ident.to_string();
+            if param.bracket.is_some() {
+                s.push_str("[]");
+            }
             // validate
             ethers_core::abi::ethabi::param_type::Reader::read(&s)
-                .map_err(|e| Error::new(param.span(), e))?;
+                .map_err(|e| Error::new(param.ident.span(), e))?;
             signature.push_str(&s);
             if i < last_i {
                 signature.push(',');
@@ -188,6 +191,23 @@ impl Parse for Method {
         let alias = input.parse()?;
 
         Ok(Method { signature, alias })
+    }
+}
+
+pub struct IdentBracket {
+    pub ident: syn::Ident,
+    pub bracket: Option<(syn::token::Bracket, Nothing)>,
+}
+
+impl Parse for IdentBracket {
+    fn parse(input: ParseStream) -> syn::parse::Result<Self> {
+        let ident = input.parse()?;
+        let bracket = move || -> std::result::Result<_, _> {
+            let content;
+            Ok((syn::bracketed!(content in input), content.parse()?))
+        };
+
+        Ok(IdentBracket { ident, bracket: bracket().ok() })
     }
 }
 

--- a/ethers-contract/ethers-contract-derive/src/abigen.rs
+++ b/ethers-contract/ethers-contract-derive/src/abigen.rs
@@ -174,11 +174,11 @@ impl Parse for Method {
         for (i, param) in params.into_iter().enumerate() {
             let mut s = param.ident.to_string();
             if let Some((_, inside_brackets)) = param.bracket {
-                s.push_str("[");
+                s.push('[');
                 if let Some(lit) = inside_brackets {
                     s.push_str(lit.base10_digits());
                 }
-                s.push_str("]");
+                s.push(']');
             }
             // validate
             ethers_core::abi::ethabi::param_type::Reader::read(&s)

--- a/ethers-contract/tests/solidity-contracts/OverloadedFuncs.json
+++ b/ethers-contract/tests/solidity-contracts/OverloadedFuncs.json
@@ -1,0 +1,73 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "bytes[]",
+          "name": "",
+          "type": "bytes[]"
+        }
+      ],
+      "name": "execute",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "bytes[]",
+          "name": "",
+          "type": "bytes[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "execute",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        },
+        {
+          "internalType": "bytes[3]",
+          "name": "",
+          "type": "bytes[3]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes[]",
+          "name": "",
+          "type": "bytes[]"
+        }
+      ],
+      "name": "execute",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ]
+}


### PR DESCRIPTION
Added support for array parameters in abigen methods. Closes #2394 