### PR TITLE
fix: return error when failing to decode output in parse_call_result

### DIFF
--- a/ethers-contract/src/multicall/middleware.rs
+++ b/ethers-contract/src/multicall/middleware.rs
@@ -684,12 +684,17 @@ impl<M: Middleware> Multicall<M> {
 
                 Err(return_data)
             } else {
-                let mut res_tokens = call.function.decode_output(return_data.as_ref())?;
-                Ok(if res_tokens.len() == 1 {
-                    res_tokens.pop().unwrap()
-                } else {
-                    Token::Tuple(res_tokens)
-                })
+                let res_tokens = call.function.decode_output(return_data.as_ref());
+                match res_tokens {
+                    Ok(mut tokens) => {
+                        Ok(if tokens.len() == 1 {
+                            tokens.pop().unwrap()
+                        } else {
+                            Token::Tuple(tokens)
+                        })
+                    },
+                    Err(_) => Err(return_data),
+                }
             };
             results.push(result);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

I ran into this issue when trying to decode the output for a call where the ABI had the incorrect type. I was calling many different ERC20 contracts for `symbol()` but found a [contract that has a different return type](https://etherscan.io/token/0xff46586fe46b814eb86e60320e1b0a29b78d4757#readContract#F7), `bytes32` instead of the expected `string`.

Without this change it's hard to understand which call is failing because the entire Multicall returns an error instead of individually for each call. 



<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
`parse_call_result` now returns `Err(bytes)` for each call output that fails to decode. It previously just returned an `Err` immediately from the failing decode function due to `?`. 

Not sure if it's still ideal to just return `bytes` since `call` and `call_array` will assume it's a revert.

The resulting different behaviour is that instead getting an error for `call_raw()` you would get an error when parsing the results similar to a regular revert error for example.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests 
-   [ ] Added Documentation
-   [x ] Breaking changes 
