### PR TITLE
get_transaction_by_block_and_index

### DIFF
--- a/ethers-providers/src/middleware.rs
+++ b/ethers-providers/src/middleware.rs
@@ -390,6 +390,18 @@ pub trait Middleware: Sync + Send + Debug {
         self.inner().get_transaction(transaction_hash).await.map_err(MiddlewareError::from_err)
     }
 
+    /// Gets the transaction with block and index
+    async fn get_transaction_by_block_and_index<T: Into<BlockId> + Send + Sync>(
+        &self,
+        block_hash_or_number: T,
+        idx: U64,
+    ) -> Result<Option<Transaction>, ProviderError> {
+        self.inner()
+            .get_transaction_by_block_and_index(block_hash_or_number, idx)
+            .await
+            .map_err(MiddlewareError::from_err)
+    }
+
     /// Gets the transaction receipt with `transaction_hash`
     async fn get_transaction_receipt<T: Send + Sync + Into<TxHash>>(
         &self,

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -392,6 +392,25 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.request("eth_getTransactionByHash", [hash]).await
     }
 
+    async fn get_transaction_by_block_and_index<T: Into<BlockId> + Send + Sync>(
+        &self,
+        block_hash_or_number: T,
+        idx: U64,
+    ) -> Result<Option<Transaction>, ProviderError> {
+        let blk_id = block_hash_or_number.into();
+        let idx = ethers_core::utils::serialize(&idx);
+        Ok(match blk_id {
+            BlockId::Hash(hash) => {
+                let hash = ethers_core::utils::serialize(&hash);
+                self.request("eth_getTransactionByBlockHashAndIndex", [hash, idx]).await?
+            }
+            BlockId::Number(num) => {
+                let num = ethers_core::utils::serialize(&num);
+                self.request("eth_getTransactionByBlockNumberAndIndex", [num, idx]).await?
+            }
+        })
+    }
+
     async fn get_transaction_receipt<T: Send + Sync + Into<TxHash>>(
         &self,
         transaction_hash: T,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

There's currently no wrapper for the `eth_getTransactionByBlockHashAndIndex` and `eth_getTransactionByBlockNumberAndIndex` RPC calls

## Solution

implementing them by combining `get_transaction` and `get_uncle`

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
