### PR TITLE
conversion of a public key, regardless of compression, to an address

### DIFF
--- a/ethers-core/src/utils/mod.rs
+++ b/ethers-core/src/utils/mod.rs
@@ -606,7 +606,7 @@ pub(crate) fn unused_port() -> u16 {
     local_addr.port()
 }
 
-
+/// Converts an public key, in compressed or uncompressed form to an Ethereum address
 pub fn pubkey_to_addr<T: AsRef<[u8]>>(pubkey: T) -> Result<[u8; 20], elliptic_curve::Error> {
     let pubkey = PublicKey::from_sec1_bytes(pubkey.as_ref())?;
     let affine: AffinePoint = pubkey.into();


### PR DESCRIPTION
This commit exposes a method to convert public keys to addresses. It is tested against the public key examples on https://docs.ethers.org/v5/api/utils/address/#utils-computeAddress. It does not convert private keys to address because `Wallet` already does that.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Often, it is helpful to compute the address from the public key, especially in threshold signature schemes, but as far is I can tell there is no convenient function to do so. _ethers.js_ exposes a `computeAddress`, but I could not find an _ethers-rs_ function to do the same. Those unfamiliar with elliptic curves typically would rather avoid dealing with the question of how to hash a public key, as they would likely have to study point encoding to do it.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This provides a simple function to convert a public key to an Ethereum address, regardless of compression.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes