### PR TITLE
feat(etherscan): Implemented Some APIs for `stats`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ auto_impl = "1.1"
 
 # misc
 bytes = "1.4"
+chrono = { version = "0.4", default-features = false }
 criterion = "0.5"
 dunce = "1.0"
 eyre = "0.6"

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -37,7 +37,7 @@ tiny-keccak.workspace = true
 rand.workspace = true
 
 # misc
-chrono = { version = "0.4", default-features = false }
+chrono.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 thiserror.workspace = true

--- a/ethers-etherscan/Cargo.toml
+++ b/ethers-etherscan/Cargo.toml
@@ -36,6 +36,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 semver.workspace = true
+chrono.workspace = true
 
 [dev-dependencies]
 ethers-solc.workspace = true

--- a/ethers-etherscan/src/errors.rs
+++ b/ethers-etherscan/src/errors.rs
@@ -15,6 +15,8 @@ pub enum EtherscanError {
     TransactionReceiptFailed,
     #[error("Gas estimation failed")]
     GasEstimationFailed,
+    #[error("Eth supply failed")]
+    EthSupplyFailed,
     #[error("Bad status code: {0}")]
     BadStatusCode(String),
     #[error(transparent)]

--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -28,6 +28,7 @@ pub mod contract;
 pub mod errors;
 pub mod gas;
 pub mod source_tree;
+pub mod stats;
 mod transaction;
 pub mod utils;
 pub mod verify;

--- a/ethers-etherscan/src/stats.rs
+++ b/ethers-etherscan/src/stats.rs
@@ -1,0 +1,228 @@
+use crate::{Client, EtherscanError, Response, Result};
+use chrono::{DateTime, NaiveDate, NaiveTime, TimeZone, Utc};
+use ethers_core::{types::U256, utils::parse_units};
+use serde::{Deserialize, Deserializer};
+use std::str::FromStr;
+
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "PascalCase")]
+pub struct EthSupply2 {
+    /// The current amount of ETH in circulation
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    #[serde(rename = "EthSupply")]
+    pub eth_supply: u128,
+    /// The current amount of ETH2 Staking rewards
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    #[serde(rename = "Eth2Staking")]
+    pub eth2_staking: u128,
+    /// The current amount of EIP1559 burnt fees
+    #[serde(deserialize_with = "deser_wei_amount")]
+    #[serde(rename = "BurntFees")]
+    pub burnt_fees: U256,
+    /// Total withdrawn ETH from the beacon chain
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    #[serde(rename = "WithdrawnTotal")]
+    pub withdrawn_total: u128,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct EthPrice {
+    /// ETH-to-BTC exchange rate
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub ethbtc: f64,
+    /// Last updated timestamp for the ETH-to-BTC exchange rate
+    #[serde(deserialize_with = "deserialize_datetime_from_string")]
+    pub ethbtc_timestamp: DateTime<Utc>,
+    /// ETH-to-USD exchange rate
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub ethusd: f64,
+    /// Last updated timestamp for the ETH-to-USD exchange rate
+    #[serde(deserialize_with = "deserialize_datetime_from_string")]
+    pub ethusd_timestamp: DateTime<Utc>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct NodeCount {
+    /// Last updated date for the total number of discoverable Ethereum nodes
+    #[serde(rename = "UTCDate")]
+    #[serde(deserialize_with = "deserialize_utc_date_from_string")]
+    pub utc_date: DateTime<Utc>,
+    /// The total number of discoverable Ethereum nodes
+    #[serde(rename = "TotalNodeCount")]
+    #[serde(deserialize_with = "deserialize_number_from_string")]
+    pub total_node_count: usize,
+}
+
+// This function is used to deserialize a string or number into a U256 with an
+// amount of wei. If the contents is a number, deserialize it. If the contents
+// is a string, attempt to deser as first a decimal f64 then a decimal U256.
+fn deser_wei_amount<'de, D>(deserializer: D) -> Result<U256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrInt {
+        Number(u64),
+        String(String),
+    }
+
+    match StringOrInt::deserialize(deserializer)? {
+        StringOrInt::Number(i) => Ok(U256::from(i)),
+        StringOrInt::String(s) => {
+            parse_units(s, "wei").map(Into::into).map_err(serde::de::Error::custom)
+        }
+    }
+}
+
+fn deserialize_number_from_string<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr + serde::Deserialize<'de>,
+    <T as FromStr>::Err: std::fmt::Display,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrInt<T> {
+        String(String),
+        Number(T),
+    }
+
+    match StringOrInt::<T>::deserialize(deserializer)? {
+        StringOrInt::String(s) => s.parse::<T>().map_err(serde::de::Error::custom),
+        StringOrInt::Number(i) => Ok(i),
+    }
+}
+
+fn deserialize_utc_date_from_string<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: String = Deserialize::deserialize(deserializer)?;
+
+    let naive_date = NaiveDate::parse_from_str(&s, "%Y-%m-%d").expect("Invalid date format");
+    let naive_time = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
+
+    Ok(DateTime::<Utc>::from_naive_utc_and_offset(naive_date.and_time(naive_time), Utc))
+}
+
+fn deserialize_datetime_from_string<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrInt {
+        String(String),
+        Number(i64),
+    }
+
+    match StringOrInt::deserialize(deserializer)? {
+        StringOrInt::String(s) => {
+            let i = s.parse::<i64>().unwrap();
+            Ok(Utc.timestamp_opt(i, 0).unwrap())
+        }
+        StringOrInt::Number(i) => Ok(Utc.timestamp_opt(i, 0).unwrap()),
+    }
+}
+
+impl Client {
+    /// Returns the current amount of Ether in circulation excluding ETH2 Staking rewards
+    /// and EIP1559 burnt fees.
+    pub async fn eth_supply(&self) -> Result<u128> {
+        let query = self.create_query("stats", "ethsupply", serde_json::Value::Null);
+        let response: Response<String> = self.get_json(&query).await?;
+
+        if response.status == "1" {
+            Ok(u128::from_str(&response.result).map_err(|_| EtherscanError::EthSupplyFailed)?)
+        } else {
+            Err(EtherscanError::EthSupplyFailed)
+        }
+    }
+
+    /// Returns the current amount of Ether in circulation, ETH2 Staking rewards,
+    /// EIP1559 burnt fees, and total withdrawn ETH from the beacon chain.
+    pub async fn eth_supply2(&self) -> Result<EthSupply2> {
+        let query = self.create_query("stats", "ethsupply2", serde_json::Value::Null);
+        let response: Response<EthSupply2> = self.get_json(&query).await?;
+
+        Ok(response.result)
+    }
+
+    /// Returns the latest price of 1 ETH.
+    pub async fn eth_price(&self) -> Result<EthPrice> {
+        let query = self.create_query("stats", "ethprice", serde_json::Value::Null);
+        let response: Response<EthPrice> = self.get_json(&query).await?;
+
+        Ok(response.result)
+    }
+
+    /// Returns the total number of discoverable Ethereum nodes.
+    pub async fn node_count(&self) -> Result<NodeCount> {
+        let query = self.create_query("stats", "nodecount", serde_json::Value::Null);
+        let response: Response<NodeCount> = self.get_json(&query).await?;
+
+        Ok(response.result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_works() {
+        // Sample Response from the etherscan documentation
+        // https://docs.etherscan.io/api-endpoints/stats-1#get-total-supply-of-ether-2
+        let v = r#"{
+                    "status":"1",
+                    "message":"OK",
+                    "result":{
+                        "EthSupply":"122373866217800000000000000",
+                        "Eth2Staking":"1157529105115885000000000",
+                        "BurntFees":"3102505506455601519229842",
+                        "WithdrawnTotal":"1170200333006131000000000"
+                    }
+                }"#;
+        let eth_supply2: Response<EthSupply2> = serde_json::from_str(v).unwrap();
+        assert_eq!(eth_supply2.message, "OK");
+        assert_eq!(eth_supply2.result.eth_supply, 122373866217800000000000000);
+        assert_eq!(eth_supply2.result.eth2_staking, 1157529105115885000000000);
+        assert_eq!(
+            eth_supply2.result.burnt_fees,
+            parse_units("3102505506455601519229842", "wei").map(Into::into).unwrap()
+        );
+        assert_eq!(eth_supply2.result.withdrawn_total, 1170200333006131000000000);
+
+        // Sample Response from the etherscan documentation
+        // https://docs.etherscan.io/api-endpoints/stats-1#get-ether-last-price
+        let v = r#"{
+                    "status":"1",
+                    "message":"OK",
+                    "result":{
+                        "ethbtc":"0.06116",
+                        "ethbtc_timestamp":"1624961308",
+                        "ethusd":"2149.18",
+                        "ethusd_timestamp":"1624961308"
+                    }
+                }"#;
+        let eth_price: Response<EthPrice> = serde_json::from_str(v).unwrap();
+        assert_eq!(eth_price.message, "OK");
+        assert_eq!(eth_price.result.ethbtc, 0.06116);
+        assert_eq!(eth_price.result.ethusd, 2149.18);
+
+        // Sample Response from the etherscan documentation
+        // https://docs.etherscan.io/api-endpoints/stats-1#get-total-nodes-count
+        let v = r#"{
+                    "status":"1",
+                    "message":"OK",
+                    "result":{
+                        "UTCDate":"2021-06-29",
+                        "TotalNodeCount":"6413"
+                    }
+                }"#;
+        let node_count: Response<NodeCount> = serde_json::from_str(v).unwrap();
+        assert_eq!(node_count.message, "OK");
+        assert_eq!(node_count.result.total_node_count, 6413);
+    }
+}

