### PR TITLE
feat: Optimism Hydrated RPC Receipt Fields

### DIFF
--- a/ethers-core/src/types/transaction/response.rs
+++ b/ethers-core/src/types/transaction/response.rs
@@ -470,6 +470,9 @@ pub struct TransactionReceipt {
     /// amount that's actually paid by users can only be determined post-execution
     #[serde(rename = "effectiveGasPrice", default, skip_serializing_if = "Option::is_none")]
     pub effective_gas_price: Option<U256>,
+    /// Deposit nonce for Optimism deposited transactions
+    #[cfg(feature = "optimism")]
+    pub deposit_nonce: Option<u64>,
     /// Captures unknown fields such as additional fields used by L2s
     #[cfg(not(feature = "celo"))]
     #[serde(flatten)]
@@ -478,11 +481,28 @@ pub struct TransactionReceipt {
 
 impl rlp::Encodable for TransactionReceipt {
     fn rlp_append(&self, s: &mut RlpStream) {
+        #[cfg(feature = "optimism")]
+        if self.transaction_type == Some(U64::from(0x7E)) {
+            s.append(&U64::from(0x7E));
+        }
+        #[cfg(not(feature = "optimism"))]
         s.begin_list(4);
+        #[cfg(feature = "optimism")]
+        if self.transaction_type == Some(U64::from(0x7E)) {
+            s.begin_list(5);
+        } else {
+            s.begin_list(4);
+        }
         rlp_opt(s, &self.status);
         s.append(&self.cumulative_gas_used);
         s.append(&self.logs_bloom);
         s.append_list(&self.logs);
+        #[cfg(feature = "optimism")]
+        if self.transaction_type == Some(U64::from(0x7E)) {
+            if let Some(deposit_nonce) = self.deposit_nonce {
+                s.append(&deposit_nonce);
+            }
+        }
     }
 }
 
@@ -505,6 +525,39 @@ impl Ord for TransactionReceipt {
 impl PartialOrd<Self> for TransactionReceipt {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "optimism")]
+mod tests {
+    use super::*;
+    use rlp::Encodable;
+
+    #[test]
+    fn decode_deposit_receipt_regolith_roundtrip() {
+        let data = hex::decode("7ef9010c0182b741b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0833d3bbf").unwrap();
+        let expected = TransactionReceipt {
+            transaction_hash: H256::zero(),
+            transaction_index: U64::zero(),
+            block_hash: None,
+            block_number: None,
+            from: Address::zero(),
+            to: None,
+            cumulative_gas_used: U256::from(46913),
+            gas_used: None,
+            contract_address: None,
+            logs: vec![],
+            status: Some(U64::from(1)),
+            root: None,
+            logs_bloom: Bloom::default(),
+            transaction_type: Some(U64::from(0x7E)),
+            effective_gas_price: None,
+            deposit_nonce: Some(4012991),
+            #[cfg(not(feature = "celo"))]
+            other: crate::types::OtherFields::default(),
+        };
+        assert_eq!(expected.rlp_bytes().to_vec(), data);
     }
 }
 


### PR DESCRIPTION
**Description**

Adds deposit nonce field and l1 block info fields to the rpc transaction receipt.

The deposit nonce field is populated at creation while the l1 block info fields are hydrated for rpc requests.