### PR TITLE
feat(rpc): add getHeader by number+hash

### DIFF
--- a/ethers-providers/src/middleware.rs
+++ b/ethers-providers/src/middleware.rs
@@ -148,6 +148,14 @@ pub trait Middleware: Sync + Send + Debug {
         self.inner().get_block_number().await.map_err(MiddlewareError::from_err)
     }
 
+    /// Get the block header by number or hash
+    async fn get_header<T: Into<BlockId> + Send + Sync>(
+        &self,
+        block_hash_or_number: T,
+    ) -> Result<Option<Block<Transaction>>, Self::Error> {
+        self.inner().get_header(block_hash_or_number).await.map_err(MiddlewareError::from_err)
+    }
+
     /// Sends the transaction to the entire Ethereum network and returns the
     /// transaction's hash. This will consume gas from the account that signed
     /// the transaction. This call will fail if no signer is available, and the

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -338,6 +338,23 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         self.get_block_gen(block_hash_or_number.into(), false).await
     }
 
+    async fn get_header<T: Into<BlockId> + Send + Sync>(
+        &self,
+        block_hash_or_number: T,
+    ) -> Result<Option<Block<Transaction>>, Self::Error> {
+        let id = block_hash_or_number.into();
+        Ok(match id {
+            BlockId::Number(num) => {
+                let num = utils::serialize(&num);
+                self.request("eth_getHeaderByNumber", [num]).await?
+            }
+            BlockId::Hash(hash) => {
+                let hash = utils::serialize(&hash);
+                self.request("eth_getHeaderByHash", [hash]).await?
+            }
+        })
+    }
+
     async fn get_block_with_txs<T: Into<BlockId> + Send + Sync>(
         &self,
         block_hash_or_number: T,


### PR DESCRIPTION
Add support for `eth_getHeaderByNumber` and `eth_getHeaderByHash` endpoints. To be used as follows:

```rust
use ethers_core::types::{BlockId, BlockNumber};
use ethers_providers::Middleware;
use ethers_providers::{Http, Provider};

async fn mytest() {
    let provider = Provider::<Http>::try_from("http://localhost:8545").unwrap();
    let by_num = BlockId::Number(BlockNumber::Number(18826806u64.into()));
    let by_hash = BlockId::Hash(
        "0xac45643453aba125a85a779163e7cfa40e4f8898639f1d5249de1c1481817510".parse().unwrap(),
    );
    // Use by_num or by_hash
    let block = provider.get_header(by_hash).await.unwrap();
    println!("block: {:?}", block);
}
```

Note that the same type `Block` is used, but non-header fields are left empty.