### PR TITLE
Don't overwrite remappings if provided by Settings

### DIFF
--- a/ethers-solc/src/artifacts/mod.rs
+++ b/ethers-solc/src/artifacts/mod.rs
@@ -159,7 +159,11 @@ impl CompilerInput {
         if self.is_yul() {
             warn!("omitting remappings supplied for the yul sources");
         } else {
-            self.settings.remappings = remappings;
+            if self.settings.remappings.is_empty() {
+                self.settings.remappings = remappings;
+            } else {
+                warn!("remappings in settings conflicts with path configurations");
+            }
         }
         self
     }


### PR DESCRIPTION
## Motivation

remappings should be simply overwritten if there is any, which is especially the case when downloading standard json from etherscan.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
