### PR TITLE
feat: support remapping contexts

### DIFF
--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -56,7 +56,7 @@ coins-ledger = { version = "0.8.3", default-features = false, optional = true }
 semver = { workspace = true, optional = true }
 
 # trezor
-trezor-client = { version = "0.1", default-features = false, features = [
+trezor-client = { version = "=0.1.0", default-features = false, features = [
     "ethereum",
 ], optional = true }
 

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -328,28 +328,34 @@ impl ProjectPathsConfig {
     pub fn resolve_library_import(&self, cwd: &Path, import: &Path) -> Option<PathBuf> {
         // if the import path starts with the name of the remapping then we get the resolved path by
         // removing the name and adding the remainder to the path of the remapping
-        // todo: check if this is sound and improve ergonomics, e.g. should the remappings context
-        // be a relativeremappingpath instead
         let cwd = cwd.strip_prefix(&self.root).unwrap_or(cwd);
-        if let Some(path) = self.remappings.iter().find_map(|r| {
-            if let Some(ctx) = r.context.as_ref() {
-                if !cwd.starts_with(ctx) {
-                    return None
+        if let Some(path) = self
+            .remappings
+            .iter()
+            .filter(|r| {
+                // only check remappings that are either global or for `cwd`
+                if let Some(ctx) = r.context.as_ref() {
+                    cwd.starts_with(ctx)
+                } else {
+                    true
                 }
-            }
-            import.strip_prefix(&r.name).ok().map(|stripped_import| {
-                let lib_path = Path::new(&r.path).join(stripped_import);
-
-                // we handle the edge case where the path of a remapping ends with "contracts"
-                // (`<name>/=.../contracts`) and the stripped import also starts with `contracts`
-                if let Ok(adjusted_import) = stripped_import.strip_prefix("contracts/") {
-                    if r.path.ends_with("contracts/") && !lib_path.exists() {
-                        return Path::new(&r.path).join(adjusted_import)
-                    }
-                }
-                lib_path
             })
-        }) {
+            .find_map(|r| {
+                import.strip_prefix(&r.name).ok().map(|stripped_import| {
+                    let lib_path = Path::new(&r.path).join(stripped_import);
+
+                    // we handle the edge case where the path of a remapping ends with "contracts"
+                    // (`<name>/=.../contracts`) and the stripped import also starts with
+                    // `contracts`
+                    if let Ok(adjusted_import) = stripped_import.strip_prefix("contracts/") {
+                        if r.path.ends_with("contracts/") && !lib_path.exists() {
+                            return Path::new(&r.path).join(adjusted_import)
+                        }
+                    }
+                    lib_path
+                })
+            })
+        {
             Some(self.root.join(path))
         } else {
             utils::resolve_library(&self.libraries, import)

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -330,7 +330,7 @@ impl ProjectPathsConfig {
         // removing the name and adding the remainder to the path of the remapping
         // todo: check if this is sound and improve ergonomics, e.g. should the remappings context
         // be a relativeremappingpath instead
-        let cwd = if let Some(cwd) = cwd.strip_prefix(&self.root).ok() { cwd } else { cwd };
+        let cwd = cwd.strip_prefix(&self.root).unwrap_or(cwd);
         if let Some(path) = self.remappings.iter().find_map(|r| {
             if let Some(ctx) = r.context.as_ref() {
                 if !cwd.starts_with(ctx) {

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -283,7 +283,7 @@ impl RelativeRemapping {
     /// Creates a new `RelativeRemapping` starting prefixed with `root`
     pub fn new(remapping: Remapping, root: impl AsRef<Path>) -> Self {
         Self {
-            context: None,
+            context: remapping.context,
             name: remapping.name,
             path: RelativeRemappingPathBuf::with_root(root, remapping.path),
         }
@@ -1167,6 +1167,34 @@ mod tests {
         ];
         expected.sort_unstable();
         pretty_assertions::assert_eq!(remappings, expected);
+    }
+
+    #[test]
+    fn can_resolve_contexts() {
+        let remapping = "context:oz=a/b/c/d";
+        let remapping = Remapping::from_str(remapping).unwrap();
+
+        assert_eq!(
+            remapping,
+            Remapping {
+                context: Some("context".to_string()),
+                name: "oz".to_string(),
+                path: "a/b/c/d".to_string(),
+            }
+        );
+        assert_eq!(remapping.to_string(), "context:oz=a/b/c/d/".to_string());
+    }
+
+    #[test]
+    fn can_resolve_global_contexts() {
+        let remapping = ":oz=a/b/c/d/";
+        let remapping = Remapping::from_str(remapping).unwrap();
+
+        assert_eq!(
+            remapping,
+            Remapping { context: None, name: "oz".to_string(), path: "a/b/c/d/".to_string() }
+        );
+        assert_eq!(remapping.to_string(), "oz=a/b/c/d/".to_string());
     }
 
     #[test]

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -275,7 +275,7 @@ impl Remapping {
             use path_slash::PathExt;
             self.path = Path::new(&self.path).to_slash_lossy().to_string();
             if let Some(context) = self.context.as_mut() {
-                *context = Path::new(&self.context).to_slash_lossy().to_string();
+                *context = Path::new(&context).to_slash_lossy().to_string();
             }
         }
     }

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -275,7 +275,7 @@ impl Remapping {
             use path_slash::PathExt;
             self.path = Path::new(&self.path).to_slash_lossy().to_string();
             if let Some(context) = self.context.as_mut() {
-                *context = Some(Path::new(&self.path).to_slash_lossy().to_string());
+                *context = Path::new(&self.context).to_slash_lossy().to_string();
             }
         }
     }

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -283,7 +283,13 @@ impl RelativeRemapping {
     /// Creates a new `RelativeRemapping` starting prefixed with `root`
     pub fn new(remapping: Remapping, root: impl AsRef<Path>) -> Self {
         Self {
-            context: remapping.context,
+            // todo: hacky way to make the context relative, should follow same rules as path
+            context: remapping.context.map(|c| {
+                RelativeRemappingPathBuf::with_root(root.as_ref(), c)
+                    .path
+                    .to_string_lossy()
+                    .to_string()
+            }),
             name: remapping.name,
             path: RelativeRemappingPathBuf::with_root(root, remapping.path),
         }
@@ -420,7 +426,13 @@ impl<'de> Deserialize<'de> for RelativeRemapping {
     {
         let remapping = String::deserialize(deserializer)?;
         let remapping = Remapping::from_str(&remapping).map_err(serde::de::Error::custom)?;
-        Ok(RelativeRemapping { context: None, name: remapping.name, path: remapping.path.into() })
+        // todo: add test for ser/de (remapping, relativeremapping)
+        // todo: add test for remapping -> relativeremapping -> remapping
+        Ok(RelativeRemapping {
+            context: remapping.context,
+            name: remapping.name,
+            path: remapping.path.into(),
+        })
     }
 }
 

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -17,7 +17,7 @@ const JS_LIB_DIR: &str = "node_modules";
 /// So importing directly from GitHub (as an example) is not possible.
 ///
 /// Let's imagine you want to use OpenZeppelin's amazing library of smart contracts,
-/// @openzeppelin/contracts-ethereum-package:
+/// `@openzeppelin/contracts-ethereum-package`:
 ///
 /// ```ignore
 /// pragma solidity 0.5.11;
@@ -30,22 +30,32 @@ const JS_LIB_DIR: &str = "node_modules";
 /// }
 /// ```
 ///
-/// When using solc, you have to specify the following:
+/// When using `solc`, you have to specify the following:
 ///
-/// "prefix" = the path that's used in your smart contract, i.e.
-/// "@openzeppelin/contracts-ethereum-package" "target" = the absolute path of OpenZeppelin's
-/// contracts downloaded on your computer
+/// - A `prefix`: the path that's used in your smart contract, i.e.
+///   `@openzeppelin/contracts-ethereum-package`
+/// - A `target`: the absolute path of the downloaded contracts on your computer
 ///
-/// The format looks like this:
-/// `solc prefix=target ./MyContract.sol`
+/// The format looks like this: `solc prefix=target ./MyContract.sol`
 ///
-/// solc --bin
-/// @openzeppelin/contracts-ethereum-package=/Your/Absolute/Path/To/@openzeppelin/
-/// contracts-ethereum-package ./MyContract.sol
+/// For example:
+///
+/// ```ignore
+/// solc --bin \
+///     @openzeppelin/contracts-ethereum-package=/Your/Absolute/Path/To/@openzeppelin/contracts-ethereum-package \
+///     ./MyContract.sol
+/// ```
+///
+/// You can also specify a `context` which limits the scope of the remapping to a subset of your
+/// project. This allows you to apply the remapping only to imports located in a specific library or
+/// a specific file. Without a context a remapping is applied to every matching import in all files.
+///
+/// The format is: `solc context:prefix=target ./MyContract.sol`
 ///
 /// [Source](https://ethereum.stackexchange.com/questions/74448/what-are-remappings-and-how-do-they-work-in-solidity)
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub struct Remapping {
+    pub context: Option<String>,
     pub name: String,
     pub path: String,
 }
@@ -78,7 +88,17 @@ pub enum RemappingError {
 impl FromStr for Remapping {
     type Err = RemappingError;
 
-    fn from_str(remapping: &str) -> Result<Self, Self::Err> {
+    fn from_str(mut remapping: &str) -> Result<Self, Self::Err> {
+        let mut context = None;
+        if let Some((prefix, rest)) = remapping.split_once(':') {
+            // Context can be empty, which just means it is global
+            if prefix.trim().is_empty() {
+                context = None;
+            } else {
+                context = Some(prefix.to_string());
+            }
+            remapping = rest;
+        }
         let (name, path) = remapping
             .split_once('=')
             .ok_or_else(|| RemappingError::InvalidRemapping(remapping.to_string()))?;
@@ -88,7 +108,7 @@ impl FromStr for Remapping {
         if path.trim().is_empty() {
             return Err(RemappingError::EmptyRemappingValue(remapping.to_string()))
         }
-        Ok(Remapping { name: name.to_string(), path: path.to_string() })
+        Ok(Remapping { context, name: name.to_string(), path: path.to_string() })
     }
 }
 
@@ -114,7 +134,12 @@ impl<'de> Deserialize<'de> for Remapping {
 // Remappings are printed as `prefix=target`
 impl fmt::Display for Remapping {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = {
+        let mut s = String::new();
+        if let Some(context) = self.context.as_ref() {
+            s.push_str(context);
+            s.push(':');
+        }
+        s.push_str(&{
             #[cfg(target_os = "windows")]
             {
                 // ensure we have `/` slashes on windows
@@ -125,7 +150,7 @@ impl fmt::Display for Remapping {
             {
                 format!("{}={}", self.name, self.path)
             }
-        };
+        });
 
         if !s.ends_with('/') {
             s.push('/');
@@ -226,7 +251,11 @@ impl Remapping {
 
         all_remappings
             .into_iter()
-            .map(|(name, path)| Remapping { name, path: format!("{}/", path.display()) })
+            .map(|(name, path)| Remapping {
+                context: None,
+                name,
+                path: format!("{}/", path.display()),
+            })
             .collect()
     }
 
@@ -245,6 +274,7 @@ impl Remapping {
 /// See [`RelativeRemappingPathBuf`]
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub struct RelativeRemapping {
+    pub context: Option<String>,
     pub name: String,
     pub path: RelativeRemappingPathBuf,
 }
@@ -253,6 +283,7 @@ impl RelativeRemapping {
     /// Creates a new `RelativeRemapping` starting prefixed with `root`
     pub fn new(remapping: Remapping, root: impl AsRef<Path>) -> Self {
         Self {
+            context: None,
             name: remapping.name,
             path: RelativeRemappingPathBuf::with_root(root, remapping.path),
         }
@@ -276,8 +307,13 @@ impl RelativeRemapping {
 // Remappings are printed as `prefix=target`
 impl fmt::Display for RelativeRemapping {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = {
-            #[cfg(windows)]
+        let mut s = String::new();
+        if let Some(context) = self.context.as_ref() {
+            s.push_str(context);
+            s.push(':');
+        }
+        s.push_str(&{
+            #[cfg(target_os = "windows")]
             {
                 // ensure we have `/` slashes on windows
                 use path_slash::PathExt;
@@ -287,7 +323,7 @@ impl fmt::Display for RelativeRemapping {
             {
                 format!("{}={}", self.name, self.path.original().display())
             }
-        };
+        });
 
         if !s.ends_with('/') {
             s.push('/');
@@ -298,7 +334,7 @@ impl fmt::Display for RelativeRemapping {
 
 impl From<RelativeRemapping> for Remapping {
     fn from(r: RelativeRemapping) -> Self {
-        let RelativeRemapping { mut name, path } = r;
+        let RelativeRemapping { context, mut name, path } = r;
         let mut path = format!("{}", path.relative().display());
         if !path.ends_with('/') {
             path.push('/');
@@ -306,13 +342,13 @@ impl From<RelativeRemapping> for Remapping {
         if !name.ends_with('/') {
             name.push('/');
         }
-        Remapping { name, path }
+        Remapping { context, name, path }
     }
 }
 
 impl From<Remapping> for RelativeRemapping {
     fn from(r: Remapping) -> Self {
-        Self { name: r.name, path: r.path.into() }
+        Self { context: r.context, name: r.name, path: r.path.into() }
     }
 }
 
@@ -384,7 +420,7 @@ impl<'de> Deserialize<'de> for RelativeRemapping {
     {
         let remapping = String::deserialize(deserializer)?;
         let remapping = Remapping::from_str(&remapping).map_err(serde::de::Error::custom)?;
-        Ok(RelativeRemapping { name: remapping.name, path: remapping.path.into() })
+        Ok(RelativeRemapping { context: None, name: remapping.name, path: remapping.path.into() })
     }
 }
 
@@ -832,6 +868,7 @@ mod tests {
         let tmp_dir_path = tmp_dir.path().join("lib");
         let remappings = Remapping::find_many(&tmp_dir_path);
         let expected = vec![Remapping {
+            context: None,
             name: "timeless/".to_string(),
             path: to_str(tmp_dir_path.join("timeless/src")),
         }];
@@ -868,30 +905,37 @@ mod tests {
         remappings.sort_unstable();
         let mut expected = vec![
             Remapping {
+                context: None,
                 name: "ds-auth/".to_string(),
                 path: to_str(tmp_dir_path.join("ds-token/lib/ds-stop/lib/ds-auth/src")),
             },
             Remapping {
+                context: None,
                 name: "ds-math/".to_string(),
                 path: to_str(tmp_dir_path.join("ds-token/lib/ds-math/src")),
             },
             Remapping {
+                context: None,
                 name: "ds-note/".to_string(),
                 path: to_str(tmp_dir_path.join("ds-token/lib/ds-stop/lib/ds-note/src")),
             },
             Remapping {
+                context: None,
                 name: "ds-stop/".to_string(),
                 path: to_str(tmp_dir_path.join("ds-token/lib/ds-stop/src")),
             },
             Remapping {
+                context: None,
                 name: "ds-test/".to_string(),
                 path: to_str(tmp_dir_path.join("ds-token/lib/ds-test/src")),
             },
             Remapping {
+                context: None,
                 name: "ds-token/".to_string(),
                 path: to_str(tmp_dir_path.join("ds-token/src")),
             },
             Remapping {
+                context: None,
                 name: "erc20/".to_string(),
                 path: to_str(tmp_dir_path.join("ds-token/lib/erc20/src")),
             },
@@ -933,6 +977,7 @@ mod tests {
         let remappings = Remapping::find_many(tmp_dir.path());
 
         let expected = vec![Remapping {
+            context: None,
             name: "@chainlink/".to_string(),
             path: to_str(tmp_dir.path().join("@chainlink")),
         }];
@@ -1017,6 +1062,7 @@ mod tests {
         let remappings = Remapping::find_many(tmp_dir.path());
 
         let expected = vec![Remapping {
+            context: None,
             name: "@openzeppelin/".to_string(),
             path: to_str(tmp_dir.path().join("@openzeppelin")),
         }];
@@ -1079,34 +1125,42 @@ mod tests {
 
         let mut expected = vec![
             Remapping {
+                context: None,
                 name: "repo1/".to_string(),
                 path: to_str(tmp_dir_path.join("repo1").join("src")),
             },
             Remapping {
+                context: None,
                 name: "ds-math/".to_string(),
                 path: to_str(tmp_dir_path.join("repo1").join("lib").join("ds-math").join("src")),
             },
             Remapping {
+                context: None,
                 name: "ds-test/".to_string(),
                 path: to_str(tmp_dir_path.join("repo1").join("lib").join("ds-test").join("src")),
             },
             Remapping {
+                context: None,
                 name: "guni-lev/".to_string(),
                 path: to_str(tmp_dir_path.join("repo1/lib/guni-lev").join("src")),
             },
             Remapping {
+                context: None,
                 name: "solmate/".to_string(),
                 path: to_str(tmp_dir_path.join("repo1/lib/solmate").join("src")),
             },
             Remapping {
+                context: None,
                 name: "openzeppelin-contracts/".to_string(),
                 path: to_str(tmp_dir_path.join("repo1/lib/openzeppelin-contracts/contracts")),
             },
             Remapping {
+                context: None,
                 name: "ds-stop/".to_string(),
                 path: to_str(tmp_dir_path.join("repo1/lib/ds-token/lib/ds-stop/src")),
             },
             Remapping {
+                context: None,
                 name: "ds-note/".to_string(),
                 path: to_str(tmp_dir_path.join("repo1/lib/ds-token/lib/ds-stop/lib/ds-note/src")),
             },
@@ -1139,10 +1193,12 @@ mod tests {
         remappings.sort_unstable();
         let mut expected = vec![
             Remapping {
+                context: None,
                 name: "src_repo/".to_string(),
                 path: format!("{}/", dir1.into_os_string().into_string().unwrap()),
             },
             Remapping {
+                context: None,
                 name: "contracts_repo/".to_string(),
                 path: format!(
                     "{}/",
@@ -1177,14 +1233,17 @@ mod tests {
 
         let mut expected = vec![
             Remapping {
+                context: None,
                 name: "ds-test/".to_string(),
                 path: to_str(tmp_dir_path.join("ds-test/src")),
             },
             Remapping {
+                context: None,
                 name: "openzeppelin/".to_string(),
                 path: to_str(tmp_dir_path.join("openzeppelin/src")),
             },
             Remapping {
+                context: None,
                 name: "standards/".to_string(),
                 path: to_str(tmp_dir_path.join("standards/src")),
             },
@@ -1217,18 +1276,22 @@ mod tests {
         remappings.sort_unstable();
         let mut expected = vec![
             Remapping {
+                context: None,
                 name: "@aave/".to_string(),
                 path: to_str(tmp_dir_node_modules.join("@aave")),
             },
             Remapping {
+                context: None,
                 name: "@ensdomains/".to_string(),
                 path: to_str(tmp_dir_node_modules.join("@ensdomains")),
             },
             Remapping {
+                context: None,
                 name: "@openzeppelin/".to_string(),
                 path: to_str(tmp_dir_node_modules.join("@openzeppelin")),
             },
             Remapping {
+                context: None,
                 name: "eth-gas-reporter/".to_string(),
                 path: to_str(tmp_dir_node_modules.join("eth-gas-reporter")),
             },
@@ -1268,14 +1331,17 @@ mod tests {
 
         let mut expected = vec![
             Remapping {
+                context: None,
                 name: "ds-test/".to_string(),
                 path: to_str(tmp_dir_path.join("lib/ds-test/src")),
             },
             Remapping {
+                context: None,
                 name: "openzeppelin/".to_string(),
                 path: to_str(tmp_dir_path.join("openzeppelin/contracts")),
             },
             Remapping {
+                context: None,
                 name: "forge-std/".to_string(),
                 path: to_str(tmp_dir_path.join("lib/forge-std/src")),
             },

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -291,7 +291,6 @@ impl RelativeRemapping {
     /// Creates a new `RelativeRemapping` starting prefixed with `root`
     pub fn new(remapping: Remapping, root: impl AsRef<Path>) -> Self {
         Self {
-            // todo: hacky way to make the context relative, should follow same rules as path
             context: remapping.context.map(|c| {
                 RelativeRemappingPathBuf::with_root(root.as_ref(), c)
                     .path
@@ -443,8 +442,6 @@ impl<'de> Deserialize<'de> for RelativeRemapping {
     {
         let remapping = String::deserialize(deserializer)?;
         let remapping = Remapping::from_str(&remapping).map_err(serde::de::Error::custom)?;
-        // todo: add test for ser/de (remapping, relativeremapping)
-        // todo: add test for remapping -> relativeremapping -> remapping
         Ok(RelativeRemapping {
             context: remapping.context,
             name: remapping.name,

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -1097,7 +1097,10 @@ mod tests {
         paths.remappings = remappings;
 
         let resolved = paths
-            .resolve_library_import(Path::new("@openzeppelin/contracts/token/ERC20/IERC20.sol"))
+            .resolve_library_import(
+                tmp_dir.path(),
+                Path::new("@openzeppelin/contracts/token/ERC20/IERC20.sol"),
+            )
             .unwrap();
         assert!(resolved.exists());
 
@@ -1105,7 +1108,10 @@ mod tests {
         paths.remappings[0].name = "@openzeppelin/".to_string();
 
         let resolved = paths
-            .resolve_library_import(Path::new("@openzeppelin/contracts/token/ERC20/IERC20.sol"))
+            .resolve_library_import(
+                tmp_dir.path(),
+                Path::new("@openzeppelin/contracts/token/ERC20/IERC20.sol"),
+            )
             .unwrap();
         assert!(resolved.exists());
     }

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -88,9 +88,10 @@ pub enum RemappingError {
 impl FromStr for Remapping {
     type Err = RemappingError;
 
-    fn from_str(mut remapping: &str) -> Result<Self, Self::Err> {
+    fn from_str(remapping_orig: &str) -> Result<Self, Self::Err> {
+        let mut remapping = remapping_orig;
         let mut context = None;
-        if let Some((prefix, rest)) = remapping.split_once(':') {
+        if let Some((prefix, rest)) = remapping_orig.split_once(':') {
             // Context can be empty, which just means it is global
             if prefix.trim().is_empty() {
                 context = None;
@@ -101,12 +102,12 @@ impl FromStr for Remapping {
         }
         let (name, path) = remapping
             .split_once('=')
-            .ok_or_else(|| RemappingError::InvalidRemapping(remapping.to_string()))?;
+            .ok_or_else(|| RemappingError::InvalidRemapping(remapping_orig.to_string()))?;
         if name.trim().is_empty() {
-            return Err(RemappingError::EmptyRemappingKey(remapping.to_string()))
+            return Err(RemappingError::EmptyRemappingKey(remapping_orig.to_string()))
         }
         if path.trim().is_empty() {
-            return Err(RemappingError::EmptyRemappingValue(remapping.to_string()))
+            return Err(RemappingError::EmptyRemappingValue(remapping_orig.to_string()))
         }
         Ok(Remapping { context, name: name.to_string(), path: path.to_string() })
     }

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -40,7 +40,7 @@ const JS_LIB_DIR: &str = "node_modules";
 ///
 /// For example:
 ///
-/// ```ignore
+/// ```text
 /// solc --bin \
 ///     @openzeppelin/contracts-ethereum-package=/Your/Absolute/Path/To/@openzeppelin/contracts-ethereum-package \
 ///     ./MyContract.sol

--- a/ethers-solc/src/remappings.rs
+++ b/ethers-solc/src/remappings.rs
@@ -136,7 +136,16 @@ impl fmt::Display for Remapping {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = String::new();
         if let Some(context) = self.context.as_ref() {
-            s.push_str(context);
+            #[cfg(target_os = "windows")]
+            {
+                // ensure we have `/` slashes on windows
+                use path_slash::PathExt;
+                s.push_str(&std::path::Path::new(context).to_slash_lossy());
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                s.push_str(context);
+            }
             s.push(':');
         }
         s.push_str(&{
@@ -265,6 +274,9 @@ impl Remapping {
         {
             use path_slash::PathExt;
             self.path = Path::new(&self.path).to_slash_lossy().to_string();
+            if let Some(context) = self.context.as_mut() {
+                *context = Some(Path::new(&self.path).to_slash_lossy().to_string());
+            }
         }
     }
 }
@@ -315,7 +327,16 @@ impl fmt::Display for RelativeRemapping {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = String::new();
         if let Some(context) = self.context.as_ref() {
-            s.push_str(context);
+            #[cfg(target_os = "windows")]
+            {
+                // ensure we have `/` slashes on windows
+                use path_slash::PathExt;
+                s.push_str(&std::path::Path::new(context).to_slash_lossy());
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                s.push_str(context);
+            }
             s.push(':');
         }
         s.push_str(&{


### PR DESCRIPTION
## Motivation

solc supports [remapping contexts](https://docs.soliditylang.org/en/latest/path-resolution.html#import-remapping) to limit the scope of remappings to subsets of your project, e.g. libraries you import.

We want this for https://github.com/foundry-rs/foundry/issues/1855

## Solution

In https://github.com/foundry-rs/foundry/issues/1855 we ideally would want to auto-detect the contexts as well, i.e. limit remappings from libraries to the library roots.

This PR adds support for parsing and serializing remapping contexts, and limits import resolution based on the remapping contexts.

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
