### PR TITLE
fix(solc): empty 'Solc error: ' message

### DIFF
--- a/ethers-solc/src/cache.rs
+++ b/ethers-solc/src/cache.rs
@@ -459,7 +459,7 @@ impl CacheEntry {
             .modified()
             .map_err(|err| SolcError::io(err, file.to_path_buf()))?
             .duration_since(UNIX_EPOCH)
-            .map_err(|err| SolcError::solc(err.to_string()))?
+            .map_err(SolcError::msg)?
             .as_millis() as u64;
         Ok(last_modification_date)
     }

--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -8,7 +8,6 @@ use semver::{Version, VersionReq};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
     fmt,
-    io::BufRead,
     path::{Path, PathBuf},
     process::{Command, Output, Stdio},
     str::FromStr,
@@ -300,7 +299,7 @@ impl Solc {
     pub fn find_svm_installed_version(version: impl AsRef<str>) -> Result<Option<Self>> {
         let version = version.as_ref();
         let solc = Self::svm_home()
-            .ok_or_else(|| SolcError::solc("svm home dir not found"))?
+            .ok_or_else(|| SolcError::msg("svm home dir not found"))?
             .join(version)
             .join(format!("solc-{version}"));
 
@@ -710,23 +709,22 @@ fn compile_output(output: Output) -> Result<Vec<u8>> {
     if output.status.success() {
         Ok(output.stdout)
     } else {
-        Err(SolcError::solc(String::from_utf8_lossy(&output.stderr).to_string()))
+        Err(SolcError::solc_output(&output))
     }
 }
 
 fn version_from_output(output: Output) -> Result<Version> {
     if output.status.success() {
-        let version = output
-            .stdout
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let version = stdout
             .lines()
-            .map_while(std::result::Result::ok)
             .filter(|l| !l.trim().is_empty())
             .last()
-            .ok_or_else(|| SolcError::solc("version not found in solc output"))?;
+            .ok_or_else(|| SolcError::msg("Version not found in Solc output"))?;
         // NOTE: semver doesn't like `+` in g++ in build metadata which is invalid semver
         Ok(Version::from_str(&version.trim_start_matches("Version: ").replace(".g++", ".gcc"))?)
     } else {
-        Err(SolcError::solc(String::from_utf8_lossy(&output.stderr).to_string()))
+        Err(SolcError::solc_output(&output))
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

When the Solc executable fails and the stderr is empty we throw `Solc error: ` which is not very helpful

cc @mattsse 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Make it print `Solc exited with {output.status}\n{output.stderr || output.stdout || "<empty output>"}`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
