### PR TITLE
perf: buffer writes when serializing json

### DIFF
--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -16,6 +16,7 @@ use std::{
         hash_map, BTreeSet, HashMap, HashSet,
     },
     fs::{self},
+    io::Write,
     path::{Path, PathBuf},
     time::{Duration, UNIX_EPOCH},
 };
@@ -139,7 +140,9 @@ impl SolFilesCache {
             self.len(),
             path.display()
         );
-        serde_json::to_writer_pretty(file, self)?;
+        let mut writer = std::io::BufWriter::with_capacity(1024 * 256, file);
+        serde_json::to_writer_pretty(&mut writer, self)?;
+        writer.flush().map_err(|e| SolcError::io(e, path))?;
         tracing::trace!("cache file located: \"{}\"", path.display());
         Ok(())
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Default is 8KiB, bumped to 256KiB for solc cache files since it seems more adequate

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
