### PR TITLE
feat: add cancun fields to Block

### DIFF
--- a/ethers-core/src/types/block.rs
+++ b/ethers-core/src/types/block.rs
@@ -86,6 +86,14 @@ pub struct Block<TX> {
     /// Base fee per unit of gas (if past London)
     #[serde(rename = "baseFeePerGas")]
     pub base_fee_per_gas: Option<U256>,
+    /// Blob gas used (if past Cancun)
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "blobGasUsed")]
+    #[cfg(not(feature = "celo"))]
+    pub blob_gas_used: Option<U256>,
+    /// Excess blob gas (if past Cancun)
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "excessBlobGas")]
+    #[cfg(not(feature = "celo"))]
+    pub excess_blob_gas: Option<U256>,
     /// Withdrawals root hash (if past Shanghai)
     #[serde(default, skip_serializing_if = "Option::is_none", rename = "withdrawalsRoot")]
     #[cfg(not(feature = "celo"))]
@@ -94,6 +102,10 @@ pub struct Block<TX> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg(not(feature = "celo"))]
     pub withdrawals: Option<Vec<Withdrawal>>,
+    /// Parent beacon block root (if past Cancun)
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "parentBeaconBlockRoot")]
+    #[cfg(not(feature = "celo"))]
+    pub parent_beacon_block_root: Option<H256>,
 
     #[cfg(feature = "celo")]
     #[cfg_attr(docsrs, doc(cfg(feature = "celo")))]
@@ -230,6 +242,9 @@ impl Block<TxHash> {
                 base_fee_per_gas,
                 withdrawals_root,
                 withdrawals,
+                blob_gas_used,
+                excess_blob_gas,
+                parent_beacon_block_root,
                 other,
                 ..
             } = self;
@@ -258,6 +273,9 @@ impl Block<TxHash> {
                 withdrawals_root,
                 withdrawals,
                 transactions,
+                blob_gas_used,
+                excess_blob_gas,
+                parent_beacon_block_root,
                 other,
             }
         }
@@ -338,6 +356,9 @@ impl From<Block<Transaction>> for Block<TxHash> {
                 base_fee_per_gas,
                 withdrawals_root,
                 withdrawals,
+                excess_blob_gas,
+                blob_gas_used,
+                parent_beacon_block_root,
                 other,
             } = full;
             Block {
@@ -364,6 +385,9 @@ impl From<Block<Transaction>> for Block<TxHash> {
                 base_fee_per_gas,
                 withdrawals_root,
                 withdrawals,
+                excess_blob_gas,
+                blob_gas_used,
+                parent_beacon_block_root,
                 transactions: transactions.iter().map(|tx| tx.hash).collect(),
                 other,
             }


### PR DESCRIPTION
## Motivation

Cancun will introduce new fields in the block, namely `parent_beacon_block_root`, `blob_gas_used`, and `excess_blob_gas`. 

## Solution

Add the fields to `Block<Tx>`.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
