### PR TITLE
Make AggregatedCompilerOutput DeSerialize/Serialize

### DIFF
--- a/ethers-solc/src/buildinfo.rs
+++ b/ethers-solc/src/buildinfo.rs
@@ -29,7 +29,7 @@ impl BuildInfo {
 }
 
 /// Represents `BuildInfo` object
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RawBuildInfo {
     /// The hash that identifies the BuildInfo
     pub id: String,

--- a/ethers-solc/src/compile/output/mod.rs
+++ b/ethers-solc/src/compile/output/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use contracts::{VersionedContract, VersionedContracts};
 use semver::Version;
+use serde::{Serialize, Deserialize};
 use std::{collections::BTreeMap, fmt, path::Path};
 use tracing::trace;
 use yansi::Paint;
@@ -424,7 +425,7 @@ impl<T: ArtifactOutput> fmt::Display for ProjectCompileOutput<T> {
 /// The aggregated output of (multiple) compile jobs
 ///
 /// This is effectively a solc version aware `CompilerOutput`
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct AggregatedCompilerOutput {
     /// all errors from all `CompilerOutput`
     pub errors: Vec<Error>,


### PR DESCRIPTION
## Motivation

Make AggregatedCompilerOutput `Serialize` and `Deserialize`, which should be trivial. Not sure why it wasn't supported before.

## Solution


## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
