### PR TITLE
feat: support Etherscan beacon withdrawal transactions

### DIFF
--- a/ethers-etherscan/src/account.rs
+++ b/ethers-etherscan/src/account.rs
@@ -317,7 +317,7 @@ pub struct MinedBlock {
     pub block_reward: String,
 }
 
-/// The raw response from the wihtdrawal transaction list API endpoint
+/// The raw response from the beacon wihtdrawal transaction list API endpoint
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BeaconWithdrawalTransaction {

--- a/ethers-etherscan/src/account.rs
+++ b/ethers-etherscan/src/account.rs
@@ -317,6 +317,21 @@ pub struct MinedBlock {
     pub block_reward: String,
 }
 
+/// The raw response from the wihtdrawal transaction list API endpoint
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BeaconWithdrawalTransaction {
+    #[serde(deserialize_with = "deserialize_stringified_block_number")]
+    pub block_number: BlockNumber,
+    pub timestamp: String,
+    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    pub withdrawal_index: u64,
+    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    pub validator_index: u64,
+    pub address: Address,
+    pub amount: String,
+}
+
 /// The pre-defined block parameter for balance API endpoints
 #[derive(Clone, Copy, Debug, Default)]
 pub enum Tag {
@@ -670,6 +685,29 @@ impl Client {
         }
         let query = self.create_query("account", "getminedblocks", params);
         let response: Response<Vec<MinedBlock>> = self.get_json(&query).await?;
+
+        Ok(response.result)
+    }
+
+    /// Returns the list of beacon withdrawal transactions performed by an address, with optional pagination.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # async fn foo(client: ethers_etherscan::Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let address = "0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f".parse()?;
+    /// let beacon_withdrawal_transactions = client.get_beacon_withdrawal_transactions(&address, None).await?;
+    /// # Ok(()) }
+    /// ```
+    pub async fn get_beacon_withdrawal_transactions(
+        &self,
+        address: &Address,
+        params: Option<TxListParams>,
+    ) -> Result<Vec<BeaconWithdrawalTransaction>> {
+        let mut tx_params: HashMap<&str, String> = params.unwrap_or_default().into();
+        tx_params.insert("address", format!("{address:?}"));
+        let query = self.create_query("account", "txsBeaconWithdrawal", tx_params);
+        let response: Response<Vec<BeaconWithdrawalTransaction>> = self.get_json(&query).await?;
 
         Ok(response.result)
     }

--- a/ethers-etherscan/src/account.rs
+++ b/ethers-etherscan/src/account.rs
@@ -689,7 +689,8 @@ impl Client {
         Ok(response.result)
     }
 
-    /// Returns the list of beacon withdrawal transactions performed by an address, with optional pagination.
+    /// Returns the list of beacon withdrawal transactions performed by an address, with optional
+    /// pagination.
     ///
     /// # Examples
     ///

--- a/ethers-etherscan/tests/it/account.rs
+++ b/ethers-etherscan/tests/it/account.rs
@@ -160,7 +160,10 @@ async fn get_mined_blocks_success() {
 async fn get_beacon_withdrawal_transactions_success() {
     run_with_client(Chain::Mainnet, |client| async move {
         let txs = client
-            .get_beacon_withdrawal_transactions(&"0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f".parse().unwrap(), None)
+            .get_beacon_withdrawal_transactions(
+                &"0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f".parse().unwrap(),
+                None,
+            )
             .await;
         txs.unwrap();
     })

--- a/ethers-etherscan/tests/it/account.rs
+++ b/ethers-etherscan/tests/it/account.rs
@@ -157,6 +157,17 @@ async fn get_mined_blocks_success() {
 
 #[tokio::test]
 #[serial]
+async fn get_beacon_withdrawal_transactions_success() {
+    run_with_client(Chain::Mainnet, |client| async move {
+        let txs = client
+            .get_beacon_withdrawal_transactions(&"0xB9D7934878B5FB9610B3fE8A5e441e8fad7E293f".parse().unwrap(), None)
+            .await;
+        txs.unwrap();
+    })
+    .await
+}
+#[tokio::test]
+#[serial]
 async fn get_avalanche_transactions() {
     run_with_client(Chain::Avalanche, |client| async move {
         let txs = client


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The Etherscan API supports querying [Beacon Chain Withdrawals by Address and Block Range](https://docs.etherscan.io/api-endpoints/accounts#get-beacon-chain-withdrawals-by-address-and-block-range) since the Capella hardfork. However, this method is not supported by `ethers-etherscan` yet.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR adds the `fn get_beacon_withdrawal_transactions` and `struct BeaconWithdrawalTransaction` type.

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
