### PR TITLE
fix: Update optimism type names to be inline with reth

### DIFF
--- a/ethers-contract/src/multicall/middleware.rs
+++ b/ethers-contract/src/multicall/middleware.rs
@@ -338,7 +338,7 @@ impl<M: Middleware> Multicall<M> {
             TypedTransaction::Eip2930(tx) => (tx.tx.to, tx.tx.data, tx.tx.value),
             TypedTransaction::Eip1559(tx) => (tx.to, tx.data, tx.value),
             #[cfg(feature = "optimism")]
-            TypedTransaction::OptimismDeposited(tx) => (tx.tx.to, tx.tx.data, tx.tx.value),
+            TypedTransaction::DepositTransaction(tx) => (tx.tx.to, tx.tx.data, tx.tx.value),
         };
         if data.is_none() && !call.function.outputs.is_empty() {
             return self

--- a/ethers-core/src/types/transaction/eip2718.rs
+++ b/ethers-core/src/types/transaction/eip2718.rs
@@ -14,9 +14,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[cfg(feature = "optimism")]
-use super::optimism_deposited::{
-    OptimismDepositedRequestError, OptimismDepositedTransactionRequest,
-};
+use super::optimism::{DepositTransaction, DepositTransactionError};
 
 /// The TypedTransaction enum represents all Ethereum transaction types.
 ///
@@ -45,7 +43,7 @@ pub enum TypedTransaction {
     // 0x7E
     #[cfg(feature = "optimism")]
     #[serde(rename = "0x7E")]
-    OptimismDeposited(OptimismDepositedTransactionRequest),
+    DepositTransaction(DepositTransaction),
 }
 
 /// An error involving a typed transaction request.
@@ -63,7 +61,7 @@ pub enum TypedTransactionError {
     /// When decoding a signed Optimism Deposited transaction
     #[cfg(feature = "optimism")]
     #[error(transparent)]
-    OptimismDepositedError(#[from] OptimismDepositedRequestError),
+    DepositTransactionError(#[from] DepositTransactionError),
     /// Error decoding the transaction type from the transaction's RLP encoding
     #[error(transparent)]
     TypeDecodingError(#[from] rlp::DecoderError),
@@ -98,7 +96,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.from.as_ref(),
             Eip1559(inner) => inner.from.as_ref(),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.from.as_ref(),
+            DepositTransaction(inner) => inner.tx.from.as_ref(),
         }
     }
 
@@ -108,7 +106,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.from = Some(from),
             Eip1559(inner) => inner.from = Some(from),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.from = Some(from),
+            DepositTransaction(inner) => inner.tx.from = Some(from),
         };
         self
     }
@@ -119,7 +117,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.to.as_ref(),
             Eip1559(inner) => inner.to.as_ref(),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.to.as_ref(),
+            DepositTransaction(inner) => inner.tx.to.as_ref(),
         }
     }
 
@@ -134,7 +132,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.to = Some(to),
             Eip1559(inner) => inner.to = Some(to),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.to = Some(to),
+            DepositTransaction(inner) => inner.tx.to = Some(to),
         };
         self
     }
@@ -145,7 +143,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.nonce.as_ref(),
             Eip1559(inner) => inner.nonce.as_ref(),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.nonce.as_ref(),
+            DepositTransaction(inner) => inner.tx.nonce.as_ref(),
         }
     }
 
@@ -156,7 +154,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.nonce = Some(nonce),
             Eip1559(inner) => inner.nonce = Some(nonce),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.nonce = Some(nonce),
+            DepositTransaction(inner) => inner.tx.nonce = Some(nonce),
         };
         self
     }
@@ -167,7 +165,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.value.as_ref(),
             Eip1559(inner) => inner.value.as_ref(),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.value.as_ref(),
+            DepositTransaction(inner) => inner.tx.value.as_ref(),
         }
     }
 
@@ -178,7 +176,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.value = Some(value),
             Eip1559(inner) => inner.value = Some(value),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.value = Some(value),
+            DepositTransaction(inner) => inner.tx.value = Some(value),
         };
         self
     }
@@ -189,7 +187,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.gas.as_ref(),
             Eip1559(inner) => inner.gas.as_ref(),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.gas.as_ref(),
+            DepositTransaction(inner) => inner.tx.gas.as_ref(),
         }
     }
 
@@ -199,7 +197,7 @@ impl TypedTransaction {
             Eip2930(inner) => &mut inner.tx.gas,
             Eip1559(inner) => &mut inner.gas,
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => &mut inner.tx.gas,
+            DepositTransaction(inner) => &mut inner.tx.gas,
         }
     }
 
@@ -210,7 +208,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.gas = Some(gas),
             Eip1559(inner) => inner.gas = Some(gas),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.gas = Some(gas),
