### PR TITLE
Add bundler to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ You can get one [here](https://etherscan.io/apis).
 -   [Celo Threshold BLS DKG](https://github.com/celo-org/celo-threshold-bls-rs/): CLI for using Celo as a data availability network for the Joint-Feldman BLS DKG
 -   [Celo Plumo Prover](https://github.com/celo-org/plumo-prover): Creates Celo's ultralight client proof from on-chain data
 -   [Celo SNARK Setup Coordinator](https://github.com/celo-org/snark-setup-operator): Coordinator for executing a pipelined Groth16 SNARK setup
+-   [ERC-4337 Bundler](https://github.com/Vid201/aa-bundler/): Account Abstraction (ERC-4337) bundler
 
 ## Credits
 


### PR DESCRIPTION
Adding bundler to the section "Projects using ethers-rs".

This PR can be ignored if you're not accepting projects to that list.