### PR TITLE
refactor: replace unused ports with unused port

### DIFF
--- a/ethers-core/src/utils/anvil.rs
+++ b/ethers-core/src/utils/anvil.rs
@@ -1,6 +1,6 @@
 use crate::{
     types::{Address, Chain},
-    utils::{secret_key_to_address, unused_ports},
+    utils::{secret_key_to_address, unused_port},
 };
 use generic_array::GenericArray;
 use k256::{ecdsa::SigningKey, SecretKey as K256SecretKey};
@@ -219,7 +219,7 @@ impl Anvil {
             Command::new("anvil")
         };
         cmd.stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::inherit());
-        let port = if let Some(port) = self.port { port } else { unused_ports::<1>()[0] };
+        let port = if let Some(port) = self.port { port } else { unused_port() };
         cmd.arg("-p").arg(port.to_string());
 
         if let Some(mnemonic) = self.mnemonic {

--- a/ethers-core/src/utils/ganache.rs
+++ b/ethers-core/src/utils/ganache.rs
@@ -1,6 +1,6 @@
 use crate::{
     types::Address,
-    utils::{secret_key_to_address, unused_ports},
+    utils::{secret_key_to_address, unused_port},
 };
 use generic_array::GenericArray;
 use k256::{ecdsa::SigningKey, SecretKey as K256SecretKey};
@@ -156,7 +156,7 @@ impl Ganache {
     pub fn spawn(self) -> GanacheInstance {
         let mut cmd = Command::new("ganache-cli");
         cmd.stdout(std::process::Stdio::piped());
-        let port = if let Some(port) = self.port { port } else { unused_ports::<1>()[0] };
+        let port = if let Some(port) = self.port { port } else { unused_port() };
         cmd.arg("-p").arg(port.to_string());
 
         if let Some(mnemonic) = self.mnemonic {

--- a/ethers-core/src/utils/geth.rs
+++ b/ethers-core/src/utils/geth.rs
@@ -1,7 +1,7 @@
-use super::{unused_ports, CliqueConfig, Genesis};
+use super::{CliqueConfig, Genesis};
 use crate::{
     types::{Bytes, H256},
-    utils::secret_key_to_address,
+    utils::{secret_key_to_address, unused_port},
 };
 use k256::ecdsa::SigningKey;
 use std::{
@@ -360,10 +360,7 @@ impl Geth {
         // geth uses stderr for its logs
         cmd.stderr(Stdio::piped());
 
-        let mut unused_ports = unused_ports::<3>().into_iter();
-        let mut unused_port = || unused_ports.next().unwrap();
-
-        let port = self.port.unwrap_or_else(&mut unused_port);
+        let port = self.port.unwrap_or_else(unused_port);
         let port_s = port.to_string();
 
         // Open the HTTP API

--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -591,24 +591,18 @@ fn base_fee_surged(base_fee_per_gas: U256) -> U256 {
     }
 }
 
-/// A bit of hack to find unused TCP ports.
+/// A bit of hack to find an unused TCP port.
 ///
 /// Does not guarantee that the given port is unused after the function exists, just that it was
 /// unused before the function started (i.e., it does not reserve a port).
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn unused_ports<const N: usize>() -> [u16; N] {
-    use std::net::{SocketAddr, TcpListener};
+pub(crate) fn unused_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("Failed to create TCP listener to find unused port");
 
-    std::array::from_fn(|_| {
-        let addr = SocketAddr::from(([127, 0, 0, 1], 0));
-        TcpListener::bind(addr).expect("Failed to create TCP listener to find unused port")
-    })
-    .map(|listener| {
-        listener
-            .local_addr()
-            .expect("Failed to read TCP listener local_addr to find unused port")
-            .port()
-    })
+    let local_addr =
+        listener.local_addr().expect("Failed to read TCP listener local_addr to find unused port");
+    local_addr.port()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
reverts changes from #2189 and only used unused port when required

cc @DaniPopes 