--- a/ethers-etherscan/tests/it/main.rs
+++ b/ethers-etherscan/tests/it/main.rs
@@ -13,6 +13,7 @@ mod account;
 mod blocks;
 mod contract;
 mod gas;
+mod stats;
 mod transaction;
 mod verify;
 mod version;

--- a/ethers-etherscan/tests/it/stats.rs
+++ b/ethers-etherscan/tests/it/stats.rs
@@ -1,0 +1,47 @@
+use crate::*;
+use ethers_core::types::Chain;
+use serial_test::serial;
+
+#[tokio::test]
+#[serial]
+async fn eth_supply_success() {
+    run_with_client(Chain::Mainnet, |client| async move {
+        let result = client.eth_supply().await;
+
+        result.unwrap();
+    })
+    .await
+}
+
+#[tokio::test]
+#[serial]
+async fn eth_supply2_success() {
+    run_with_client(Chain::Mainnet, |client| async move {
+        let result = client.eth_supply2().await;
+
+        result.unwrap();
+    })
+    .await
+}
+
+#[tokio::test]
+#[serial]
+async fn eth_price_success() {
+    run_with_client(Chain::Mainnet, |client| async move {
+        let result = client.eth_price().await;
+
+        result.unwrap();
+    })
+    .await
+}
+
+#[tokio::test]
+#[serial]
+async fn node_count_success() {
+    run_with_client(Chain::Mainnet, |client| async move {
+        let result = client.node_count().await;
+
+        result.unwrap();
+    })
+    .await
+}


### PR DESCRIPTION
The following APIs have been implemented.
- https://docs.etherscan.io/api-endpoints/stats-1
    - Get Total Supply of Ether (`ethsupply`)
    - Get Total Supply of Ether 2 (`ethsupply2`)
    - Get Ether Last Price (`ethprice`)
    - Get Total Node Count (`nodecount`)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
Thank you for developing such fantastic software. I'm working on a project called "[lazy-etherscan](https://github.com/woxjro/lazy-etherscan)",
and I would like to display statistical information about Ethereum within it.
After reviewing "ether-rs", I noticed that this functionality was not yet implemented,
so I decided to create this pull request.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
I have implemented several of the statistical APIs from Etherscan's API documentation (https://docs.etherscan.io/api-endpoints/stats-1),
excluding the PRO features and "Get Ethereum Node Size". I have also added some tests.
Additionally, I needed to handle date information, so I added the "chrono" crate to "ethers-rs."


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist
-   [x] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes