### PR TITLE
Correctly parse null values in 0.7.0 asts

### DIFF
--- a/ethers-solc/src/artifacts/ast/mod.rs
+++ b/ethers-solc/src/artifacts/ast/mod.rs
@@ -176,9 +176,9 @@ ast_node!(
         linearized_base_contracts: Vec<usize>,
         nodes: Vec<ContractDefinitionPart>,
         scope: usize,
-        #[serde(default)]
+        #[serde(default, deserialize_with = "serde_helpers::default_for_null")]
         used_errors: Vec<usize>,
-        #[serde(default)]
+        #[serde(default, deserialize_with = "serde_helpers::default_for_null")]
         used_events: Vec<usize>,
         #[serde(default, rename = "internalFunctionIDs")]
         internal_function_ids: BTreeMap<usize, usize>,
@@ -607,7 +607,7 @@ ast_node!(
 expr_node!(
     /// A tuple expression.
     struct TupleExpression {
-        components: Vec<Expression>,
+        components: Vec<Option<Expression>>,
         is_inline_array: bool,
     }
 );
@@ -696,7 +696,7 @@ ast_node!(
         name: String,
         #[serde(default, with = "serde_helpers::display_from_str_opt")]
         name_location: Option<SourceLocation>,
-        #[serde(default)]
+        #[serde(default, deserialize_with = "serde_helpers::default_for_null")]
         base_functions: Vec<usize>,
         body: Option<Block>,
         documentation: Option<StructuredDocumentation>,
@@ -870,7 +870,7 @@ ast_node!(
         // TODO: We need this camel case for the AST, but pascal case other places in ethers-solc
         //evm_version: EvmVersion,
         external_references: Vec<ExternalInlineAssemblyReference>,
-        #[serde(default)]
+        #[serde(default, deserialize_with = "serde_helpers::default_for_null")]
         flags: Vec<InlineAssemblyFlag>,
     }
 );
@@ -943,7 +943,7 @@ ast_node!(
     struct TryCatchClause {
         block: Block,
         error_name: String,
-        #[serde(default)]
+        #[serde(default, deserialize_with = "serde_helpers::default_for_null")]
         parameters: Vec<ParameterList>,
     }
 );
@@ -966,7 +966,7 @@ stmt_node!(
 ast_node!(
     /// A modifier or base constructor invocation.
     struct ModifierInvocation {
-        #[serde(default)]
+        #[serde(default, deserialize_with = "serde_helpers::default_for_null")]
         arguments: Vec<Expression>,
         kind: Option<ModifierInvocationKind>,
         modifier_name: IdentifierOrIdentifierPath,
@@ -1028,7 +1028,7 @@ ast_node!(
 ast_node!(
     /// A using for directive.
     struct UsingForDirective {
-        #[serde(default)]
+        #[serde(default, deserialize_with = "serde_helpers::default_for_null")]
         function_list: Vec<FunctionIdentifierPath>,
         #[serde(default)]
         global: bool,

--- a/ethers-solc/test-data/ast/bit_not.json
+++ b/ethers-solc/test-data/ast/bit_not.json
@@ -1,1 +1,334 @@
-{"absolutePath":"Bytes.sol","exportedSymbols":{"Bytes":[25]},"id":26,"license":"UNLICENSED","nodeType":"SourceUnit","nodes":[{"id":1,"literals":["solidity","0.8",".13"],"nodeType":"PragmaDirective","src":"40:23:0"},{"abstract":false,"baseContracts":[],"canonicalName":"Bytes","contractDependencies":[],"contractKind":"library","fullyImplemented":true,"id":25,"linearizedBaseContracts":[25],"name":"Bytes","nameLocation":"73:5:0","nodeType":"ContractDefinition","nodes":[{"body":{"id":23,"nodeType":"Block","src":"207:164:0","statements":[{"expression":{"commonType":{"typeIdentifier":"t_uint192","typeString":"uint192"},"id":21,"isConstant":false,"isLValue":false,"isPure":false,"lValueRequested":false,"leftExpression":{"id":12,"name":"_packedBools","nodeType":"Identifier","overloadedDeclarations":[],"referencedDeclaration":3,"src":"314:12:0","typeDescriptions":{"typeIdentifier":"t_uint192","typeString":"uint192"}},"nodeType":"BinaryOperation","operator":"&","rightExpression":{"id":20,"isConstant":false,"isLValue":false,"isPure":false,"lValueRequested":false,"nodeType":"UnaryOperation","operator":"~","prefix":true,"src":"329:28:0","subExpression":{"components":[{"commonType":{"typeIdentifier":"t_uint192","typeString":"uint192"},"id":18,"isConstant":false,"isLValue":false,"isPure":false,"lValueRequested":false,"leftExpression":{"arguments":[{"hexValue":"31","id":15,"isConstant":false,"isLValue":false,"isPure":true,"kind":"number","lValueRequested":false,"nodeType":"Literal","src":"339:1:0","typeDescriptions":{"typeIdentifier":"t_rational_1_by_1","typeString":"int_const 1"},"value":"1"}],"expression":{"argumentTypes":[{"typeIdentifier":"t_rational_1_by_1","typeString":"int_const 1"}],"id":14,"isConstant":false,"isLValue":false,"isPure":true,"lValueRequested":false,"nodeType":"ElementaryTypeNameExpression","src":"331:7:0","typeDescriptions":{"typeIdentifier":"t_type$_t_uint192_$","typeString":"type(uint192)"},"typeName":{"id":13,"name":"uint192","nodeType":"ElementaryTypeName","src":"331:7:0","typeDescriptions":{}}},"id":16,"isConstant":false,"isLValue":false,"isPure":true,"kind":"typeConversion","lValueRequested":false,"names":[],"nodeType":"FunctionCall","src":"331:10:0","tryCall":false,"typeDescriptions":{"typeIdentifier":"t_uint192","typeString":"uint192"}},"nodeType":"BinaryOperation","operator":"<<","rightExpression":{"id":17,"name":"_boolNumber","nodeType":"Identifier","overloadedDeclarations":[],"referencedDeclaration":5,"src":"345:11:0","typeDescriptions":{"typeIdentifier":"t_uint192","typeString":"uint192"}},"src":"331:25:0","typeDescriptions":{"typeIdentifier":"t_uint192","typeString":"uint192"}}],"id":19,"isConstant":false,"isInlineArray":false,"isLValue":false,"isPure":false,"lValueRequested":false,"nodeType":"TupleExpression","src":"330:27:0","typeDescriptions":{"typeIdentifier":"t_uint192","typeString":"uint192"}},"typeDescriptions":{"typeIdentifier":"t_uint192","typeString":"uint192"}},"src":"314:43:0","typeDescriptions":{"typeIdentifier":"t_uint192","typeString":"uint192"}},"functionReturnParameters":11,"id":22,"nodeType":"Return","src":"307:50:0"}]},"id":24,"implemented":true,"kind":"function","modifiers":[],"name":"setBoolean","nameLocation":"92:10:0","nodeType":"FunctionDefinition","parameters":{"id":8,"nodeType":"ParameterList","parameters":[{"constant":false,"id":3,"mutability":"mutable","name":"_packedBools","nameLocation":"116:12:0","nodeType":"VariableDeclaration","scope":24,"src":"108:20:0","stateVariable":false,"storageLocation":"default","typeDescriptions":{"typeIdentifier":"t_uint192","typeString":"uint192"},"typeName":{"id":2,"name":"uint192","nodeType":"ElementaryTypeName","src":"108:7:0","typeDescriptions":{"typeIdentifier":"t_uint192","typeString":"uint192"}},"visibility":"internal"},{"constant":false,"id":5,"mutability":"mutable","name":"_boolNumber","nameLocation":"142:11:0","nodeType":"VariableDeclaration","scope":24,"src":"134:19:0","stateVariable":false,"storageLocation":"default","typeDescriptions":{"typeIdentifier":"t_uint192","typeString":"uint192"},"typeName":{"id":4,"name":"uint192","nodeType":"ElementaryTypeName","src":"134:7:0","typeDescriptions":{"typeIdentifier":"t_uint192","typeString":"uint192"}},"visibility":"internal"},{"constant":false,"id":7,"mutability":"mutable","name":"_value","nameLocation":"164:6:0","nodeType":"VariableDeclaration","scope":24,"src":"159:11:0","stateVariable":false,"storageLocation":"default","typeDescriptions":{"typeIdentifier":"t_bool","typeString":"bool"},"typeName":{"id":6,"name":"bool","nodeType":"ElementaryTypeName","src":"159:4:0","typeDescriptions":{"typeIdentifier":"t_bool","typeString":"bool"}},"visibility":"internal"}],"src":"102:72:0"},"returnParameters":{"id":11,"nodeType":"ParameterList","parameters":[{"constant":false,"id":10,"mutability":"mutable","name":"","nameLocation":"-1:-1:-1","nodeType":"VariableDeclaration","scope":24,"src":"198:7:0","stateVariable":false,"storageLocation":"default","typeDescriptions":{"typeIdentifier":"t_uint192","typeString":"uint192"},"typeName":{"id":9,"name":"uint192","nodeType":"ElementaryTypeName","src":"198:7:0","typeDescriptions":{"typeIdentifier":"t_uint192","typeString":"uint192"}},"visibility":"internal"}],"src":"197:9:0"},"scope":25,"src":"83:288:0","stateMutability":"pure","virtual":false,"visibility":"internal"}],"scope":26,"src":"65:308:0","usedErrors":[]}],"src":"40:334:0"}
+{
+  "absolutePath": "Bytes.sol",
+  "exportedSymbols": { "Bytes": [25] },
+  "id": 26,
+  "license": "UNLICENSED",
+  "nodeType": "SourceUnit",
+  "nodes": [
+    {
+      "id": 1,
+      "literals": ["solidity", "0.8", ".13"],
+      "nodeType": "PragmaDirective",
+      "src": "40:23:0"
+    },
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "canonicalName": "Bytes",
+      "contractDependencies": [],
+      "contractKind": "library",
+      "fullyImplemented": true,
+      "id": 25,
+      "linearizedBaseContracts": [25],
+      "name": "Bytes",
+      "nameLocation": "73:5:0",
+      "nodeType": "ContractDefinition",
+      "nodes": [
+        {
+          "body": {
+            "id": 23,
+            "nodeType": "Block",
+            "src": "207:164:0",
+            "statements": [
+              {
+                "expression": {
+                  "commonType": {
+                    "typeIdentifier": "t_uint192",
+                    "typeString": "uint192"
+                  },
+                  "id": 21,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "lValueRequested": false,
+                  "leftExpression": {
+                    "id": 12,
+                    "name": "_packedBools",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 3,
+                    "src": "314:12:0",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint192",
+                      "typeString": "uint192"
+                    }
+                  },
+                  "nodeType": "BinaryOperation",
+                  "operator": "&",
+                  "rightExpression": {
+                    "id": 20,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "nodeType": "UnaryOperation",
+                    "operator": "~",
+                    "prefix": true,
+                    "src": "329:28:0",
+                    "subExpression": {
+                      "components": [
+                        {
+                          "commonType": {
+                            "typeIdentifier": "t_uint192",
+                            "typeString": "uint192"
+                          },
+                          "id": 18,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "leftExpression": {
+                            "arguments": [
+                              {
+                                "hexValue": "31",
+                                "id": 15,
+                                "isConstant": false,
+                                "isLValue": false,
+                                "isPure": true,
+                                "kind": "number",
+                                "lValueRequested": false,
+                                "nodeType": "Literal",
+                                "src": "339:1:0",
+                                "typeDescriptions": {
+                                  "typeIdentifier": "t_rational_1_by_1",
+                                  "typeString": "int_const 1"
+                                },
+                                "value": "1"
+                              }
+                            ],
+                            "expression": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_rational_1_by_1",
+                                  "typeString": "int_const 1"
+                                }
+                              ],
+                              "id": 14,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": true,
+                              "lValueRequested": false,
+                              "nodeType": "ElementaryTypeNameExpression",
+                              "src": "331:7:0",
+                              "typeDescriptions": {
+                                "typeIdentifier": "t_type$_t_uint192_$",
+                                "typeString": "type(uint192)"
+                              },
+                              "typeName": {
+                                "id": 13,
+                                "name": "uint192",
+                                "nodeType": "ElementaryTypeName",
+                                "src": "331:7:0",
+                                "typeDescriptions": {}
+                              }
+                            },
+                            "id": 16,
+                            "isConstant": false,
+                            "isLValue": false,
+                            "isPure": true,
+                            "kind": "typeConversion",
+                            "lValueRequested": false,
+                            "names": [],
+                            "nodeType": "FunctionCall",
+                            "src": "331:10:0",
+                            "tryCall": false,
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint192",
+                              "typeString": "uint192"
+                            }
+                          },
+                          "nodeType": "BinaryOperation",
+                          "operator": "<<",
+                          "rightExpression": {
+                            "id": 17,
+                            "name": "_boolNumber",
+                            "nodeType": "Identifier",
+                            "overloadedDeclarations": [],
+                            "referencedDeclaration": 5,
+                            "src": "345:11:0",
+                            "typeDescriptions": {
+                              "typeIdentifier": "t_uint192",
+                              "typeString": "uint192"
+                            }
+                          },
+                          "src": "331:25:0",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_uint192",
+                            "typeString": "uint192"
+                          }
+                        }
+                      ],
+                      "id": 19,
+                      "isConstant": false,
+                      "isInlineArray": false,
+                      "isLValue": false,
+                      "isPure": false,
+                      "lValueRequested": false,
+                      "nodeType": "TupleExpression",
+                      "src": "330:27:0",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint192",
+                        "typeString": "uint192"
+                      }
+                    },
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint192",
+                      "typeString": "uint192"
+                    }
+                  },
+                  "src": "314:43:0",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint192",
+                    "typeString": "uint192"
+                  }
+                },
+                "functionReturnParameters": 11,
+                "id": 22,
+                "nodeType": "Return",
+                "src": "307:50:0"
+              }
+            ]
+          },
+          "id": 24,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "setBoolean",
+          "nameLocation": "92:10:0",
+          "nodeType": "FunctionDefinition",
+          "parameters": {
+            "id": 8,
+            "nodeType": "ParameterList",
+            "parameters": [
+              {
+                "constant": false,
+                "id": 3,
+                "mutability": "mutable",
+                "name": "_packedBools",
+                "nameLocation": "116:12:0",
+                "nodeType": "VariableDeclaration",
+                "scope": 24,
+                "src": "108:20:0",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_uint192",
+                  "typeString": "uint192"
+                },
+                "typeName": {
+                  "id": 2,
+                  "name": "uint192",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "108:7:0",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint192",
+                    "typeString": "uint192"
+                  }
+                },
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 5,
+                "mutability": "mutable",
+                "name": "_boolNumber",
+                "nameLocation": "142:11:0",
+                "nodeType": "VariableDeclaration",
+                "scope": 24,
+                "src": "134:19:0",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_uint192",
+                  "typeString": "uint192"
+                },
+                "typeName": {
+                  "id": 4,
+                  "name": "uint192",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "134:7:0",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint192",
+                    "typeString": "uint192"
+                  }
+                },
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 7,
+                "mutability": "mutable",
+                "name": "_value",
+                "nameLocation": "164:6:0",
+                "nodeType": "VariableDeclaration",
+                "scope": 24,
+                "src": "159:11:0",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_bool",
+                  "typeString": "bool"
+                },
+                "typeName": {
+                  "id": 6,
+                  "name": "bool",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "159:4:0",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_bool",
+                    "typeString": "bool"
+                  }
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "102:72:0"
+          },
+          "returnParameters": {
+            "id": 11,
+            "nodeType": "ParameterList",
+            "parameters": [
+              {
+                "constant": false,
+                "id": 10,
+                "mutability": "mutable",
+                "name": "",
+                "nameLocation": "-1:-1:-1",
+                "nodeType": "VariableDeclaration",
+                "scope": 24,
+                "src": "198:7:0",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_uint192",
+                  "typeString": "uint192"
+                },
+                "typeName": {
+                  "id": 9,
+                  "name": "uint192",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "198:7:0",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint192",
+                    "typeString": "uint192"
+                  }
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "197:9:0"
+          },
+          "scope": 25,
+          "src": "83:288:0",
+          "stateMutability": "pure",
+          "virtual": false,
+          "visibility": "internal"
+        }
+      ],
+      "scope": 26,
+      "src": "65:308:0",
+      "usedErrors": []
+    }
+  ],
+  "src": "40:334:0"
+}

