### PR TITLE
feat: add `dependencies` to `MultiBindingsInner`

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -144,7 +144,11 @@ impl MultiAbigen {
     /// Build the contract bindings and prepare for writing
     pub fn build(self) -> Result<MultiBindings> {
         let format = self.abigens.iter().any(|gen| gen.format);
-        Ok(MultiBindings { expansion: MultiExpansion::from_abigen(self.abigens)?.expand(), format })
+        Ok(MultiBindings {
+            expansion: MultiExpansion::from_abigen(self.abigens)?.expand(),
+            format,
+            dependencies: vec![],
+        })
     }
 }
 
@@ -299,7 +303,12 @@ impl MultiExpansionResult {
     }
 
     /// Converts this result into [`MultiBindingsInner`]
-    fn into_bindings(mut self, single_file: bool, format: bool) -> MultiBindingsInner {
+    fn into_bindings(
+        mut self,
+        single_file: bool,
+        format: bool,
+        dependencies: Vec<String>,
+    ) -> MultiBindingsInner {
         self.set_shared_import_path(single_file);
         let Self { contracts, shared_types, root, .. } = self;
         let bindings = contracts
@@ -333,12 +342,7 @@ impl MultiExpansionResult {
             None
         };
 
-        MultiBindingsInner {
-            root,
-            bindings,
-            shared_types,
-            dependencies: vec![String::from(r#"serde = "1.0.188""#)],
-        }
+        MultiBindingsInner { root, bindings, shared_types, dependencies }
     }
 }
 
@@ -371,6 +375,7 @@ impl MultiExpansionResult {
 pub struct MultiBindings {
     expansion: MultiExpansionResult,
     format: bool,
+    dependencies: Vec<String>,
 }
 
 impl MultiBindings {
@@ -401,8 +406,19 @@ impl MultiBindings {
         self
     }
 
+    /// Specify a set of dependencies to use for the generated crate.
+    ///
+    /// By default, this is empty and only the `ethers` dependency is added.
+    pub fn dependencies(
+        mut self,
+        dependencies: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.dependencies = dependencies.into_iter().map(|dep| dep.into()).collect();
+        self
+    }
+
     fn into_inner(self, single_file: bool) -> MultiBindingsInner {
-        self.expansion.into_bindings(single_file, self.format)
+        self.expansion.into_bindings(single_file, self.format, self.dependencies)
     }
 
     /// Generates all the bindings and writes them to the given module

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -602,7 +602,8 @@ struct MultiBindingsInner {
     bindings: BTreeMap<String, ContractBindings>,
     /// contains the content of the shared types if any
     shared_types: Option<ContractBindings>,
-    /// Dependencies other than `ethers-rs` to add to the `Cargo.toml` for bindings generated as a crate.
+    /// Dependencies other than `ethers-rs` to add to the `Cargo.toml` for bindings generated as a
+    /// crate.
     dependencies: Vec<String>,
 }
 

--- a/ethers-contract/ethers-contract-abigen/src/multi.rs
+++ b/ethers-contract/ethers-contract-abigen/src/multi.rs
@@ -333,7 +333,12 @@ impl MultiExpansionResult {
             None
         };
 
-        MultiBindingsInner { root, bindings, shared_types }
+        MultiBindingsInner {
+            root,
+            bindings,
+            shared_types,
+            dependencies: vec![String::from(r#"serde = "1.0.188""#)],
+        }
     }
 }
 
@@ -581,6 +586,8 @@ struct MultiBindingsInner {
     bindings: BTreeMap<String, ContractBindings>,
     /// contains the content of the shared types if any
     shared_types: Option<ContractBindings>,
+    /// Dependencies other than `ethers-rs` to add to the `Cargo.toml` for bindings generated as a crate.
+    dependencies: Vec<String>,
 }
 
 // deref allows for inspection without modification
@@ -611,6 +618,9 @@ impl MultiBindingsInner {
         writeln!(toml)?;
         writeln!(toml, "[dependencies]")?;
         writeln!(toml, r#"{crate_version}"#)?;
+        for dependency in self.dependencies.clone() {
+            writeln!(toml, "{}", dependency)?;
+        }
         Ok(toml)
     }
 


### PR DESCRIPTION
## Motivation
This seeks to close #2599 and should link to [Foundry PR #5836](https://github.com/foundry-rs/foundry/pull/5836). The intent is to be able to allow for `serde::{Deserialize, Serialize}` to be derived on contract bindings either via module or crate. 

PR here has the intent of providing support for an additional dependency in the `Cargo.toml` generated when bindings are output as a crate.

## Solution
This solution here seems a bit simplistic and forcefully assumes the end user will want a specific version of `serde` as an included dependency. It could be good, instead, to:
- Allow for dependencies to be chosen if there are extra derives added to the crate.
- Also forcefully add the `serde` derives to the contract bindings at this level.
- Check for most recent `serde` version or the version used within `ethers-rs` directly.

Let me know if we wish to make any of the above changes or otherwise!

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [x] Breaking changes
