### PR TITLE
fix: better file name to ident conversion

### DIFF
--- a/ethers-contract/tests/solidity-contracts/draft-IERCPermit.json
+++ b/ethers-contract/tests/solidity-contracts/draft-IERCPermit.json
@@ -1,0 +1,12 @@
+{
+  "abi": [],
+  "bytecode": {
+    "object": "0x",
+    "linkReferences": {}
+  },
+  "deployedBytecode": {
+    "object": "0x",
+    "linkReferences": {}
+  },
+  "id": 217
+}


### PR DESCRIPTION
closes https://github.com/foundry-rs/foundry/issues/6010

we were converting the file name to the contract's ident which fails if the file name is not an ident.

better errors and replace commonly used invalid tokens like `-`.