### PR TITLE
fix: handle SyncingStatus from erigon

### DIFF
--- a/ethers-core/src/types/syncing.rs
+++ b/ethers-core/src/types/syncing.rs
@@ -62,12 +62,17 @@ impl<'de> Deserialize<'de> for SyncingStatus {
 /// > highestBlock: QUANTITY - The estimated highest block
 ///
 /// Geth returns additional fields: <https://github.com/ethereum/go-ethereum/blob/0ce494b60cd00d70f1f9f2dd0b9bfbd76204168a/ethclient/ethclient.go#L597-L617>
+///
+/// Erigon does not return the startingBlock field and also returns an additional staging field <https://github.com/ledgerwatch/erigon/blob/6a1bb1dff1deca7a50d66bfbc9e0b89bb4e335a1/turbo/jsonrpc/eth_system.go#L70-L74>
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncProgress {
     pub current_block: U64,
     pub highest_block: U64,
-    pub starting_block: U64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stages: Option<Vec<SyncStage>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub starting_block: Option<U64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pulled_states: Option<U64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -98,6 +103,12 @@ pub struct SyncProgress {
     pub synced_storage_bytes: Option<U64>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SyncStage {
+    stage_name: String,
+    block_number: U64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -122,6 +133,84 @@ mod tests {
         "syncedStorage": "0x2a517da1",
         "syncedStorageBytes": "0x23634dbedf"
     }"#;
+
+        let sync: SyncingStatus = serde_json::from_str(s).unwrap();
+        match sync {
+            SyncingStatus::IsFalse => {
+                panic!("unexpected variant")
+            }
+            SyncingStatus::IsSyncing(_) => {}
+        }
+    }
+
+    // <https://github.com/ledgerwatch/erigon/blob/6a1bb1dff1deca7a50d66bfbc9e0b89bb4e335a1/turbo/jsonrpc/eth_system.go#L70-L74>
+    #[test]
+    fn deserialize_sync_erigon() {
+        let s = r#"{
+        "currentBlock": "0x11ef283",
+        "highestBlock": "0x11ef284",
+        "stages": [
+            {
+                "block_number": "0x11ef283",
+                "stage_name": "Snapshots"
+            },
+            {
+                "block_number": "0x11ef284",
+                "stage_name": "Headers"
+            },
+            {
+                "block_number": "0x11ef284",
+                "stage_name": "BlockHashes"
+            },
+            {
+                "block_number": "0x11ef284",
+                "stage_name": "Bodies"
+            },
+            {
+                "block_number": "0x11ef284",
+                "stage_name": "Senders"
+            },
+            {
+                "block_number": "0x11ef284",
+                "stage_name": "Execution"
+            },
+            {
+                "block_number": "0x0",
+                "stage_name": "Translation"
+            },
+            {
+                "block_number": "0x11ef284",
+                "stage_name": "HashState"
+            },
+            {
+                "block_number": "0x11ef284",
+                "stage_name": "IntermediateHashes"
+            },
+            {
+                "block_number": "0x11ef283",
+                "stage_name": "AccountHistoryIndex"
+            },
+            {
+                "block_number": "0x11ef283",
+                "stage_name": "StorageHistoryIndex"
+            },
+            {
+                "block_number": "0x11ef283",
+                "stage_name": "LogIndex"
+            },
+            {
+                "block_number": "0x11ef284",
+                "stage_name": "CallTraces"
+            },
+            {
+                "block_number": "0x11ef283",
+                "stage_name": "TxLookup"
+            },
+            {
+                "block_number": "0x11ef283",
+                "stage_name": "Finish"
+            }
+        ]}"#;
 
         let sync: SyncingStatus = serde_json::from_str(s).unwrap();
         match sync {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation
The `syncing()`  `eth_syncing` rpc call fails on Erigon clients when the node is not synced.  Erigon gives a different response format that we fail to parse.  This change adds handling for the Erigon response format: https://github.com/ledgerwatch/erigon/blob/6a1bb1dff1deca7a50d66bfbc9e0b89bb4e335a1/turbo/jsonrpc/eth_system.go#L70-L74 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Modifies the `SyncProgress` struct to handle all responses, adds a unit test.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation - just code comments
-   [ ] Breaking changes
