### PR TITLE
FIx unsubscribe() issues (#2669)

### DIFF
--- a/ethers-core/src/utils/genesis.rs
+++ b/ethers-core/src/utils/genesis.rs
@@ -358,7 +358,7 @@ where
                 return Numeric::from_str(num)
                     .map(U256::from)
                     .map(Some)
-                    .map_err(serde::de::Error::custom);
+                    .map_err(serde::de::Error::custom)
             }
 
             if let serde_json::Value::Number(num) = val {

--- a/ethers-providers/src/rpc/transports/ws/manager.rs
+++ b/ethers-providers/src/rpc/transports/ws/manager.rs
@@ -75,7 +75,7 @@ impl SubscriptionManager {
                 // result in the server sending us notifications we ignore
                 let unsub_request = InFlight {
                     method: "eth_unsubscribe".to_string(),
-                    params: SubId(server_id).serialize_raw().ok()?,
+                    params: to_raw_value(&[server_id]).ok()?,
                     channel,
                 };
                 // reuse the RPC ID. this is somewhat dirty.

--- a/ethers-providers/src/rpc/transports/ws/types.rs
+++ b/ethers-providers/src/rpc/transports/ws/types.rs
@@ -11,12 +11,6 @@ pub type Response = Result<Box<RawValue>, JsonRpcError>;
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct SubId(pub U256);
 
-impl SubId {
-    pub(super) fn serialize_raw(&self) -> Result<Box<RawValue>, serde_json::Error> {
-        to_raw_value(&self)
-    }
-}
-
 #[derive(Deserialize, Debug, Clone)]
 pub struct Notification {
     pub subscription: U256,


### PR DESCRIPTION
This is a set of proposed changes to fix the 4 issues with unsubscribe which are described in issue 2669.

## Motivation

The goal of these changes is to ensure that eth_unsubscribe is called properly every time a subscription is ended, either via SubscriptionStream::drop or SubscriptionStream::unsubscribe().

## Solution

This fixes a json-rpc formatting issue, an issue of translating subscription ID from client-side to server-side ID, and issues of simply not calling eth_unsubscribe in the IPC and ws-legacy PubsubClients.

I tried to keep these changes to a minimal set which would fix these issues and avoid any breaking changes. There's some remaining weirdness in that the boolean return value from eth_unsubscribe indicating success is not plumbed through ethers to the caller. Doing so complicates things as it requires await-ing the response, and the unsubscribe code is used in non-async contexts including pinned SubscriptionStream::drop(), which isn't easily modified to call async functions. If we want to plumb the return value, I can make additional changes to do so, but I suspect it would either require some code duplication or trickery which may not be worthwhile.

## PR Checklist

-   [ x] Added Tests
-   [ x] Added Documentation
-   [ x] Breaking changes
