### PR TITLE
fix(oracle): update helper function to use correct conversion maths

### DIFF
--- a/ethers-middleware/src/gas_oracle/mod.rs
+++ b/ethers-middleware/src/gas_oracle/mod.rs
@@ -152,8 +152,8 @@ pub trait GasOracle: Send + Sync + Debug {
 
 #[inline]
 #[doc(hidden)]
-pub(crate) fn from_gwei_f64(gwei: f64) -> U256 {
-    ethers_core::types::u256_from_f64_saturating(gwei) * GWEI_TO_WEI_U256
+pub fn from_gwei_f64(gwei: f64) -> U256 {
+    U256::from((gwei * GWEI_TO_WEI as f64).ceil() as u64)
 }
 
 #[cfg(test)]
@@ -165,5 +165,13 @@ mod tests {
         let as_u256: U256 = GWEI_TO_WEI.into();
         assert_eq!(as_u256, GWEI_TO_WEI_U256);
         assert_eq!(GWEI_TO_WEI_U256.as_u64(), GWEI_TO_WEI);
+    }
+
+    #[test]
+    fn test_gwei_conversion() {
+        let max_priority_fee: f64 = 1.8963421368;
+
+        let result = from_gwei_f64(max_priority_fee);
+        assert_eq!(result, U256::from(1896342137));
     }
 }


### PR DESCRIPTION
When converting between gwei and U256 it was rounding to the nearest whole number based on the decimal. For example if you added 2.49, the result would be 20000000 which is not idea

## Solution

Multiplied the f64 before the rounding occurs

## PR Checklist

-   [ yes] Added Tests
-   [no ] Added Documentation
-   [no ] Breaking changes
