### PR TITLE
Update solang-parser to v0.3.3

### DIFF
--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -28,7 +28,7 @@ all-features = true
 [dependencies]
 ethers-core.workspace = true
 
-solang-parser = { version = "=0.3.2", default-features = false }
+solang-parser = { version = "=0.3.3", default-features = false }
 
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json.workspace = true


### PR DESCRIPTION
solang-parser v0.3.3 has been released, which fixes some minor solidity parsing issues.
