### PR TITLE
chore: support latest svm

### DIFF
--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -353,7 +353,7 @@ impl Solc {
         let _lock = take_solc_installer_lock();
 
         // load the local / remote versions
-        let versions = utils::installed_versions(svm::SVM_HOME.as_path()).unwrap_or_default();
+        let versions = utils::installed_versions(svm::SVM_DATA_DIR.as_path()).unwrap_or_default();
 
         let local_versions = Self::find_matching_installation(&versions, sol_version);
         let remote_versions = Self::find_matching_installation(&RELEASES.1, sol_version);
@@ -861,14 +861,14 @@ mod tests {
         let _lock = LOCK.lock();
         let ver = "0.8.6";
         let version = Version::from_str(ver).unwrap();
-        if utils::installed_versions(svm::SVM_HOME.as_path())
+        if utils::installed_versions(svm::SVM_DATA_DIR.as_path())
             .map(|versions| !versions.contains(&version))
             .unwrap_or_default()
         {
             Solc::blocking_install(&version).unwrap();
         }
         let res = Solc::find_svm_installed_version(version.to_string()).unwrap().unwrap();
-        let expected = svm::SVM_HOME.join(ver).join(format!("solc-{ver}"));
+        let expected = svm::SVM_DATA_DIR.join(ver).join(format!("solc-{ver}"));
         assert_eq!(res.solc, expected);
     }
 


### PR DESCRIPTION

## Motivation

Due to https://github.com/alloy-rs/svm-rs/commit/9b0fa3a751312c153d9bb785b48a25d9bf679e40#diff-4ac4c674e2696c0c39e91b7ba5af3f65b6ffb1a0fa9b90d3f9930a14254ecb98L126 some changes are needed to point to the correct var here, as `SVM_HOME` does not exist anymore

## Solution

Use `SVM_DATA_DIR`

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
