### PR TITLE
chore: make `compiled_artifacts` public in `ProjectCompileOutput` struct

### DIFF
--- a/ethers-solc/src/compile/output/mod.rs
+++ b/ethers-solc/src/compile/output/mod.rs
@@ -28,7 +28,7 @@ pub struct ProjectCompileOutput<T: ArtifactOutput = ConfigurableArtifacts> {
     /// contains the aggregated `CompilerOutput`
     pub(crate) compiler_output: AggregatedCompilerOutput,
     /// all artifact files from `output` that were freshly compiled and written
-    pub(crate) compiled_artifacts: Artifacts<T::Artifact>,
+    pub compiled_artifacts: Artifacts<T::Artifact>,
     /// All artifacts that were read from cache
     pub(crate) cached_artifacts: Artifacts<T::Artifact>,
     /// errors that should be omitted


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->


This pull request proposes a change to the `ProjectCompileOutput` struct by making the `compiled_artifacts` field public. The modification is required for the usage of extending `foundry` to work with non-solc compilers like [`zksolc`](https://github.com/matter-labs/era-compiler-solidity/tree/main) for zkSync.

**Context:**

Currently, the `compiled_artifacts` field is marked as `pub(crate)`, making it accessible only within the same crate. This encapsulation poses a limitation when the struct is used as part of a larger build process where access to `compiled_artifacts` is needed.

**Rationale:**

In effort to extend `foundry` support to zkSync ecosystem, direct access is needed to the `compiled_artifacts` field. You can see where we make use of `compiled_artifacts` [here](https://github.com/matter-labs/foundry-zksync/blob/bedd7221cd5af506c01080eb794e72391fdd97c7/crates/common/src/zk_compile.rs#L351).

- **Enhanced Flexibility:** Making `compiled_artifacts` public allows for more flexible post-compilation processes, including custom artifact handling, storage, and modifications tailored to specific use cases.

**Functionality Impact:**

The proposed change will have no impact on existing functionality. It merely extends the accessibility of the `compiled_artifacts` field, enabling external crates to utilize the compiled bytecode. This change is backward-compatible and does not alter the behavior of any existing code that depends on the `ProjectCompileOutput` struct.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

**Solution:**

```
pub compiled_artifacts: Artifacts<T::Artifact>,
```

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
