### PR TITLE
feat(signers): add Wallet::encrypt_keystore

### DIFF
--- a/ethers-signers/src/wallet/private_key.rs
+++ b/ethers-signers/src/wallet/private_key.rs
@@ -239,7 +239,6 @@ mod tests {
         // create and store an encrypted JSON keystore in this directory
         let dir = tempdir().unwrap();
         let mut rng = rand::thread_rng();
-        // Construct a 32-byte random private key.
         let private_key = "6f142508b4eea641e33cb2a0161221105086a84584c74245ca463a49effea30b";
 
         let (key, uuid) =

--- a/ethers-signers/src/wallet/private_key.rs
+++ b/ethers-signers/src/wallet/private_key.rs
@@ -239,7 +239,10 @@ mod tests {
         // create and store an encrypted JSON keystore in this directory
         let dir = tempdir().unwrap();
         let mut rng = rand::thread_rng();
-        let private_key = "6f142508b4eea641e33cb2a0161221105086a84584c74245ca463a49effea30b";
+
+        let private_key =
+            hex::decode("6f142508b4eea641e33cb2a0161221105086a84584c74245ca463a49effea30b")
+                .unwrap();
 
         let (key, uuid) =
             Wallet::<SigningKey>::encrypt_keystore(&dir, &mut rng, private_key, "randpsswd", None)

--- a/ethers-signers/src/wallet/private_key.rs
+++ b/ethers-signers/src/wallet/private_key.rs
@@ -188,7 +188,6 @@ mod tests {
     use super::*;
     use crate::{LocalWallet, Signer};
     use ethers_core::types::Address;
-    use rand::RngCore;
     use tempfile::tempdir;
 
     #[test]
@@ -241,8 +240,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let mut rng = rand::thread_rng();
         // Construct a 32-byte random private key.
-        let mut private_key = [0u8; 32];
-        rng.fill_bytes(private_key.as_mut_slice());
+        let private_key = "6f142508b4eea641e33cb2a0161221105086a84584c74245ca463a49effea30b";
 
         let (key, uuid) =
             Wallet::<SigningKey>::encrypt_keystore(&dir, &mut rng, private_key, "randpsswd", None)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
This function is similar to Wallet::new_keystore, but instead of adding the a random private key to the file, it adds a key passed as a parameter.
This is handy when you want to safe an existing private key in an encrypted file.

This can also help with the implementation of https://github.com/foundry-rs/foundry/issues/5057

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
