### PR TITLE
Add Holesky to the Multicall supported chain id's

### DIFF
--- a/ethers-contract/src/multicall/constants.rs
+++ b/ethers-contract/src/multicall/constants.rs
@@ -14,6 +14,7 @@ pub const MULTICALL_SUPPORTED_CHAIN_IDS: &[u64] = {
     use Chain::*;
     &[
         Mainnet as u64,                  // Mainnet
+        Holesky as u64,                  // Holesky
         Kovan as u64,                    // Kovan
         Rinkeby as u64,                  // Rinkeby
         Goerli as u64,                   // Görli


### PR DESCRIPTION
## Motivation

I project I am using uses MulticallV3 across different chains and currently MulticallV3 is deployed on Holesky (https://holesky.etherscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11) however not listed in ethers-rs.

## Solution

Added Holesky support to the supported chain id's constant.
