### PR TITLE
fix: gas oracle `from_gwei_f64()`

### DIFF
--- a/ethers-middleware/src/gas_oracle/mod.rs
+++ b/ethers-middleware/src/gas_oracle/mod.rs
@@ -153,7 +153,7 @@ pub trait GasOracle: Send + Sync + Debug {
 #[inline]
 #[doc(hidden)]
 pub(crate) fn from_gwei_f64(gwei: f64) -> U256 {
-    ethers_core::types::u256_from_f64_saturating(gwei) * GWEI_TO_WEI_U256
+    U256::from((gwei * GWEI_TO_WEI as f64).ceil() as u64)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Motivation

I found a problem that the network does not include transactions that filled the gas cost related fields using the Mumbai gas station oracle.
The `estimate_eip1559_fees()` impl of the initial implementation output `(1 gwei, 1 gwei)`. The value given by the gas station was actually `(1.48666678666667gwei, 1.48666663666668gwei)`.
The proposed modification allows Oracle to simply convert the value given from the source to wei, raise the decimal point, and express it as a U256.

Frankly, I was not smart enough to fully understand how the `u256_from_f64_saturating()` function operates. However, I believe there is a definite issue with how the existing oracle function works, and the modified code has worked as intended.

## Solution

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
