### PR TITLE
fix(ethers_solc): hardcoded import remapping fix

### DIFF
--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -320,8 +320,8 @@ impl ProjectPathsConfig {
     ///
     /// There is no strict rule behind this, but because [`crate::remappings::Remapping::find_many`]
     /// returns `'@openzeppelin/=node_modules/@openzeppelin/contracts/'` we should handle the
-    /// case if the remapping path ends with `contracts` and the import path starts with
-    /// `<remapping name>/contracts`. Otherwise we can end up with a resolved path that has a
+    /// case if the remapping path ends with `/contracts/` and the import path starts with
+    /// `<remapping name>/contracts/`. Otherwise we can end up with a resolved path that has a
     /// duplicate `contracts` segment:
     /// `@openzeppelin/contracts/contracts/token/ERC20/IERC20.sol` we check for this edge case
     /// here so that both styles work out of the box.
@@ -344,10 +344,12 @@ impl ProjectPathsConfig {
                 import.strip_prefix(&r.name).ok().map(|stripped_import| {
                     let lib_path = Path::new(&r.path).join(stripped_import);
 
-                    // we handle the edge case where the path of a remapping ends with "contracts"
-                    // (`<name>/=.../contracts`) and the stripped import also starts with
-                    // `contracts`
+                    // we handle the edge case where the path of a remapping ends with "/contracts/"
+                    // (`<name>/=.../contracts/`) and the stripped import also starts with
+                    // `contracts/`
                     if let Ok(adjusted_import) = stripped_import.strip_prefix("contracts/") {
+                        // Wrap suffix check in `/` so this prevents matching remapping paths that
+                        // end with '-contracts/', '_contracts/', '.contracts/' etc.
                         if r.path.ends_with("/contracts/") && !lib_path.exists() {
                             return Path::new(&r.path).join(adjusted_import)
                         }

--- a/ethers-solc/src/config.rs
+++ b/ethers-solc/src/config.rs
@@ -348,7 +348,7 @@ impl ProjectPathsConfig {
                     // (`<name>/=.../contracts`) and the stripped import also starts with
                     // `contracts`
                     if let Ok(adjusted_import) = stripped_import.strip_prefix("contracts/") {
-                        if r.path.ends_with("contracts/") && !lib_path.exists() {
+                        if r.path.ends_with("/contracts/") && !lib_path.exists() {
                             return Path::new(&r.path).join(adjusted_import)
                         }
                     }


### PR DESCRIPTION
## Motivation

When using ethers_solc to compile contracts, remappings have an issue with the hardcoded specific fix for an openzeppelin contracts issue. 

I'm not very familiar with the issue described in the doc comments, but it is erroring in situations where it shouldn't be applicable. 

```rust
// we handle the edge case where the path of a remapping ends with "contracts"
// (`<name>/=.../contracts`) and the stripped import also starts with
// `contracts`
if let Ok(adjusted_import) = stripped_import.strip_prefix("contracts/") {
    if r.path.ends_with("contracts/") && !lib_path.exists() {
        return Path::new(&r.path).join(adjusted_import)
    }
}
```

### Problematic setup

Example import in sol file:
```
import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
```

Example remapping:
```
@openzeppelin/=lib/openzeppelin-contracts/
```

in this case, the path of the remapping ends in "contracts/" (lib/openzeppelin-contracts/) and the stripped import also starts with "contracts" (contracts/utils/math/Math.sol).

this makes the resolver look at:
lib/openzeppelin-contracts/utils/math/Math.sol
when it should instead look at:
lib/openzeppelin-contracts/contracts/utils/math/Math.sol

## Solution

Stripping based on `.ends_with("contracts/")` isn't precise. Better suited for issue regarding the comment is `.ends_with("/contracts/")`.

In this instance, the remapping correctly would not get flagged, as it is does not end with "/contracts/" (lib/openzeppelin-contracts/).
