### PR TITLE
feat: feat: add BlockOverrides for debug_traceCall

### DIFF
--- a/ethers-core/src/types/trace/geth.rs
+++ b/ethers-core/src/types/trace/geth.rs
@@ -212,9 +212,9 @@ pub struct GethDebugTracingCallOptions {
     pub block_overrides: Option<BlockOverrides>,
 }
 
-/// Bindings for additional `debug_traceTransaction` options
+/// Additional BlockOverrides Options
 ///
-/// See <https://geth.ethereum.org/docs/rpc/ns-debug#debug_tracetransaction>
+/// See <https://geth.ethereum.org/docs/rpc/ns-debug#debug_tracecall>
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct BlockOverrides {

--- a/ethers-core/src/types/trace/geth.rs
+++ b/ethers-core/src/types/trace/geth.rs
@@ -209,7 +209,29 @@ pub struct GethDebugTracingCallOptions {
     pub tracing_options: GethDebugTracingOptions,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub state_overrides: Option<spoof::State>,
-    // TODO: Add blockoverrides options
+    pub block_overrides: Option<BlockOverrides>,
+}
+
+/// Bindings for additional `debug_traceTransaction` options
+///
+/// See <https://geth.ethereum.org/docs/rpc/ns-debug#debug_tracetransaction>
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockOverrides {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub number: Option<U256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub difficulty: Option<U256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub time: Option<U64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gas_limit: Option<U64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coinbase: Option<Address>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub random: Option<H256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_fee: Option<U256>,
 }
 
 /// Provides types and methods for constructing an `eth_call`

--- a/examples/transactions/examples/trace_call.rs
+++ b/examples/transactions/examples/trace_call.rs
@@ -27,6 +27,7 @@ async fn main() -> Result<()> {
                 ..Default::default()
             },
             state_overrides: None,
+            block_overrides: None,
         };
         let traces = client.debug_trace_call(tx, Some(block), options).await?;
         println!("{traces:?}");


### PR DESCRIPTION
Implements BlockOverrides for debug_TraceCall according to [Geth BlockOverrides Implementation](https://github.com/ethereum/go-ethereum/blob/6d2aeb43d516fbe2cafd9e65df7ccbd885f861d3/internal/ethapi/api.go#L944)

## PR Checklist

-   [ ] Added Tests
-   [x ] Added Documentation
-   [ ] Breaking changes
