### PR TITLE
added blockoverride field in geth tracing call options

### DIFF
--- a/ethers-core/src/types/trace/geth.rs
+++ b/ethers-core/src/types/trace/geth.rs
@@ -199,6 +199,28 @@ pub struct GethDebugTracingOptions {
     pub timeout: Option<String>,
 }
 
+/// Bindings for block overrides in `debug_traceCall` options
+///
+/// See <https://github.com/ethereum/go-ethereum/pull/24871>
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockOverrides {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub number: Option<U64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub difficulty: Option<U256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub time: Option<U64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gas_limit: Option<U64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coinbase: Option<Address>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub random: Option<H256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_fee: Option<U256>,
+}
+
 /// Bindings for additional `debug_traceCall` options
 ///
 /// See <https://geth.ethereum.org/docs/rpc/ns-debug#debug_tracecall>
@@ -209,7 +231,8 @@ pub struct GethDebugTracingCallOptions {
     pub tracing_options: GethDebugTracingOptions,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub state_overrides: Option<spoof::State>,
-    // TODO: Add blockoverrides options
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_overrides: Option<BlockOverrides>,
 }
 
 /// Provides types and methods for constructing an `eth_call`

--- a/examples/transactions/examples/trace_call.rs
+++ b/examples/transactions/examples/trace_call.rs
@@ -27,6 +27,7 @@ async fn main() -> Result<()> {
                 ..Default::default()
             },
             state_overrides: None,
+            block_overrides: None,
         };
         let traces = client.debug_trace_call(tx, Some(block), options).await?;
         println!("{traces:?}");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->
Fixes #2604 
## Motivation
Allow to override block params for `debug_traceCall` which would in turn allow to trace a pending txn against pending block.

## Solution
Added BlockOverrides fields which is similar to following impls.

https://github.com/ethereum/go-ethereum/blob/16cd1a7561155a264b1a1a2a5850b11c47dc18d4/internal/ethapi/api.go#L993
https://paradigmxyz.github.io/reth/docs/reth/rpc/types/struct.BlockOverrides.html

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
