### PR TITLE
Recognize localdev.me as "local" domain

### DIFF
--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -1501,6 +1501,7 @@ impl ProviderExt for Provider<HttpProvider> {
 /// ```
 /// use ethers_providers::is_local_endpoint;
 /// assert!(is_local_endpoint("http://localhost:8545"));
+/// assert!(is_local_endpoint("http://test.localdev.me"));
 /// assert!(is_local_endpoint("http://169.254.0.0:8545"));
 /// assert!(is_local_endpoint("http://127.0.0.1:8545"));
 /// assert!(!is_local_endpoint("http://206.71.50.230:8545"));

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -1513,7 +1513,9 @@ pub fn is_local_endpoint(endpoint: &str) -> bool {
     if let Ok(url) = Url::parse(endpoint) {
         if let Some(host) = url.host() {
             match host {
-                Host::Domain(domain) => return domain.contains("localhost"),
+                Host::Domain(domain) => {
+                    return domain.contains("localhost") || domain.contains("localdev.me")
+                }
                 Host::Ipv4(ipv4) => {
                     return ipv4 == Ipv4Addr::LOCALHOST ||
                         ipv4.is_link_local() ||


### PR DESCRIPTION
## Motivation

When running an application in k8s locally it is common to use `localdev.me` domain for ingress, as documented in [ingress-nginx docs](https://kubernetes.github.io/ingress-nginx/deploy/#local-testing). This is a domain owned by Amazon which DNS points to `127.0.01`, can be considered stable. Ethers-rs, however, doesn't recognize this as a local chain. 

My primary motivation here is for polling in foundry to have local polling behavior running against a local k8s cluster.

## Solution

Update the`is_local_endpoint` rules to recognize `localdev.me` as local chain.

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation (I don't think this is needed)
-   [x] Breaking changes (none)
