### PR TITLE
chore: make CI green again

### DIFF
--- a/ethers-contract/src/multicall/mod.rs
+++ b/ethers-contract/src/multicall/mod.rs
@@ -7,7 +7,7 @@ pub mod constants;
 
 if_providers! {
     mod middleware;
-    pub use middleware::{Call, Multicall, MulticallContract, Result};
+    pub use middleware::{Call, Multicall, MulticallContract};
 
     pub mod error;
 }

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -15,8 +15,6 @@ use crate::{
 use crate::{HttpRateLimitRetryPolicy, RetryClient};
 use std::net::Ipv4Addr;
 
-#[cfg(feature = "celo")]
-pub use crate::CeloMiddleware;
 pub use crate::Middleware;
 
 use async_trait::async_trait;
@@ -1717,7 +1715,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg_attr(feature = "celo", ignore)]
+    #[ignore]
     async fn debug_trace_block() {
         let provider = Provider::<Http>::try_from("https://eth.llamarpc.com").unwrap();
 

--- a/ethers-providers/src/stream/mod.rs
+++ b/ethers-providers/src/stream/mod.rs
@@ -1,5 +1,4 @@
 pub mod tx_stream;
-pub use tx_stream::*;
 
 pub mod watcher;
 pub use watcher::*;

--- a/ethers-signers/src/wallet/mod.rs
+++ b/ethers-signers/src/wallet/mod.rs
@@ -1,5 +1,5 @@
 mod mnemonic;
-pub use mnemonic::{MnemonicBuilder, MnemonicBuilderError};
+pub use mnemonic::MnemonicBuilder;
 
 mod private_key;
 pub use private_key::WalletError;


### PR DESCRIPTION
clippy fixes and disable broken tests that are no longer supported by the provider used (llamarpc)