### PR TITLE
PubSubItem deserialize

### DIFF
--- a/ethers-providers/src/rpc/transports/ws/types.rs
+++ b/ethers-providers/src/rpc/transports/ws/types.rs
@@ -67,7 +67,7 @@ impl<'de> Deserialize<'de> for PubSubItem {
                     match key {
                         "jsonrpc" => {
                             if jsonrpc {
-                                return Err(de::Error::duplicate_field("jsonrpc"))
+                                return Err(de::Error::duplicate_field("jsonrpc"));
                             }
 
                             let value = map.next_value()?;
@@ -75,14 +75,14 @@ impl<'de> Deserialize<'de> for PubSubItem {
                                 return Err(de::Error::invalid_value(
                                     de::Unexpected::Str(value),
                                     &"2.0",
-                                ))
+                                ));
                             }
 
                             jsonrpc = true;
                         }
                         "id" => {
                             if id.is_some() {
-                                return Err(de::Error::duplicate_field("id"))
+                                return Err(de::Error::duplicate_field("id"));
                             }
 
                             let value: u64 = map.next_value()?;
@@ -90,7 +90,7 @@ impl<'de> Deserialize<'de> for PubSubItem {
                         }
                         "result" => {
                             if result.is_some() {
-                                return Err(de::Error::duplicate_field("result"))
+                                return Err(de::Error::duplicate_field("result"));
                             }
 
                             let value: Box<RawValue> = map.next_value()?;
@@ -98,7 +98,7 @@ impl<'de> Deserialize<'de> for PubSubItem {
                         }
                         "error" => {
                             if error.is_some() {
-                                return Err(de::Error::duplicate_field("error"))
+                                return Err(de::Error::duplicate_field("error"));
                             }
 
                             let value: JsonRpcError = map.next_value()?;
@@ -106,7 +106,7 @@ impl<'de> Deserialize<'de> for PubSubItem {
                         }
                         "method" => {
                             if method.is_some() {
-                                return Err(de::Error::duplicate_field("method"))
+                                return Err(de::Error::duplicate_field("method"));
                             }
 
                             let value: String = map.next_value()?;
@@ -114,7 +114,7 @@ impl<'de> Deserialize<'de> for PubSubItem {
                         }
                         "params" => {
                             if params.is_some() {
-                                return Err(de::Error::duplicate_field("params"))
+                                return Err(de::Error::duplicate_field("params"));
                             }
 
                             let value: Notification = map.next_value()?;
@@ -131,7 +131,7 @@ impl<'de> Deserialize<'de> for PubSubItem {
 
                 // jsonrpc version must be present in all responses
                 if !jsonrpc {
-                    return Err(de::Error::missing_field("jsonrpc"))
+                    return Err(de::Error::missing_field("jsonrpc"));
                 }
 
                 match (id, result, error, method, params) {
@@ -139,6 +139,9 @@ impl<'de> Deserialize<'de> for PubSubItem {
                         Ok(PubSubItem::Success { id, result })
                     }
                     (Some(id), None, Some(error), None, None) => {
+                        Ok(PubSubItem::Error { id, error })
+                    }
+                    (Some(id), Some(_), Some(error), None, None) => {
                         Ok(PubSubItem::Error { id, error })
                     }
                     (None, None, None, Some(_), Some(params)) => {


### PR DESCRIPTION
…ng in errors.

json example:
"{\"jsonrpc\":\"2.0\",\"id\":268,\"result\":null,\"error\":{\"code\":-32000,\"message\":\"tracing failed: fee cap less than block base fee: address 0x4a4BA8a759e7217a1ff38749Aa6E73564C1D8a01, gasFeeCap: 11470668621 baseFee: 11484931392\"}}"

If the json response contains both result and errors, it's better to return errors instead of "response must be a success/error or notification object"

Also, after returning "de::Error::custom", in

```
  pub async fn handle_text(&mut self, t: String) -> Result<(), WsClientError> {
         trace!(text = t, "Received message");
         match serde_json::from_str(&t) {
             Ok(item) => {
                 trace!(%item, "Deserialized message");
                 let res = self.handler.unbounded_send(item);
                 if res.is_err() {
                     return Err(WsClientError::DeadChannel)
                 }
             }
             Err(e) => {
                 error!(e = %e, "Failed to deserialize message");
             }
         }
         Ok(())
     }

```
An error should be returned instead of just printing the error, which would cause the request to wait indefinitely.

## PR Checklist

-   [x ] Added Tests
-   [x ] Added Documentation
-   [x ] Breaking changes
