### PR TITLE
[fix] Missed renaming a field in camelcase

### DIFF
--- a/ethers-core/src/types/transaction/optimism.rs
+++ b/ethers-core/src/types/transaction/optimism.rs
@@ -30,6 +30,7 @@ pub struct DepositTransaction {
 
     /// If true, the transaction does not interact with the L2 block gas pool.
     /// Note: boolean is disabled (enforced to be false) starting from the Regolith upgrade.
+    #[serde(rename = "isSystemTx")]
     pub is_system_tx: bool,
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
The `is_system_tx` field is not being renamed to camel case version like the other fields, and is causing issues since it is renamed in a different part of the code: https://github.com/gakonst/ethers-rs/blob/34030b3e942be619ae180d0f9f0ae9b3121081a3/ethers-core/src/types/transaction/response.rs#L81

## Solution

Rename to camel case. It brings up a question though which is why we dont by default rename all fields in the struct? I can make this change if that's preferred.
By making this change, it allows the tests in this PR to pass: https://github.com/foundry-rs/foundry/pull/6073

cc @mattsse 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [X] Added Tests (in foundry PR)
-   [ ] Added Documentation
-   [ ] Breaking changes
