### PR TITLE
docs: add deprecation notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 [crates-badge]: https://img.shields.io/crates/v/ethers.svg
 [crates-url]: https://crates.io/crates/ethers
 
+> **Warning**
+>
+> This library is in the process of being deprecated. See [#2667](https://github.com/gakonst/ethers-rs/issues/2667) for more information.
+
 ## Quickstart
 
 Add this to your Cargo.toml:

--- a/ethers-addressbook/README.md
+++ b/ethers-addressbook/README.md
@@ -4,6 +4,10 @@ A collection of commonly used smart contract addresses.
 
 For more information, please refer to the [book](https://gakonst.com/ethers-rs).
 
+> **Warning**
+>
+> This library is in the process of being deprecated. See [#2667](https://github.com/gakonst/ethers-rs/issues/2667) for more information.
+
 ## Examples
 
 ```rust

--- a/ethers-contract/README.md
+++ b/ethers-contract/README.md
@@ -2,6 +2,10 @@
 
 Type-safe abstractions for interacting with Ethereum smart contracts.
 
+> **Warning**
+>
+> This library is in the process of being deprecated. See [#2667](https://github.com/gakonst/ethers-rs/issues/2667) for more information.
+
 Interacting with a smart contract requires broadcasting carefully crafted
 [transactions](ethers_core::types::TransactionRequest) where the `data` field
 contains the

--- a/ethers-core/README.md
+++ b/ethers-core/README.md
@@ -2,6 +2,10 @@
 
 Ethereum data types, cryptography and utilities.
 
+> **Warning**
+>
+> This library is in the process of being deprecated. See [#2667](https://github.com/gakonst/ethers-rs/issues/2667) for more information.
+
 It is recommended to use the `utils`, `types` and `abi` re-exports instead of
 the `core` module to simplify your imports.
 

--- a/ethers-etherscan/README.md
+++ b/ethers-etherscan/README.md
@@ -4,6 +4,10 @@ Bindings for the [etherscan.io web API](https://docs.etherscan.io).
 
 For more information, please refer to the [book](https://gakonst.com/ethers-rs).
 
+> **Warning**
+> 
+> This crate is deprecated in favor of [`foundry-block-explorers`](https://crates.io/foundry-block-explorers) ([foundry-rs/block-explorers](https://github.com/foundry-rs/block-explorers)). See [#2667](https://github.com/gakonst/ethers-rs/issues/2667) for more information.
+
 ## Examples
 
 ```rust,no_run

--- a/ethers-middleware/README.md
+++ b/ethers-middleware/README.md
@@ -4,6 +4,10 @@ Your ethers application interacts with the blockchain through a [`Provider`](eth
 
 For more information, please refer to the [book](https://gakonst.com/ethers-rs).
 
+> **Warning**
+>
+> This library is in the process of being deprecated. See [#2667](https://github.com/gakonst/ethers-rs/issues/2667) for more information.
+
 ## Available Middleware
 
 -   [`Signer`](./signer/struct.SignerMiddleware.html): Signs transactions locally, with a private key or a hardware wallet.

--- a/ethers-providers/README.md
+++ b/ethers-providers/README.md
@@ -8,6 +8,10 @@ clients.
 
 For more information, please refer to the [book](https://gakonst.com/ethers-rs).
 
+> **Warning**
+>
+> This library is in the process of being deprecated. See [#2667](https://github.com/gakonst/ethers-rs/issues/2667) for more information.
+
 ## Websockets
 
 This crate supports for WebSockets via `tokio-tungstenite`.

--- a/ethers-signers/README.md
+++ b/ethers-signers/README.md
@@ -2,6 +2,10 @@
 
 A unified interface for locally signing Ethereum transactions.
 
+> **Warning**
+>
+> This library is in the process of being deprecated. See [#2667](https://github.com/gakonst/ethers-rs/issues/2667) for more information.
+
 You can implement the `Signer` trait to extend functionality to other signers
 such as Hardware Security Modules, KMS etc.
 

--- a/ethers-solc/README.md
+++ b/ethers-solc/README.md
@@ -2,6 +2,10 @@
 
 Utilities for working with native `solc` and compiling projects.
 
+> **Warning**
+> 
+> This crate is deprecated in favor of [`foundry-compilers`](https://crates.io/foundry-compilers) ([foundry-rs/compilers](https://github.com/foundry-rs/compilers)). See [#2667](https://github.com/gakonst/ethers-rs/issues/2667) for more information.
+
 To also compile contracts during `cargo build` (so that ethers `abigen!` can pull in updated abi automatically) you can configure a `ethers_solc::Project` in your `build.rs` file
 
 First add `ethers-solc` to your cargo build-dependencies.

--- a/ethers/src/lib.rs
+++ b/ethers/src/lib.rs
@@ -1,6 +1,11 @@
 //! # ethers-rs
 //!
 //! A complete Ethereum and Celo Rust library.
+//! 
+//! <div class="warning">
+//! This crate is in the process of being deprecated.
+//! See <a href="https://github.com/gakonst/ethers-rs/issues/2667">#2667</a> for more information.
+//! </div>
 //!
 //! ## Quickstart: `prelude`
 //!


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

ethers-rs is being deprecated in favor of Alloy and Foundry. See #2667.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add deprecation notices to READMEs and crate-level doc comments.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
