### PR TITLE
Add aliases for TypedTransaction tags that work with Hardhat

### DIFF
--- a/ethers-core/src/types/transaction/eip2718.rs
+++ b/ethers-core/src/types/transaction/eip2718.rs
@@ -34,13 +34,13 @@ use super::optimism_deposited::{
 #[cfg_attr(feature = "legacy", serde(untagged))]
 pub enum TypedTransaction {
     // 0x00
-    #[serde(rename = "0x00")]
+    #[serde(rename = "0x00", alias = "0x0")]
     Legacy(TransactionRequest),
     // 0x01
-    #[serde(rename = "0x01")]
+    #[serde(rename = "0x01", alias = "0x1")]
     Eip2930(Eip2930TransactionRequest),
     // 0x02
-    #[serde(rename = "0x02")]
+    #[serde(rename = "0x02", alias = "0x2")]
     Eip1559(Eip1559TransactionRequest),
     // 0x7E
     #[cfg(feature = "optimism")]
@@ -715,7 +715,7 @@ mod tests {
 
     #[test]
     fn test_typed_tx() {
-        let tx: Eip1559TransactionRequest = serde_json::from_str(
+        let envelope: TypedTransaction = serde_json::from_str(
             r#"{
             "gas": "0x186a0",
             "maxFeePerGas": "0x77359400",
@@ -740,8 +740,6 @@ mod tests {
         }"#,
         )
         .unwrap();
-
-        let envelope = TypedTransaction::Eip1559(tx);
 
         let expected =
             H256::from_str("0x090b19818d9d087a49c3d2ecee4829ee4acea46089c1381ac5e588188627466d")

--- a/ethers-core/src/types/transaction/eip2718.rs
+++ b/ethers-core/src/types/transaction/eip2718.rs
@@ -387,7 +387,7 @@ impl TypedTransaction {
             // Legacy (0x00)
             // use the original rlp
             let decoded_request = TransactionRequest::decode_signed_rlp(rlp)?;
-            return Ok((Self::Legacy(decoded_request.0), decoded_request.1))
+            return Ok((Self::Legacy(decoded_request.0), decoded_request.1));
         }
 
         let rest = rlp::Rlp::new(
@@ -397,18 +397,18 @@ impl TypedTransaction {
         if first == 0x01 {
             // EIP-2930 (0x01)
             let decoded_request = Eip2930TransactionRequest::decode_signed_rlp(&rest)?;
-            return Ok((Self::Eip2930(decoded_request.0), decoded_request.1))
+            return Ok((Self::Eip2930(decoded_request.0), decoded_request.1));
         }
         if first == 0x02 {
             // EIP-1559 (0x02)
             let decoded_request = Eip1559TransactionRequest::decode_signed_rlp(&rest)?;
-            return Ok((Self::Eip1559(decoded_request.0), decoded_request.1))
+            return Ok((Self::Eip1559(decoded_request.0), decoded_request.1));
         }
         #[cfg(feature = "optimism")]
         if first == 0x7E {
             // Optimism Deposited (0x7E)
             let decoded_request = OptimismDepositedTransactionRequest::decode_signed_rlp(&rest)?;
-            return Ok((Self::OptimismDeposited(decoded_request.0), decoded_request.1))
+            return Ok((Self::OptimismDeposited(decoded_request.0), decoded_request.1));
         }
 
         Err(rlp::DecoderError::Custom("invalid tx type").into())
@@ -714,6 +714,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "legacy", ignore)]
     fn test_typed_tx() {
         let envelope: TypedTransaction = serde_json::from_str(
             r#"{
@@ -740,6 +741,8 @@ mod tests {
         }"#,
         )
         .unwrap();
+
+        assert!(matches!(envelope, TypedTransaction::Eip1559(_)));
 
         let expected =
             H256::from_str("0x090b19818d9d087a49c3d2ecee4829ee4acea46089c1381ac5e588188627466d")

--- a/ethers-core/src/types/transaction/eip2718.rs
+++ b/ethers-core/src/types/transaction/eip2718.rs
@@ -387,7 +387,7 @@ impl TypedTransaction {
             // Legacy (0x00)
             // use the original rlp
             let decoded_request = TransactionRequest::decode_signed_rlp(rlp)?;
-            return Ok((Self::Legacy(decoded_request.0), decoded_request.1));
+            return Ok((Self::Legacy(decoded_request.0), decoded_request.1))
         }
 
         let rest = rlp::Rlp::new(
@@ -397,18 +397,18 @@ impl TypedTransaction {
         if first == 0x01 {
             // EIP-2930 (0x01)
             let decoded_request = Eip2930TransactionRequest::decode_signed_rlp(&rest)?;
-            return Ok((Self::Eip2930(decoded_request.0), decoded_request.1));
+            return Ok((Self::Eip2930(decoded_request.0), decoded_request.1))
         }
         if first == 0x02 {
             // EIP-1559 (0x02)
             let decoded_request = Eip1559TransactionRequest::decode_signed_rlp(&rest)?;
-            return Ok((Self::Eip1559(decoded_request.0), decoded_request.1));
+            return Ok((Self::Eip1559(decoded_request.0), decoded_request.1))
         }
         #[cfg(feature = "optimism")]
         if first == 0x7E {
             // Optimism Deposited (0x7E)
             let decoded_request = OptimismDepositedTransactionRequest::decode_signed_rlp(&rest)?;
-            return Ok((Self::OptimismDeposited(decoded_request.0), decoded_request.1));
+            return Ok((Self::OptimismDeposited(decoded_request.0), decoded_request.1))
         }
 
         Err(rlp::DecoderError::Custom("invalid tx type").into())


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

@cryptoAtWill was testing an API that used `ethers_core::types::TypedTransaction` on the server side to decode the JSON-RPC parameters of an `eth_estimateGas` call sent by Hardhat when he noticed that it was rejected due to the tag not being recognised. The reason was that `ethers` [expects](https://github.com/gakonst/ethers-rs/blob/ethers-v2.0.8/ethers-core/src/types/transaction/eip2718.rs#L43) `"type": "0x02"` while Hardhat sends `"type": "0x2"`. 

I noticed that some of the [tests](https://github.com/gakonst/ethers-rs/blob/ethers-v2.0.8/ethers-core/src/types/transaction/eip2718.rs#L727) actually contain `"0x2"` but it's not used, so I thought this is a bug.

## Solution

The simple solution in this PR is to add an `alias` to the `TypedTransaction` variants, so both padded and non-padded versions are accepted.

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
