### PR TITLE
feat: add ws subscribe example

### DIFF
--- a/book/events/logs-and-filtering.md
+++ b/book/events/logs-and-filtering.md
@@ -2,4 +2,5 @@
 
 ```rust
 {{#include ../../examples/events/examples/filtering.rs}}
+{{#include ../../examples/events/examples/subscribe.rs}}
 ```

--- a/examples/events/Cargo.toml
+++ b/examples/events/Cargo.toml
@@ -9,7 +9,7 @@ rust-version.workspace = true
 edition.workspace = true
 
 [dev-dependencies]
-ethers = { workspace = true, features = ["rustls"] }
+ethers = { workspace = true, features = ["rustls", "ws"] }
 
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/examples/events/examples/subscribe.rs
+++ b/examples/events/examples/subscribe.rs
@@ -1,0 +1,29 @@
+use ethers::prelude::*;
+use eyre::Result;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+const WSS_URL: &str = "wss://mainnet.infura.io/ws/v3/c60b0bb42f8a4c6481ecd229eddaca27";
+
+#[derive(Clone, Debug, Serialize, Deserialize, EthEvent)]
+pub struct Transfer {
+    #[ethevent(indexed)]
+    pub from: Address,
+    #[ethevent(indexed)]
+    pub to: Address,
+    pub tokens: U256,
+}
+
+/// This example shows how to subscribe to events using the Ws transport for a specific event
+#[tokio::main]
+async fn main() -> Result<()> {
+    let provider = Provider::<Ws>::connect(WSS_URL).await?;
+    let provider = Arc::new(provider);
+    let event = Transfer::new::<_, Provider<Ws>>(Filter::new(), Arc::clone(&provider));
+    let mut transfers = event.subscribe().await?.take(5);
+    while let Some(log) = transfers.next().await {
+        println!("Transfer: {:?}", log);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
adds an example of how to subscribe to EthEvents


I realized the Borrow requirement is really bad DX when using Arc

```rust
fn new<B, M>(filter: Filter, provider: B) -> Event<B, M, Self>
    where
        Self: Sized,
        B: Borrow<M>,
        M: Middleware,
    {
```