+            DepositTransaction(inner) => inner.tx.gas = Some(gas),
         };
         self
     }
@@ -228,7 +226,7 @@ impl TypedTransaction {
                 }
             }
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.gas_price,
+            DepositTransaction(inner) => inner.tx.gas_price,
         }
     }
 
@@ -242,7 +240,7 @@ impl TypedTransaction {
                 inner.max_priority_fee_per_gas = Some(gas_price);
             }
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.gas_price = Some(gas_price),
+            DepositTransaction(inner) => inner.tx.gas_price = Some(gas_price),
         };
         self
     }
@@ -253,7 +251,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.chain_id,
             Eip1559(inner) => inner.chain_id,
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.chain_id,
+            DepositTransaction(inner) => inner.tx.chain_id,
         }
     }
 
@@ -264,7 +262,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.chain_id = Some(chain_id),
             Eip1559(inner) => inner.chain_id = Some(chain_id),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.chain_id = Some(chain_id),
+            DepositTransaction(inner) => inner.tx.chain_id = Some(chain_id),
         };
         self
     }
@@ -275,7 +273,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.data.as_ref(),
             Eip1559(inner) => inner.data.as_ref(),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.data.as_ref(),
+            DepositTransaction(inner) => inner.tx.data.as_ref(),
         }
     }
 
@@ -285,7 +283,7 @@ impl TypedTransaction {
             Eip2930(inner) => Some(&inner.access_list),
             Eip1559(inner) => Some(&inner.access_list),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(_) => None,
+            DepositTransaction(_) => None,
         }
     }
 
@@ -295,7 +293,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.access_list = access_list,
             Eip1559(inner) => inner.access_list = access_list,
             #[cfg(feature = "optimism")]
-            OptimismDeposited(_) => {}
+            DepositTransaction(_) => {}
         };
         self
     }
@@ -306,7 +304,7 @@ impl TypedTransaction {
             Eip2930(inner) => inner.tx.data = Some(data),
             Eip1559(inner) => inner.data = Some(data),
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => inner.tx.data = Some(data),
+            DepositTransaction(inner) => inner.tx.data = Some(data),
         };
         self
     }
@@ -326,7 +324,7 @@ impl TypedTransaction {
                 encoded.extend_from_slice(inner.rlp_signed(signature).as_ref());
             }
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => {
+            DepositTransaction(inner) => {
                 encoded.extend_from_slice(&[0x7E]);
                 encoded.extend_from_slice(inner.rlp().as_ref());
             }
@@ -349,7 +347,7 @@ impl TypedTransaction {
                 encoded.extend_from_slice(inner.rlp().as_ref());
             }
             #[cfg(feature = "optimism")]
-            OptimismDeposited(inner) => {
+            DepositTransaction(inner) => {
                 encoded.extend_from_slice(&[0x7E]);
                 encoded.extend_from_slice(inner.rlp().as_ref());
             }
@@ -407,8 +405,8 @@ impl TypedTransaction {
         #[cfg(feature = "optimism")]
         if first == 0x7E {
             // Optimism Deposited (0x7E)
-            let decoded_request = OptimismDepositedTransactionRequest::decode_signed_rlp(&rest)?;
-            return Ok((Self::OptimismDeposited(decoded_request.0), decoded_request.1))
+            let decoded_request = DepositTransaction::decode_signed_rlp(&rest)?;
+            return Ok((Self::DepositTransaction(decoded_request.0), decoded_request.1))
         }
 
         Err(rlp::DecoderError::Custom("invalid tx type").into())
@@ -438,7 +436,7 @@ impl Decodable for TypedTransaction {
             #[cfg(feature = "optimism")]
             Some(x) if x == U64::from(0x7E) => {
                 // Optimism Deposited (0x7E)
-                Ok(Self::OptimismDeposited(OptimismDepositedTransactionRequest::decode(&rest)?))
+                Ok(Self::DepositTransaction(DepositTransaction::decode(&rest)?))
             }
             _ => {
                 // Legacy (0x00)
@@ -468,9 +466,9 @@ impl From<Eip1559TransactionRequest> for TypedTransaction {
 }
 
 #[cfg(feature = "optimism")]
-impl From<OptimismDepositedTransactionRequest> for TypedTransaction {
-    fn from(src: OptimismDepositedTransactionRequest) -> TypedTransaction {
-        TypedTransaction::OptimismDeposited(src)
+impl From<DepositTransaction> for TypedTransaction {
+    fn from(src: DepositTransaction) -> TypedTransaction {
+        TypedTransaction::DepositTransaction(src)
     }
 }
 
@@ -490,7 +488,7 @@ impl From<&Transaction> for TypedTransaction {
             #[cfg(feature = "optimism")]
             // Optimism Deposited (0x7E)
             Some(x) if x == U64::from(0x7E) => {
-                let request: OptimismDepositedTransactionRequest = tx.into();
+                let request: DepositTransaction = tx.into();
                 request.into()
             }
             // Legacy (0x00)
@@ -522,9 +520,9 @@ impl TypedTransaction {
         }
     }
     #[cfg(feature = "optimism")]
-    pub fn as_optimism_deposited_ref(&self) -> Option<&OptimismDepositedTransactionRequest> {
+    pub fn as_optimism_deposited_ref(&self) -> Option<&DepositTransaction> {
         match self {
-            OptimismDeposited(tx) => Some(tx),
+            DepositTransaction(tx) => Some(tx),
             _ => None,
         }
     }
@@ -548,11 +546,9 @@ impl TypedTransaction {
         }
     }
     #[cfg(feature = "optimism")]
-    pub fn as_optimism_deposited_mut(
-        &mut self,
-    ) -> Option<&mut OptimismDepositedTransactionRequest> {
+    pub fn as_optimism_deposited_mut(&mut self) -> Option<&mut DepositTransaction> {
         match self {
-            OptimismDeposited(tx) => Some(tx),
+            DepositTransaction(tx) => Some(tx),
             _ => None,
         }
     }
@@ -608,7 +604,7 @@ impl TypedTransaction {
                 gateway_fee: None,
             },
             #[cfg(feature = "optimism")]
-            OptimismDeposited(tx) => tx.tx,
+            DepositTransaction(tx) => tx.tx,
         }
     }
 }
@@ -649,7 +645,7 @@ impl TypedTransaction {
                 access_list,
             },
             #[cfg(feature = "optimism")]
-            OptimismDeposited(tx) => Eip2930TransactionRequest { tx: tx.tx, access_list },
+            DepositTransaction(tx) => Eip2930TransactionRequest { tx: tx.tx, access_list },
         }
     }
 }

--- a/ethers-core/src/types/transaction/mod.rs
+++ b/ethers-core/src/types/transaction/mod.rs
@@ -6,7 +6,7 @@ pub mod eip2718;
 pub mod eip2930;
 
 #[cfg(feature = "optimism")]
-pub mod optimism_deposited;
+pub mod optimism;
 
 pub mod eip712;
 

--- a/ethers-middleware/src/gas_oracle/middleware.rs
+++ b/ethers-middleware/src/gas_oracle/middleware.rs
@@ -94,7 +94,7 @@ where
                 }
             }
             #[cfg(feature = "optimism")]
-            TypedTransaction::OptimismDeposited(ref mut inner) => {
+            TypedTransaction::DepositTransaction(ref mut inner) => {
                 if inner.tx.gas_price.is_none() {
                     inner.tx.gas_price = Some(self.get_gas_price().await?);
                 }

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -313,7 +313,7 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
                 };
             }
             #[cfg(feature = "optimism")]
-            TypedTransaction::OptimismDeposited(_) => {
+            TypedTransaction::DepositTransaction(_) => {
                 let gas_price = maybe(tx.gas_price(), self.get_gas_price()).await?;
                 tx.set_gas_price(gas_price);
             }

--- a/ethers-signers/src/ledger/app.rs
+++ b/ethers-signers/src/ledger/app.rs
@@ -162,7 +162,7 @@ impl LedgerEthereum {
                 }
                 TypedTransaction::Legacy(_) => eip155_chain_id + ecc_parity,
                 #[cfg(feature = "optimism")]
-                TypedTransaction::OptimismDeposited(_) => 0,
+                TypedTransaction::DepositTransaction(_) => 0,
             };
         }
 

--- a/ethers-signers/src/trezor/app.rs
+++ b/ethers-signers/src/trezor/app.rs
@@ -193,7 +193,7 @@ impl TrezorEthereum {
                 transaction.access_list,
             )?,
             #[cfg(feature = "optimism")]
-            TypedTransaction::OptimismDeposited(tx) => {
+            TypedTransaction::DepositTransaction(tx) => {
                 trezor_client::client::Signature { r: 0.into(), s: 0.into(), v: 0 }
             }
         };

--- a/ethers-signers/src/trezor/types.rs
+++ b/ethers-signers/src/trezor/types.rs
@@ -136,7 +136,7 @@ impl TrezorTransaction {
                 })
             }
             #[cfg(feature = "optimism")]
-            TypedTransaction::OptimismDeposited(_) => Ok(Self {
+            TypedTransaction::DepositTransaction(_) => Ok(Self {
                 nonce,
                 gas,
                 gas_price,


### PR DESCRIPTION
**Description**

Updates Optimism types to be inline with [op-reth](https://github.com/paradigmxyz/reth/pull/4377).