### PR TITLE
fix: metis is no 1559

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -359,6 +359,7 @@ impl Chain {
             MantleTestnet |
             PolygonZkEvm |
             PolygonZkEvmTestnet |
+            Metis |
             Scroll => true,
 
             // Known EIP-1559 chains
@@ -392,8 +393,7 @@ impl Chain {
             // Unknown / not applicable, default to false for backwards compatibility
             Dev | AnvilHardhat | Morden | Ropsten | Rinkeby | Cronos | CronosTestnet | Kovan |
             Sokol | Poa | Moonbeam | MoonbeamDev | Moonriver | Moonbase | Evmos |
-            EvmosTestnet | Aurora | AuroraTestnet | Canto | CantoTestnet | ScrollAlphaTestnet |
-            Metis => false,
+            EvmosTestnet | Aurora | AuroraTestnet | Canto | CantoTestnet | ScrollAlphaTestnet => false,
         }
     }
 


### PR DESCRIPTION
## Motivation

ppl not providing `--legacy` for metis on foundry will face errors

## Solution

specify that metis is not 1559 compatible


----

when i run fmt as described on the docs i'm getting a huge amount of changes
<img width="775" alt="image" src="https://github.com/gakonst/ethers-rs/assets/4396533/a165daae-40be-4c62-8fff-ff1c6234112f">

That is the reason why i didn't commit the changes.