### PR TITLE
fix(core): rm xDai chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "bytes",
  "ethers-addressbook",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-addressbook"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1327,7 +1327,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "arrayvec 0.7.2",
  "bincode",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-derive-eip712"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ethers-contract-derive",
  "ethers-core",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1557,7 +1557,7 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "cfg-if 1.0.0",
  "criterion",
@@ -1615,7 +1615,7 @@ dependencies = [
 
 [[package]]
 name = "examples-anvil"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ethers",
  "eyre",
@@ -1624,14 +1624,14 @@ dependencies = [
 
 [[package]]
 name = "examples-big-numbers"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ethers",
 ]
 
 [[package]]
 name = "examples-contracts"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ethers",
  "eyre",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "examples-events"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ethers",
  "eyre",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "examples-middleware"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "ethers",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "examples-providers"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "ethers",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "examples-queries"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ethers",
  "eyre",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "examples-subscriptions"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ethers",
  "eyre",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "examples-transactions"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ethers",
  "eyre",
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "examples-wallets"
-version = "1.0.2"
+version = "2.0.0"
 dependencies = [
  "ethers",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.64" # must also be changed in **/Cargo.toml and .clippy.toml
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
@@ -94,21 +94,21 @@ solc-tests = ["ethers-solc", "ethers-solc/tests"]
 solc-sha2-asm = ["ethers-solc", "ethers-solc/asm"]
 
 [dependencies]
-ethers-addressbook = { version = "^1.0.0", default-features = false, path = "./ethers-addressbook" }
-ethers-contract = { version = "^1.0.0", default-features = false, path = "./ethers-contract" }
-ethers-core = { version = "^1.0.0", default-features = false, path = "./ethers-core" }
-ethers-providers = { version = "^1.0.0", default-features = false, path = "./ethers-providers" }
-ethers-signers = { version = "^1.0.0", default-features = false, path = "./ethers-signers" }
-ethers-middleware = { version = "^1.0.0", default-features = false, path = "./ethers-middleware" }
-ethers-solc = { version = "^1.0.0", default-features = false, path = "./ethers-solc", optional = true }
-ethers-etherscan = { version = "^1.0.0", default-features = false, path = "./ethers-etherscan" }
+ethers-addressbook = { version = "^2.0.0", default-features = false, path = "./ethers-addressbook" }
+ethers-contract = { version = "^2.0.0", default-features = false, path = "./ethers-contract" }
+ethers-core = { version = "^2.0.0", default-features = false, path = "./ethers-core" }
+ethers-providers = { version = "^2.0.0", default-features = false, path = "./ethers-providers" }
+ethers-signers = { version = "^2.0.0", default-features = false, path = "./ethers-signers" }
+ethers-middleware = { version = "^2.0.0", default-features = false, path = "./ethers-middleware" }
+ethers-solc = { version = "^2.0.0", default-features = false, path = "./ethers-solc", optional = true }
+ethers-etherscan = { version = "^2.0.0", default-features = false, path = "./ethers-etherscan" }
 
 [dev-dependencies]
-ethers-contract = { version = "^1.0.0", default-features = false, path = "./ethers-contract", features = [
+ethers-contract = { version = "^2.0.0", default-features = false, path = "./ethers-contract", features = [
     "abigen",
     "eip712",
 ] }
-ethers-providers = { version = "^1.0.0", default-features = false, path = "./ethers-providers", features = [
+ethers-providers = { version = "^2.0.0", default-features = false, path = "./ethers-providers", features = [
     "ws",
     "ipc",
 ] }

--- a/ethers-addressbook/Cargo.toml
+++ b/ethers-addressbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-addressbook"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
@@ -11,7 +11,7 @@ repository = "https://github.com/gakonst/ethers-rs"
 keywords = ["ethereum", "web3", "celo", "ethers"]
 
 [dependencies]
-ethers-core = { version = "^1.0.0", path = "../ethers-core", default-features = false }
+ethers-core = { version = "^2.0.0", path = "../ethers-core", default-features = false }
 
 once_cell = "1.17.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/ethers-contract/Cargo.toml
+++ b/ethers-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-contract"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
@@ -11,11 +11,11 @@ repository = "https://github.com/gakonst/ethers-rs"
 keywords = ["ethereum", "web3", "celo", "ethers"]
 
 [dependencies]
-ethers-providers = { version = "^1.0.0", path = "../ethers-providers", default-features = false }
-ethers-core = { version = "^1.0.0", path = "../ethers-core", default-features = false }
-ethers-contract-abigen = { version = "^1.0.0", path = "ethers-contract-abigen", default-features = false, optional = true }
-ethers-contract-derive = { version = "^1.0.0", path = "ethers-contract-derive", optional = true }
-ethers-derive-eip712 = { version = "^1.0.0", path = "../ethers-core/ethers-derive-eip712", optional = true }
+ethers-providers = { version = "^2.0.0", path = "../ethers-providers", default-features = false }
+ethers-core = { version = "^2.0.0", path = "../ethers-core", default-features = false }
+ethers-contract-abigen = { version = "^2.0.0", path = "ethers-contract-abigen", default-features = false, optional = true }
+ethers-contract-derive = { version = "^2.0.0", path = "ethers-contract-derive", optional = true }
+ethers-derive-eip712 = { version = "^2.0.0", path = "../ethers-core/ethers-derive-eip712", optional = true }
 
 serde = { version = "1.0.124", default-features = false }
 serde_json = { version = "1.0.64", default-features = false }
@@ -26,17 +26,17 @@ futures-util = { version = "^0.3" }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-ethers-providers = { version = "^1.0.0", path = "../ethers-providers", default-features = false, features = [
+ethers-providers = { version = "^2.0.0", path = "../ethers-providers", default-features = false, features = [
     "ws",
 ] }
-ethers-signers = { version = "^1.0.0", path = "../ethers-signers" }
-ethers-contract-abigen = { version = "^1.0.0", path = "ethers-contract-abigen" }
-ethers-contract-derive = { version = "^1.0.0", path = "ethers-contract-derive" }
-ethers-core = { version = "^1.0.0", path = "../ethers-core", default-features = false, features = [
+ethers-signers = { version = "^2.0.0", path = "../ethers-signers" }
+ethers-contract-abigen = { version = "^2.0.0", path = "ethers-contract-abigen" }
+ethers-contract-derive = { version = "^2.0.0", path = "ethers-contract-derive" }
+ethers-core = { version = "^2.0.0", path = "../ethers-core", default-features = false, features = [
     "eip712",
 ] }
-ethers-derive-eip712 = { version = "^1.0.0", path = "../ethers-core/ethers-derive-eip712" }
-ethers-solc = { version = "^1.0.0", path = "../ethers-solc", default-features = false }
+ethers-derive-eip712 = { version = "^2.0.0", path = "../ethers-core/ethers-derive-eip712" }
+ethers-solc = { version = "^2.0.0", path = "../ethers-solc", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1.18", default-features = false, features = ["macros"] }

--- a/ethers-contract/ethers-contract-abigen/Cargo.toml
+++ b/ethers-contract/ethers-contract-abigen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-contract-abigen"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.64"
 authors = [
@@ -14,8 +14,8 @@ repository = "https://github.com/gakonst/ethers-rs"
 keywords = ["ethereum", "web3", "celo", "ethers"]
 
 [dependencies]
-ethers-core = { version = "^1.0.0", path = "../../ethers-core", features = ["macros"] }
-ethers-etherscan = { path = "../../ethers-etherscan", default-features = false, optional = true }
+ethers-core = { version = "^2.0.0", path = "../../ethers-core", features = ["macros"] }
+ethers-etherscan = { version = "^2.0.0", path = "../../ethers-etherscan", default-features = false, optional = true }
 
 proc-macro2 = "1.0"
 quote = "1.0"
@@ -53,7 +53,7 @@ rustls = ["online", "reqwest/rustls-tls", "ethers-etherscan/rustls"]
 
 [dev-dependencies]
 tempfile = "3.2.0"
-ethers-solc = { version = "^1.0.0", path = "../../ethers-solc", default-features = false, features = [
+ethers-solc = { version = "^2.0.0", path = "../../ethers-solc", default-features = false, features = [
     "project-util",
     "svm-solc",
 ] }

--- a/ethers-contract/ethers-contract-derive/Cargo.toml
+++ b/ethers-contract/ethers-contract-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-contract-derive"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.64"
 authors = [
@@ -17,8 +17,8 @@ keywords = ["ethereum", "web3", "celo", "ethers"]
 proc-macro = true
 
 [dependencies]
-ethers-core = { version = "^1.0.0", path = "../../ethers-core" }
-ethers-contract-abigen = { version = "^1.0.0", path = "../ethers-contract-abigen", default-features = false }
+ethers-core = { version = "^2.0.0", path = "../../ethers-core" }
+ethers-contract-abigen = { version = "^2.0.0", path = "../ethers-contract-abigen", default-features = false }
 
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/ethers-contract/src/multicall/constants.rs
+++ b/ethers-contract/src/multicall/constants.rs
@@ -28,7 +28,6 @@ pub const MULTICALL_SUPPORTED_CHAIN_IDS: &[u64] = {
         ArbitrumTestnet as u64,          // Arbitrum Rinkeby
         Polygon as u64,                  // Polygon
         PolygonMumbai as u64,            // Polygon Mumbai
-        XDai as u64,                     // Gnosis Chain
         Avalanche as u64,                // Avalanche
         AvalancheFuji as u64,            // Avalanche Fuji
         FantomTestnet as u64,            // Fantom Testnet

--- a/ethers-core/Cargo.toml
+++ b/ethers-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-core"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]

--- a/ethers-core/ethers-derive-eip712/Cargo.toml
+++ b/ethers-core/ethers-derive-eip712/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-derive-eip712"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.64"
 description = "Custom derive macro for EIP-712 typed data"
@@ -12,7 +12,7 @@ proc-macro = true
 [dependencies]
 quote = "1.0.9"
 syn = "1.0.77"
-ethers-core = { version = "^1.0.0", path = "../", default-features = false, features = [
+ethers-core = { version = "^2.0.0", path = "../", default-features = false, features = [
     "eip712",
     "macros",
 ] }
@@ -20,4 +20,4 @@ hex = "0.4.3"
 serde_json = "1.0.68"
 
 [dev-dependencies]
-ethers-contract-derive = { version = "^1.0.0", path = "../../ethers-contract/ethers-contract-derive" }
+ethers-contract-derive = { version = "^2.0.0", path = "../../ethers-contract/ethers-contract-derive" }

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -77,9 +77,6 @@ pub enum Chain {
     Poa = 99,
     Sokol = 77,
 
-    #[strum(serialize = "gnosis", serialize = "xdai", serialize = "gnosis-chain")]
-    XDai = 100,
-
     Polygon = 137,
     #[strum(serialize = "mumbai", serialize = "polygon-mumbai")]
     PolygonMumbai = 80001,
@@ -256,7 +253,7 @@ impl Chain {
             FilecoinHyperspaceTestnet | FilecoinMainnet => 30_000,
 
             // Explicitly exhaustive. See NB above.
-            Morden | Ropsten | Rinkeby | Goerli | Kovan | XDai | Chiado | Sepolia | Moonbase |
+            Morden | Ropsten | Rinkeby | Goerli | Kovan | Chiado | Sepolia | Moonbase |
             MoonbeamDev | Optimism | OptimismGoerli | OptimismKovan | Poa | Sokol | Rsk |
             EmeraldTestnet | Boba => return None,
         };
@@ -312,7 +309,7 @@ impl Chain {
 
             // Unknown / not applicable, default to false for backwards compatibility
             Dev | AnvilHardhat | Morden | Ropsten | Rinkeby | Cronos | CronosTestnet | Kovan |
-            Sokol | Poa | XDai | Moonbeam | MoonbeamDev | Moonriver | Moonbase | Evmos |
+            Sokol | Poa | Moonbeam | MoonbeamDev | Moonriver | Moonbase | Evmos |
             EvmosTestnet | Chiado | Aurora | AuroraTestnet | Canto | CantoTestnet |
             FilecoinMainnet => false,
         }
@@ -393,11 +390,6 @@ impl Chain {
             Moonbeam => ("https://api-moonbeam.moonscan.io/api", "https://moonbeam.moonscan.io/"),
             Moonbase => ("https://api-moonbase.moonscan.io/api", "https://moonbase.moonscan.io/"),
             Moonriver => ("https://api-moonriver.moonscan.io/api", "https://moonriver.moonscan.io"),
-
-            // blockscout API is etherscan compatible
-            XDai => {
-                ("https://blockscout.com/xdai/mainnet/api", "https://blockscout.com/xdai/mainnet")
-            }
 
             Chiado => {
                 ("https://blockscout.chiadochain.net/api", "https://blockscout.chiadochain.net")
@@ -507,7 +499,6 @@ impl Chain {
             Boba => "BOBASCAN_API_KEY",
 
             // Explicitly exhaustive. See NB above.
-            XDai |
             Chiado |
             Sepolia |
             Rsk |

--- a/ethers-etherscan/Cargo.toml
+++ b/ethers-etherscan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-etherscan"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.64"
 authors = [
@@ -18,8 +18,8 @@ Rust API bindings for the etherscan.io web API
 keywords = ["ethereum", "web3", "etherscan", "ethers"]
 
 [dependencies]
-ethers-core = { version = "^1.0.0", path = "../ethers-core", default-features = false }
-ethers-solc = { version = "^1.0.0", path = "../ethers-solc", default-features = false, optional = true }
+ethers-core = { version = "^2.0.0", path = "../ethers-core", default-features = false }
+ethers-solc = { version = "^2.0.0", path = "../ethers-solc", default-features = false, optional = true }
 reqwest = { version = "0.11.14", default-features = false, features = ["json"] }
 serde = { version = "1.0.124", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.64", default-features = false }
@@ -33,7 +33,7 @@ semver = "1.0.16"
 getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
-ethers-solc = { version = "^1.0.0", path = "../ethers-solc", default-features = false }
+ethers-solc = { version = "^2.0.0", path = "../ethers-solc", default-features = false }
 
 tempfile = "3.4.0"
 tokio = { version = "1.18", features = ["macros", "rt-multi-thread", "time"] }

--- a/ethers-etherscan/src/lib.rs
+++ b/ethers-etherscan/src/lib.rs
@@ -87,7 +87,6 @@ impl Client {
                 .map_err(Into::into),
 
             // Backwards compatibility, ideally these should return an error.
-            Chain::XDai |
             Chain::Chiado |
             Chain::Sepolia |
             Chain::Rsk |

--- a/ethers-middleware/Cargo.toml
+++ b/ethers-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-middleware"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
@@ -16,13 +16,13 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-ethers-contract = { version = "^1.0.0", path = "../ethers-contract", default-features = false, features = [
+ethers-contract = { version = "^2.0.0", path = "../ethers-contract", default-features = false, features = [
     "abigen",
 ] }
-ethers-core = { version = "^1.0.0", path = "../ethers-core", default-features = false }
-ethers-etherscan = { version = "^1.0.0", path = "../ethers-etherscan", default-features = false }
-ethers-providers = { version = "^1.0.0", path = "../ethers-providers", default-features = false }
-ethers-signers = { version = "^1.0.0", path = "../ethers-signers", default-features = false }
+ethers-core = { version = "^2.0.0", path = "../ethers-core", default-features = false }
+ethers-etherscan = { version = "^2.0.0", path = "../ethers-etherscan", default-features = false }
+ethers-providers = { version = "^2.0.0", path = "../ethers-providers", default-features = false }
+ethers-signers = { version = "^2.0.0", path = "../ethers-signers", default-features = false }
 
 async-trait = { version = "0.1.50", default-features = false }
 auto_impl = { version = "1.0.1", default-features = false }
@@ -44,11 +44,11 @@ instant = { version = "0.1.12", features = ["now"] }
 tokio = { version = "1.18" }
 
 [dev-dependencies]
-ethers-providers = { version = "^1.0.0", path = "../ethers-providers", default-features = false, features = [
+ethers-providers = { version = "^2.0.0", path = "../ethers-providers", default-features = false, features = [
     "ws",
     "rustls",
 ] }
-ethers-solc = { version = "^1.0.0", path = "../ethers-solc" }
+ethers-solc = { version = "^2.0.0", path = "../ethers-solc" }
 
 hex = { version = "0.4.3", default-features = false, features = ["std"] }
 rand = { version = "0.8.5", default-features = false }

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-providers"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
@@ -16,7 +16,7 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-ethers-core = { version = "^1.0.0", path = "../ethers-core", default-features = false }
+ethers-core = { version = "^2.0.0", path = "../ethers-core", default-features = false }
 
 async-trait = { version = "0.1.50", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["std"] }

--- a/ethers-signers/Cargo.toml
+++ b/ethers-signers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-signers"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.64"
 authors = ["Georgios Konstantopoulos <me@gakonst.com>"]
@@ -16,7 +16,7 @@ rustc-args = ["--cfg", "docsrs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-ethers-core = { version = "^1.0.0", path = "../ethers-core", features = ["eip712"] }
+ethers-core = { version = "^2.0.0", path = "../ethers-core", features = ["eip712"] }
 thiserror = { version = "1.0.39", default-features = false }
 coins-bip32 = "0.7.0"
 coins-bip39 = "0.7.0"
@@ -45,8 +45,8 @@ eth-keystore = { version = "0.5.0" }
 home = { version = "0.5.4", optional = true }
 
 [dev-dependencies]
-ethers-contract-derive = { version = "^1.0.0", path = "../ethers-contract/ethers-contract-derive" }
-ethers-derive-eip712 = { version = "^1.0.0", path = "../ethers-core/ethers-derive-eip712" }
+ethers-contract-derive = { version = "^2.0.0", path = "../ethers-contract/ethers-contract-derive" }
+ethers-derive-eip712 = { version = "^2.0.0", path = "../ethers-core/ethers-derive-eip712" }
 
 serde_json = { version = "1.0.64" }
 yubihsm = { version = "0.41.0", features = ["secp256k1", "usb", "mockhsm"] }

--- a/ethers-solc/Cargo.toml
+++ b/ethers-solc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethers-solc"
-version = "1.0.2"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.64"
 authors = [
@@ -16,7 +16,7 @@ description = "Utilites for working with solc"
 keywords = ["ethereum", "web3", "solc", "solidity", "ethers"]
 
 [dependencies]
-ethers-core = { version = "^1.0.0", path = "../ethers-core", default-features = false }
+ethers-core = { version = "^2.0.0", path = "../ethers-core", default-features = false }
 serde_json = "1.0.68"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 semver = { version = "1.0.16", features = ["serde"] }

--- a/examples/anvil/Cargo.toml
+++ b/examples/anvil/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "examples-anvil"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Andrea Simeoni <andreasimeoni84@gmail.com>"]
 edition = "2021"
 
 [dev-dependencies]
-ethers = { path = "../..", version = "1.0.0" }
+ethers = { path = "../..", version = "2.0.0" }
 eyre = "0.6"
 tokio = { version = "1.18", features = ["full"] }

--- a/examples/big-numbers/Cargo.toml
+++ b/examples/big-numbers/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "examples-big-numbers"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Andrea Simeoni <andreasimeoni84@gmail.com>"]
 edition = "2021"
 
 [dev-dependencies]
 #ethers-core = { version = "^1.0.0", path = "../../ethers-core" }
-ethers = { path = "../..", version = "1.0.0" }
+ethers = { path = "../..", version = "2.0.0" }
 

--- a/examples/contracts/Cargo.toml
+++ b/examples/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples-contracts"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Andrea Simeoni <andreasimeoni84@gmail.com>"]
 edition = "2021"
 
@@ -9,7 +9,7 @@ default = ["legacy"]
 legacy = []
 
 [dev-dependencies]
-ethers = { path = "../..", version = "1.0.0", features = ["abigen", "ethers-solc", "legacy", "rustls", "ws"] }
+ethers = { path = "../..", version = "2.0.0", features = ["abigen", "ethers-solc", "legacy", "rustls", "ws"] }
 
 eyre = "0.6"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/examples/ethers-wasm/Cargo.toml
+++ b/examples/ethers-wasm/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-ethers = { path = "../..", version = "1.0.0", features = ["abigen", "legacy", "ws"] }
+ethers = { path = "../..", version = "2.0.0", features = ["abigen", "legacy", "ws"] }
 
 wasm-bindgen-futures = "0.4.34"
 wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }

--- a/examples/events/Cargo.toml
+++ b/examples/events/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "examples-events"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Andrea Simeoni <andreasimeoni84@gmail.com>"]
 edition = "2021"
 
 [dev-dependencies]
-ethers = { path = "../..", version = "1.0.0" }
+ethers = { path = "../..", version = "2.0.0" }
 
 eyre = "0.6"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/examples/middleware/Cargo.toml
+++ b/examples/middleware/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "examples-middleware"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Andrea Simeoni <andreasimeoni84@gmail.com>"]
 edition = "2021"
 
 [dev-dependencies]
-ethers = { path = "../..", version = "1.0.0", features = ["rustls", "ws"] }
+ethers = { path = "../..", version = "2.0.0", features = ["rustls", "ws"] }
 
 async-trait = { version = "0.1.50", default-features = false }
 eyre = "0.6"

--- a/examples/providers/Cargo.toml
+++ b/examples/providers/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "examples-providers"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Andrea Simeoni <andreasimeoni84@gmail.com>"]
 edition = "2021"
 
 [dev-dependencies]
-ethers = { path = "../..", version = "1.0.0", features = ["abigen", "ipc", "rustls", "ws"] }
+ethers = { path = "../..", version = "2.0.0", features = ["abigen", "ipc", "rustls", "ws"] }
 
 eyre = "0.6"
 reqwest = { version = "0.11.14", default-features = false }

--- a/examples/queries/Cargo.toml
+++ b/examples/queries/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "examples-queries"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Andrea Simeoni <andreasimeoni84@gmail.com>"]
 edition = "2021"
 
 [dev-dependencies]
-ethers = { path = "../..", version = "1.0.0", features = ["abigen", "rustls", "ws"] }
+ethers = { path = "../..", version = "2.0.0", features = ["abigen", "rustls", "ws"] }
 
 eyre = "0.6"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/examples/subscriptions/Cargo.toml
+++ b/examples/subscriptions/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "examples-subscriptions"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Andrea Simeoni <andreasimeoni84@gmail.com>"]
 edition = "2021"
 
 [dev-dependencies]
-ethers = { path = "../..", version = "1.0.0", features = ["abigen", "rustls", "ws"] }
+ethers = { path = "../..", version = "2.0.0", features = ["abigen", "rustls", "ws"] }
 
 eyre = "0.6"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/examples/transactions/Cargo.toml
+++ b/examples/transactions/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "examples-transactions"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Andrea Simeoni <andreasimeoni84@gmail.com>"]
 edition = "2021"
 
 [dev-dependencies]
-ethers = { path = "../..", version = "1.0.0", features = ["abigen", "rustls", "ws"] }
+ethers = { path = "../..", version = "2.0.0", features = ["abigen", "rustls", "ws"] }
 
 eyre = "0.6"
 serde = { version = "1.0.144", features = ["derive"] }

--- a/examples/wallets/Cargo.toml
+++ b/examples/wallets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "examples-wallets"
-version = "1.0.2"
+version = "2.0.0"
 authors = ["Andrea Simeoni <andreasimeoni84@gmail.com>"]
 edition = "2021"
 
@@ -11,7 +11,7 @@ trezor = []
 yubi = []
 
 [dev-dependencies]
-ethers = { path = "../..", version = "1.0.0", features = ["abigen", "eip712", "ledger", "rustls", "trezor", "ws", "yubi"] }
+ethers = { path = "../..", version = "2.0.0", features = ["abigen", "eip712", "ledger", "rustls", "trezor", "ws", "yubi"] }
 
 eyre = "0.6"
 serde = { version = "1.0.144", features = ["derive"] }


### PR DESCRIPTION
trying to fix error during crates installation

```
# cargo run

   Compiling ethers-contract v2.0.7
   Compiling revm v3.5.0
error[E0425]: cannot find value `XDai` in this scope
  --> /home/yegor/.cargo/registry/src/index.crates.io-6f17d22bba15001f/ethers-contract-2.0.7/src/multicall/constants.rs:31:9
   |
31 |         XDai as u64,                     // Gnosis Chain
   |         ^^^^ not found in this scope

For more information about this error, try `rustc --explain E0425`.
error: could not compile `ethers-contract` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
```