### PR TITLE
fix(providers): `ens::namehash` with Unicode characters

### DIFF
--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -32,7 +32,6 @@ http = "0.2"
 reqwest = { workspace = true, features = ["json"] }
 url.workspace = true
 base64 = "0.21"
-idna = "0.4.0"
 
 async-trait.workspace = true
 hex.workspace = true

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -32,6 +32,7 @@ http = "0.2"
 reqwest = { workspace = true, features = ["json"] }
 url.workspace = true
 base64 = "0.21"
+idna = "0.4.0"
 
 async-trait.workspace = true
 hex.workspace = true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
`ens::namehash` doesn't correctly compute nodes for ENS names that contain Unicode characters as documented in [foundry#5386](https://github.com/foundry-rs/foundry/issues/5386)

Currently, when `providers::resolve_name` is called on an ENS name like ret↩️rn.eth, it will produce a flawed node.
`ethers-rs` treats the nodes as sets of 32 decimal values that when converted into their hex equivalent and prepended with `0x`, produce a node which is used to get the resolver contract for the ENS name. 

```bash
# Currently, `ens::namehash` will return:
[58, 221, 97, 107, 77, 172, 118, 9, 34, 35, 212, 59, 68, 92, 73, 191, 217, 137, 183, 219, 23, 92, 60, 236, 100, 137, 88, 71, 201, 249, 185, 116]

# This will be converted to the invalid node:
0xadb545a232c011f5aa341c04e144e7ab15be672fe94cfea9138fc0b293229ad5
```

```bash
# The correct return value should be: 
[61, 229, 244, 192, 45, 182, 27, 34, 30, 125, 231, 241, 196, 14, 41, 182, 226, 240, 126, 180, 141, 101, 191, 126, 48, 71, 21, 205, 158, 211, 59, 36]

# which produces the valid node:
0x3de5f4c02db61b221e7de7f1c40e29b6e2f07eb48d65bf7e304715cd9ed33b24
```

Nodes can be verified through the ENS contract's `resolver` and `owner` functions [here](https://etherscan.io/address/0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e#readContract).
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
The reason for the discrepancy is that ret↩️rn.eth was not being stripped of its trailing `VARIATION SELECTOR 16` after the Unicode character. ENS ignores these but the `namehash` function did not account for them. 

The `namehash` function has been modified to strip any VS16's thus enabling it to successfully resolve ENS names with emojis.

A test with the appropriate name has been added for verification.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
