### PR TITLE
fix(`middleware`): fix gas oracle polygon urls

### DIFF
--- a/ethers-middleware/src/gas_oracle/polygon.rs
+++ b/ethers-middleware/src/gas_oracle/polygon.rs
@@ -5,8 +5,8 @@ use reqwest::Client;
 use serde::Deserialize;
 use url::Url;
 
-const MAINNET_URL: &str = "https://gasstation-mainnet.matic.network/v2";
-const MUMBAI_URL: &str = "https://gasstation-mumbai.matic.today/v2";
+const MAINNET_URL: &str = "https://gasstation.polygon.technology/v2";
+const MUMBAI_URL: &str = "https://gasstation-testnet.polygon.technology/v2";
 
 /// The [Polygon](https://docs.polygon.technology/docs/develop/tools/polygon-gas-station/) gas station API
 /// Queries over HTTP and implements the `GasOracle` trait.


### PR DESCRIPTION

## Motivation

It seems that the polygon gas oracle urls changed, and now users are getting errors regarding estimation on mumbai and mainnet.

## Solution

Change the URLs for the new ones on https://wiki.polygon.technology/docs/develop/tools/polygon-gas-station/

## PR Checklist

-   [n/a] Added Tests
-   [n/a] Added Documentation
-   [n/a] Breaking changes
