### PR TITLE
fix(solc): use Solc::version_req to parse version req

### DIFF
--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -395,7 +395,10 @@ impl Solc {
         Self::version_req(version.as_str())
     }
 
-    /// Returns the corresponding SemVer version requirement for the solidity version
+    /// Returns the corresponding SemVer version requirement for the solidity version.
+    ///
+    /// Note: This is a workaround for the fact that `VersionReq::parse` does not support whitespace
+    /// separators and requires comma separated operators. See [VersionReq].
     pub fn version_req(version: &str) -> Result<VersionReq> {
         let version = version.replace(' ', ",");
 
@@ -744,6 +747,13 @@ impl<T: Into<PathBuf>> From<T> for Solc {
 mod tests {
     use super::*;
     use crate::{Artifact, CompilerInput};
+
+    #[test]
+    fn test_version_parse() {
+        let req = Solc::version_req(">=0.6.2 <0.8.21").unwrap();
+        let semver_req: VersionReq = ">=0.6.2,<0.8.21".parse().unwrap();
+        assert_eq!(req, semver_req);
+    }
 
     fn solc() -> Solc {
         Solc::default()

--- a/ethers-solc/src/resolver/mod.rs
+++ b/ethers-solc/src/resolver/mod.rs
@@ -46,9 +46,7 @@
 //! [version pragma](https://docs.soliditylang.org/en/develop/layout-of-source-files.html#version-pragma),
 //! which is defined on a per source file basis.
 
-use crate::{
-    error::Result, utils, IncludePaths, ProjectPathsConfig, SolcError, SolcVersion, Source, Sources,
-};
+use crate::{error::Result, utils, IncludePaths, ProjectPathsConfig, SolcError, Source, Sources};
 use parse::{SolData, SolDataUnit, SolImport};
 use rayon::prelude::*;
 use semver::VersionReq;
@@ -908,14 +906,14 @@ impl Node {
     #[cfg(all(feature = "svm-solc", not(target_arch = "wasm32")))]
     fn check_available_version(
         &self,
-        all_versions: &[SolcVersion],
+        all_versions: &[crate::SolcVersion],
         offline: bool,
     ) -> std::result::Result<(), SourceVersionError> {
         let Some(data) = &self.data.version else { return Ok(()) };
         let v = data.data();
 
-        let req: VersionReq =
-            v.parse().map_err(|err| SourceVersionError::InvalidVersion(v.to_string(), err))?;
+        let req = crate::Solc::version_req(v)
+            .map_err(|err| SourceVersionError::InvalidVersion(v.to_string(), err))?;
 
         if !all_versions.iter().any(|v| req.matches(v.as_ref())) {
             return if offline {
@@ -951,7 +949,7 @@ impl<'a> fmt::Display for DisplayNode<'a> {
 #[allow(unused)]
 enum SourceVersionError {
     #[error("Failed to parse solidity version {0}: {1}")]
-    InvalidVersion(String, semver::Error),
+    InvalidVersion(String, SolcError),
     #[error("No solc version exists that matches the version requirement: {0}")]
     NoMatchingVersion(VersionReq),
     #[error("No solc version installed that matches the version requirement: {0}")]


### PR DESCRIPTION
use custom Solc::version_req to parse version req because semver Version req differs from solidity's format