### PR TITLE
doc: clarify docs for `ProjectCompileOutput::versioned_artifacts`

### DIFF
--- a/ethers-solc/src/compile/output/mod.rs
+++ b/ethers-solc/src/compile/output/mod.rs
@@ -98,7 +98,7 @@ impl<T: ArtifactOutput> ProjectCompileOutput<T> {
     }
 
     /// This returns a chained iterator of both cached and recompiled contract artifacts that yields
-    /// the contract name and the corresponding artifact
+    /// the contract name and the corresponding artifact with its version
     ///
     /// # Example
     ///


### PR DESCRIPTION
## Motivation

The main docstring for this function seems copy-pasted from the one above, this just adds some more details.

## Solution

Add some more details to the docs.

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [x] Breaking changes
