### PR TITLE
PubSubItem deserialize

### DIFF
--- a/ethers-providers/src/rpc/transports/ws/backend.rs
+++ b/ethers-providers/src/rpc/transports/ws/backend.rs
@@ -103,6 +103,7 @@ impl WsBackend {
             }
             Err(e) => {
                 error!(e = %e, "Failed to deserialize message");
+                return Err(WsClientError::JsonError(e))
             }
         }
         Ok(())

--- a/ethers-providers/src/rpc/transports/ws/types.rs
+++ b/ethers-providers/src/rpc/transports/ws/types.rs
@@ -141,6 +141,9 @@ impl<'de> Deserialize<'de> for PubSubItem {
                     (Some(id), None, Some(error), None, None) => {
                         Ok(PubSubItem::Error { id, error })
                     }
+                    (Some(id), Some(_), Some(error), None, None) => {
+                        Ok(PubSubItem::Error { id, error })
+                    }
                     (None, None, None, Some(_), Some(params)) => {
                         Ok(PubSubItem::Notification { params })
                     }


### PR DESCRIPTION
…ng in errors.

json example:
"{"jsonrpc":"2.0","id":268,"result":null,"error":{"code":-32000,"message":"tracing failed: fee cap less than block base fee: address 0x4a4BA8a759e7217a1ff38749Aa6E73564C1D8a01, gasFeeCap: 11470668621 baseFee: 11484931392"}}"

If the json response contains both result and errors, it's better to return errors instead of "response must be a success/error or notification object"

Also, after returning "de::Error::custom", in

```
  pub async fn handle_text(&mut self, t: String) -> Result<(), WsClientError> {
         trace!(text = t, "Received message");
         match serde_json::from_str(&t) {
             Ok(item) => {
                 trace!(%item, "Deserialized message");
                 let res = self.handler.unbounded_send(item);
                 if res.is_err() {
                     return Err(WsClientError::DeadChannel)
                 }
             }
             Err(e) => {
                 error!(e = %e, "Failed to deserialize message");
             }
         }
         Ok(())
     }
```

An error should be returned instead of just printing the error, which would cause the request to wait indefinitely.

PR Checklist
[x ] Added Tests
[x ] Added Documentation
[x ] Breaking changes