--- a/ethers-solc/test-data/ast/bit_not.json
+++ b/ethers-solc/test-data/ast/bit_not.json
@@ -156,7 +156,8 @@
                             "typeIdentifier": "t_uint192",
                             "typeString": "uint192"
                           }
-                        }
+                        },
+                        null
                       ],
                       "id": 19,
                       "isConstant": false,

--- a/ethers-solc/test-data/ast/modifier_definition.json
+++ b/ethers-solc/test-data/ast/modifier_definition.json
@@ -111,6 +111,21 @@
               },
               "nodeType": "ModifierInvocation",
               "src": "52:4:1"
+            },
+            {
+              "arguments": null,
+              "id": 10,
+              "kind": "modifierInvocation",
+              "modifierName": {
+                "id": 8,
+                "name": "M",
+                "nameLocations": ["52:1:1"],
+                "nodeType": "IdentifierPath",
+                "referencedDeclaration": 6,
+                "src": "52:1:1"
+              },
+              "nodeType": "ModifierInvocation",
+              "src": "52:4:1"
             }
           ],
           "name": "F",

--- a/ethers-solc/test-data/ast/modifier_definition.json
+++ b/ethers-solc/test-data/ast/modifier_definition.json
@@ -1,1 +1,144 @@
-{"absolutePath":"a","exportedSymbols":{"C":[14]},"id":15,"nodeType":"SourceUnit","nodes":[{"abstract":false,"baseContracts":[],"canonicalName":"C","contractDependencies":[],"contractKind":"contract","fullyImplemented":true,"id":14,"linearizedBaseContracts":[14],"name":"C","nameLocation":"9:1:1","nodeType":"ContractDefinition","nodes":[{"body":{"id":5,"nodeType":"Block","src":"32:6:1","statements":[{"id":4,"nodeType":"PlaceholderStatement","src":"34:1:1"}]},"id":6,"name":"M","nameLocation":"22:1:1","nodeType":"ModifierDefinition","parameters":{"id":3,"nodeType":"ParameterList","parameters":[{"constant":false,"id":2,"mutability":"mutable","name":"i","nameLocation":"29:1:1","nodeType":"VariableDeclaration","scope":6,"src":"24:6:1","stateVariable":false,"storageLocation":"default","typeDescriptions":{"typeIdentifier":"t_uint256","typeString":"uint256"},"typeName":{"id":1,"name":"uint","nodeType":"ElementaryTypeName","src":"24:4:1","typeDescriptions":{"typeIdentifier":"t_uint256","typeString":"uint256"}},"visibility":"internal"}],"src":"23:8:1"},"src":"13:25:1","virtual":false,"visibility":"internal"},{"body":{"id":12,"nodeType":"Block","src":"64:2:1","statements":[]},"functionSelector":"28811f59","id":13,"implemented":true,"kind":"function","modifiers":[{"arguments":[{"hexValue":"31","id":9,"isConstant":false,"isLValue":false,"isPure":true,"kind":"number","lValueRequested":false,"nodeType":"Literal","src":"54:1:1","typeDescriptions":{"typeIdentifier":"t_rational_1_by_1","typeString":"int_const 1"},"value":"1"}],"id":10,"kind":"modifierInvocation","modifierName":{"id":8,"name":"M","nameLocations":["52:1:1"],"nodeType":"IdentifierPath","referencedDeclaration":6,"src":"52:1:1"},"nodeType":"ModifierInvocation","src":"52:4:1"}],"name":"F","nameLocation":"48:1:1","nodeType":"FunctionDefinition","parameters":{"id":7,"nodeType":"ParameterList","parameters":[],"src":"49:2:1"},"returnParameters":{"id":11,"nodeType":"ParameterList","parameters":[],"src":"64:0:1"},"scope":14,"src":"39:27:1","stateMutability":"nonpayable","virtual":false,"visibility":"public"}],"scope":15,"src":"0:68:1","usedErrors":[]}],"src":"0:69:1"}
+{
+  "absolutePath": "a",
+  "exportedSymbols": { "C": [14] },
+  "id": 15,
+  "nodeType": "SourceUnit",
+  "nodes": [
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "canonicalName": "C",
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "fullyImplemented": true,
+      "id": 14,
+      "linearizedBaseContracts": [14],
+      "name": "C",
+      "nameLocation": "9:1:1",
+      "nodeType": "ContractDefinition",
+      "nodes": [
+        {
+          "body": {
+            "id": 5,
+            "nodeType": "Block",
+            "src": "32:6:1",
+            "statements": [
+              { "id": 4, "nodeType": "PlaceholderStatement", "src": "34:1:1" }
+            ]
+          },
+          "id": 6,
+          "name": "M",
+          "nameLocation": "22:1:1",
+          "nodeType": "ModifierDefinition",
+          "parameters": {
+            "id": 3,
+            "nodeType": "ParameterList",
+            "parameters": [
+              {
+                "constant": false,
+                "id": 2,
+                "mutability": "mutable",
+                "name": "i",
+                "nameLocation": "29:1:1",
+                "nodeType": "VariableDeclaration",
+                "scope": 6,
+                "src": "24:6:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_uint256",
+                  "typeString": "uint256"
+                },
+                "typeName": {
+                  "id": 1,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "24:4:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  }
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "23:8:1"
+          },
+          "src": "13:25:1",
+          "virtual": false,
+          "visibility": "internal"
+        },
+        {
+          "body": {
+            "id": 12,
+            "nodeType": "Block",
+            "src": "64:2:1",
+            "statements": []
+          },
+          "functionSelector": "28811f59",
+          "id": 13,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [
+            {
+              "arguments": [
+                {
+                  "hexValue": "31",
+                  "id": 9,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": true,
+                  "kind": "number",
+                  "lValueRequested": false,
+                  "nodeType": "Literal",
+                  "src": "54:1:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_rational_1_by_1",
+                    "typeString": "int_const 1"
+                  },
+                  "value": "1"
+                }
+              ],
+              "id": 10,
+              "kind": "modifierInvocation",
+              "modifierName": {
+                "id": 8,
+                "name": "M",
+                "nameLocations": ["52:1:1"],
+                "nodeType": "IdentifierPath",
+                "referencedDeclaration": 6,
+                "src": "52:1:1"
+              },
+              "nodeType": "ModifierInvocation",
+              "src": "52:4:1"
+            }
+          ],
+          "name": "F",
+          "nameLocation": "48:1:1",
+          "nodeType": "FunctionDefinition",
+          "parameters": {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "49:2:1"
+          },
+          "returnParameters": {
+            "id": 11,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "64:0:1"
+          },
+          "scope": 14,
+          "src": "39:27:1",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "scope": 15,
+      "src": "0:68:1",
+      "usedErrors": []
+    }
+  ],
+  "src": "0:69:1"
+}


### PR DESCRIPTION

## Motivation

Parsing failed on a number of solc contract json outputs found in wild.

## Solution

Handle null values in some AST structures

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
