### PR TITLE
fix: skip checksums for old windows solc

### DIFF
--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -480,7 +480,7 @@ impl Solc {
 
         #[cfg(windows)]
         {
-            // first windows .exe release, prior to 0.7.2, binaries are released as exe files which are hard to verify: <https://github.com/foundry-rs/foundry/issues/5601>
+            // Prior to 0.7.2, binaries are released as exe files which are hard to verify: <https://github.com/foundry-rs/foundry/issues/5601>
             // <https://binaries.soliditylang.org/windows-amd64/list.json>
             const V0_7_2: Version = Version::new(0, 7, 2);
             if version < V0_7_2 {

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -464,7 +464,6 @@ impl Solc {
     /// Verify that the checksum for this version of solc is correct. We check against the SHA256
     /// checksum from the build information published by [binaries.soliditylang.org](https://binaries.soliditylang.org/)
     #[cfg(all(feature = "svm-solc", not(target_arch = "wasm32")))]
-    #[cfg_attr(windows, allow(unreachable_code, unused_variables))]
     pub fn verify_checksum(&self) -> Result<()> {
         let version = self.version_short()?;
         let mut version_path = svm::version_path(version.to_string().as_str());
@@ -481,9 +480,12 @@ impl Solc {
 
         #[cfg(windows)]
         {
-            // we skip checksum verification on windows because the expected checksum is for the
-            // entire zip file and not the extracted solc binary TODO: <https://github.com/alloy-rs/svm-rs/issues/95>
-            return Ok(())
+            // first windows .exe release, prior to 0.7.2, binaries are released as exe files which are hard to verify: <https://github.com/foundry-rs/foundry/issues/5601>
+            // <https://binaries.soliditylang.org/windows-amd64/list.json>
+            const V0_7_2: Version = Version::new(0, 7, 2);
+            if version < V0_7_2 {
+                return Ok(())
+            }
         }
 
         use sha2::Digest;


### PR DESCRIPTION
ref https://github.com/foundry-rs/foundry/issues/5601