### PR TITLE
feat(ethers-solc): add with_via_ir_minimum_optimization

### DIFF
--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -453,6 +453,34 @@ impl Settings {
         self.set_via_ir(true)
     }
 
+    /// Enable `viaIR` and use the minimum optimization settings
+    ///
+    /// This is useful in the following scenarios:
+    /// - When compiling for test coverage, this can resolve the "stack too deep" error while still
+    ///   giving a relatively accurate source mapping
+    /// - When compiling for test, this can reduce the compilation time
+    pub fn with_via_ir_minimum_optimization(mut self) -> Self {
+        // https://github.com/foundry-rs/foundry/pull/5349
+        // https://github.com/ethereum/solidity/issues/12533#issuecomment-1013073350
+        self.via_ir = Some(true);
+        self.optimizer.details = Some(OptimizerDetails {
+            peephole: Some(false),
+            inliner: Some(false),
+            jumpdest_remover: Some(false),
+            order_literals: Some(false),
+            deduplicate: Some(false),
+            cse: Some(false),
+            constant_optimizer: Some(false),
+            yul: Some(true), // enable yul optimizer
+            yul_details: Some(YulDetails {
+                stack_allocation: Some(true),
+                // with only unused prunner step
+                optimizer_steps: Some("u".to_string()),
+            }),
+        });
+        self
+    }
+
     /// Adds `ast` to output
     #[must_use]
     pub fn with_ast(mut self) -> Self {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

related to https://github.com/foundry-rs/foundry/pull/5349: 

> More and more people (including myself) are using the magical via-ir to solve the "stack too deep" issue. However, this would cause problems in test coverage as all the optimizations are disabled in test coverage.
> 
> The solidity team suggests working around this issue by enabling "via-ir" with a https://github.com/ethereum/solidity/issues/12533#issuecomment-1013073350
> 
> And this workaround is also recommended in the [FAQ](https://github.com/sc-forks/solidity-coverage/blob/89882a211e9f69ed6b1afc99b2bb9d56b857e686/docs/faq.md?plain=1#L85) of solcoverage.
> 
> In this pr, a new "--ir-minimum" option is added to the coverage subcommand, which enables "via-ir" with a minimum amount of optimization.


And @mattsse  suggests adding a function to the `Settings` type  in `ethers-solc`. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add a function called `with_via_ir_minimum_optimization` for enabling `viaIR` with a minimum amount of optimization. 

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
