### PR TITLE
FIX: Accept 'input' or 'data', (but not both), in transaction request

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -515,9 +515,10 @@ impl Chain {
                 ("https://alpha-blockscout.scroll.io/api", "https://alpha-blockscout.scroll.io/")
             }
 
-            Metis => {
-                ("https://api.routescan.io/v2/network/mainnet/evm/1088/etherscan/api", "https://explorer.metis.io/")
-            }
+            Metis => (
+                "https://api.routescan.io/v2/network/mainnet/evm/1088/etherscan/api",
+                "https://explorer.metis.io/",
+            ),
 
             Chiado => {
                 ("https://blockscout.chiadochain.net/api", "https://blockscout.chiadochain.net")
@@ -599,7 +600,7 @@ impl Chain {
             AnvilHardhat | Dev | Morden | MoonbeamDev | FilecoinMainnet => {
                 // this is explicitly exhaustive so we don't forget to add new urls when adding a
                 // new chain
-                return None;
+                return None
             }
         };
 

--- a/ethers-core/src/types/transaction/request.rs
+++ b/ethers-core/src/types/transaction/request.rs
@@ -48,7 +48,7 @@ pub struct TransactionRequest {
 
     /// The compiled code of a contract OR the first 4 bytes of the hash of the
     /// invoked method signature and encoded parameters. For details see Ethereum Contract ABI
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "input")]
     pub data: Option<Bytes>,
 
     /// Transaction nonce (None for next available nonce)

--- a/ethers-core/src/utils/genesis.rs
+++ b/ethers-core/src/utils/genesis.rs
@@ -358,7 +358,7 @@ where
                 return Numeric::from_str(num)
                     .map(U256::from)
                     .map(Some)
-                    .map_err(serde::de::Error::custom);
+                    .map_err(serde::de::Error::custom)
             }
 
             if let serde_json::Value::Number(num) = val {


### PR DESCRIPTION
## Motivation

https://github.com/ethereum/go-ethereum/pull/28078 changed the `go-ethereum` client to send the transaction payload in an `input` field instead of `data`, which is how it's [defined](https://github.com/ethereum/execution-apis/blob/431cf72fd3403d946ca3e3afc36b973fc87e0e89/src/schemas/transaction.yaml#L33-L35) in the API. Apparently most server implementations accept both fields, preferring `input` where both are present at the same time.

The `Eip1559TransactionRequest` has a `data` field, and thus it could not be used to deserialize such requests. 

## Solution

The PR adds a special deserializer to the `Eip1559TransactionRequest::data` field so that it looks for `input` first, `data` second.

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
