### PR TITLE
generic Provider allowing relaxed json rpc handling

### DIFF
--- a/ethers-providers/src/lib.rs
+++ b/ethers-providers/src/lib.rs
@@ -40,7 +40,7 @@ pub use test_provider::{GOERLI, MAINNET, ROPSTEN, SEPOLIA};
 /// to prevent rate limits
 pub mod test_provider {
     use super::*;
-    use crate::Http;
+    use crate::Http; // TODO: test LooseHttp
     use once_cell::sync::Lazy;
     use std::{convert::TryFrom, iter::Cycle, slice::Iter, sync::Mutex};
 

--- a/ethers-providers/src/rpc/transports/common.rs
+++ b/ethers-providers/src/rpc/transports/common.rs
@@ -96,7 +96,7 @@ impl<'a, T> Request<'a, T> {
 
 /// A JSON-RPC response
 #[derive(Debug)]
-pub enum Response<'a> {
+pub enum Response<'a, const STRICT:bool > {
     Success { id: u64, result: &'a RawValue },
     Error { id: u64, error: JsonRpcError },
     Notification { method: &'a str, params: Params<'a> },
@@ -109,120 +109,122 @@ pub struct Params<'a> {
     pub result: &'a RawValue,
 }
 
-// FIXME: ideally, this could be auto-derived as an untagged enum, but due to
-// https://github.com/serde-rs/serde/issues/1183 this currently fails
-impl<'de: 'a, 'a> Deserialize<'de> for Response<'a> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+struct ResponseVisitor<'b,const STRICT:bool>(&'b ());
+
+impl<'de: 'a, 'a, const STRICT:bool> Visitor<'de> for ResponseVisitor<'a,STRICT> {
+    type Value = Response<'a,STRICT>;
+    
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a valid jsonrpc 2.0 response object")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
     where
-        D: serde::Deserializer<'de>,
+        A: MapAccess<'de>,
     {
-        struct ResponseVisitor<'a>(&'a ());
-        impl<'de: 'a, 'a> Visitor<'de> for ResponseVisitor<'a> {
-            type Value = Response<'a>;
+        let mut jsonrpc = false;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a valid jsonrpc 2.0 response object")
-            }
+        // response & error
+        let mut id = None;
+        // only response
+        let mut result = None;
+        // only error
+        let mut error = None;
+        // only notification
+        let mut method = None;
+        let mut params = None;
 
-            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-            where
-                A: MapAccess<'de>,
-            {
-                let mut jsonrpc = false;
-
-                // response & error
-                let mut id = None;
-                // only response
-                let mut result = None;
-                // only error
-                let mut error = None;
-                // only notification
-                let mut method = None;
-                let mut params = None;
-
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        "jsonrpc" => {
-                            if jsonrpc {
-                                return Err(de::Error::duplicate_field("jsonrpc"))
-                            }
-
-                            let value = map.next_value()?;
-                            if value != "2.0" {
-                                return Err(de::Error::invalid_value(Unexpected::Str(value), &"2.0"))
-                            }
-
-                            jsonrpc = true;
-                        }
-                        "id" => {
-                            if id.is_some() {
-                                return Err(de::Error::duplicate_field("id"))
-                            }
-
-                            let value: u64 = map.next_value()?;
-                            id = Some(value);
-                        }
-                        "result" => {
-                            if result.is_some() {
-                                return Err(de::Error::duplicate_field("result"))
-                            }
-
-                            let value: &RawValue = map.next_value()?;
-                            result = Some(value);
-                        }
-                        "error" => {
-                            if error.is_some() {
-                                return Err(de::Error::duplicate_field("error"))
-                            }
-
-                            let value: JsonRpcError = map.next_value()?;
-                            error = Some(value);
-                        }
-                        "method" => {
-                            if method.is_some() {
-                                return Err(de::Error::duplicate_field("method"))
-                            }
-
-                            let value: &str = map.next_value()?;
-                            method = Some(value);
-                        }
-                        "params" => {
-                            if params.is_some() {
-                                return Err(de::Error::duplicate_field("params"))
-                            }
-
-                            let value: Params = map.next_value()?;
-                            params = Some(value);
-                        }
-                        key => {
-                            return Err(de::Error::unknown_field(
-                                key,
-                                &["id", "jsonrpc", "result", "error", "params", "method"],
-                            ))
-                        }
+        while let Some(key) = map.next_key()? {
+            match key {
+                "jsonrpc" => {
+                    if jsonrpc {
+                        return Err(de::Error::duplicate_field("jsonrpc"))
                     }
+
+                    let value = map.next_value()?;
+                    if value != "2.0" {
+                        return Err(de::Error::invalid_value(Unexpected::Str(value), &"2.0"))
+                    }
+
+                    jsonrpc = true;
                 }
+                "id" => {
+                    if id.is_some() {
+                        return Err(de::Error::duplicate_field("id"))
+                    }
 
-                // jsonrpc version must be present in all responses
-                if !jsonrpc {
-                    return Err(de::Error::missing_field("jsonrpc"))
+                    let value: u64 = map.next_value()?;
+                    id = Some(value);
                 }
+                "result" => {
+                    if result.is_some() {
+                        return Err(de::Error::duplicate_field("result"))
+                    }
 
-                match (id, result, error, method, params) {
-                    (Some(id), Some(result), None, None, None) => {
-                        Ok(Response::Success { id, result })
+                    let value: &RawValue = map.next_value()?;
+                    result = Some(value);
+                }
+                "error" => {
+                    if error.is_some() {
+                        return Err(de::Error::duplicate_field("error"))
                     }
-                    (Some(id), None, Some(error), None, None) => Ok(Response::Error { id, error }),
-                    (None, None, None, Some(method), Some(params)) => {
-                        Ok(Response::Notification { method, params })
+
+                    let value: JsonRpcError = map.next_value()?;
+                    error = Some(value);
+                }
+                "method" => {
+                    if method.is_some() {
+                        return Err(de::Error::duplicate_field("method"))
                     }
-                    _ => Err(de::Error::custom(
-                        "response must be either a success/error or notification object",
-                    )),
+
+                    let value: &str = map.next_value()?;
+                    method = Some(value);
+                }
+                "params" => {
+                    if params.is_some() {
+                        return Err(de::Error::duplicate_field("params"))
+                    }
+
+                    let value: Params = map.next_value()?;
+                    params = Some(value);
+                }
+                key => {
+                    return Err(de::Error::unknown_field(
+                        key,
+                        &["id", "jsonrpc", "result", "error", "params", "method"],
+                    ))
                 }
             }
         }
 
+        // jsonrpc version must be present in all responses
+        if !jsonrpc {
+            return Err(de::Error::missing_field("jsonrpc"))
+        }
+
+        match (id, result, error, method, params) {
+            (Some(id), Some(result), None, None, None) if STRICT => {
+                Ok(Response::Success { id, result })
+            }
+            (Some(id), Some(result), None, _, _) if !STRICT => {
+                Ok(Response::Success { id, result })
+            }
+            (Some(id), None, Some(error), None, None) => Ok(Response::Error { id, error }),
+            (None, None, None, Some(method), Some(params)) => {
+                Ok(Response::Notification { method, params })
+            }
+            _ => Err(de::Error::custom(
+                "response must be either a success/error or notification object",
+            )),
+        }
+    }
+}
+
+
+// FIXME: ideally, this could be auto-derived as an untagged enum, but due to
+// https://github.com/serde-rs/serde/issues/1183 this currently fails
+impl<'a, const STRICT: bool> Deserialize<'a> for Response<'a, STRICT> {
+    fn deserialize<D: serde::Deserializer<'a> >(deserializer: D) -> Result<Self, D::Error> {
         deserializer.deserialize_map(ResponseVisitor(&()))
     }
 }
@@ -279,11 +281,11 @@ mod tests {
     #[test]
     fn deser_response() {
         let _ =
-            serde_json::from_str::<Response<'_>>(r#"{"jsonrpc":"2.0","result":19}"#).unwrap_err();
-        let _ = serde_json::from_str::<Response<'_>>(r#"{"jsonrpc":"3.0","result":19,"id":1}"#)
+            serde_json::from_str::<Response<'_,true>>(r#"{"jsonrpc":"2.0","result":19}"#).unwrap_err();
+        let _ = serde_json::from_str::<Response<'_,true>>(r#"{"jsonrpc":"3.0","result":19,"id":1}"#)
             .unwrap_err();
 
-        let response: Response<'_> =
+        let response: Response<'_,true> =
             serde_json::from_str(r#"{"jsonrpc":"2.0","result":19,"id":1}"#).unwrap();
 
         match response {
@@ -295,7 +297,7 @@ mod tests {
             _ => panic!("expected `Success` response"),
         }
 
-        let response: Response<'_> = serde_json::from_str(
+        let response: Response<'_,true> = serde_json::from_str(
             r#"{"jsonrpc":"2.0","error":{"code":-32000,"message":"error occurred"},"id":2}"#,
         )
         .unwrap();
@@ -310,7 +312,7 @@ mod tests {
             _ => panic!("expected `Error` response"),
         }
 
-        let response: Response<'_> =
+        let response: Response<'_,true> =
             serde_json::from_str(r#"{"jsonrpc":"2.0","result":"0xfa","id":0}"#).unwrap();
 
         match response {

--- a/ethers-providers/src/rpc/transports/ipc.rs
+++ b/ethers-providers/src/rpc/transports/ipc.rs
@@ -409,7 +409,7 @@ impl Shared {
 
     fn handle_bytes(&self, bytes: &BytesMut) -> Result<usize, IpcError> {
         // deserialize all complete jsonrpc responses in the buffer
-        let mut de = Deserializer::from_slice(bytes.as_ref()).into_iter();
+        let mut de = Deserializer::from_slice(bytes.as_ref()).into_iter::<Response<'_,true>>();
         while let Some(Ok(response)) = de.next() {
             match response {
                 Response::Success { id, result } => self.send_response(id, Ok(result.to_owned())),

--- a/ethers-providers/src/rpc/transports/mod.rs
+++ b/ethers-providers/src/rpc/transports/mod.rs
@@ -2,7 +2,17 @@ pub(crate) mod common;
 pub use common::{Authorization, JsonRpcError};
 
 mod http;
-pub use self::http::{ClientError as HttpClientError, Provider as Http};
+pub use self::http::{ClientError as HttpClientError, Provider as HttpProvider};
+use self::http::{JsonRpcClient as RawJsonRpcClient,ClientError};
+
+///the old strict Http provider -- fails if the response has a `method:` entry
+pub type Http = HttpProvider<true>;
+
+///the new loose Http provider
+pub type LooseHttp = HttpProvider<false>;
+
+///when you want either Http or LooseHttp
+pub type HttpClient = dyn RawJsonRpcClient<Error=ClientError>;
 
 #[cfg(all(feature = "ipc", any(unix, windows)))]
 mod ipc;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

Sometimes you have no choice but to interact with json rpc endpoints that don't exactly adhere to the standards. Innocuous departures from the standard should be tolerable.

## Solution

I'm new to Rust, so I do not claim this implementation is ideal. From what I could tell the only way to achieve this is to modify the deserializer, and in order to do this without additional runtime state variables, I implemented this via a const bool generic type parameter on Response and Provider. A pull request I am submitting to https://github.com/foundry-rs/foundry will reference this pull request.

Because I export a type name Http which is equivalent to the old type, I believe this is not a breaking change; but that depends on what level of abstraction your source is at.

## PR Checklist

-   [x] Added Tests -- the existing tests cover the implementation except in the relaxed/loose case which I tested manually
-   [x] Added Documentation
-   [ ] Breaking changes
