### PR TITLE
use https://api.scrollscan.com/ instead

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -487,7 +487,7 @@ impl Chain {
 
             Gnosis => ("https://api.gnosisscan.io/api", "https://gnosisscan.io"),
 
-            Scroll => ("https://scrollscan.com/api", "https://scrollscan.com"),
+            Scroll => ("https://api.scrollscan.com", "https://scrollscan.com"),
             ScrollAlphaTestnet => {
                 ("https://blockscout.scroll.io/api", "https://blockscout.scroll.io/")
             }


### PR DESCRIPTION
https://scrollscan.com/api

results in

```
{"status":"0","message":"NOTOK","result":"Invalid API URL endpoint, use https://api.scrollscan.com"}
```

I presume this is why scroll verify is now failing