### PR TITLE
feat(multicall): add support for Arbitrum Sepolia

### DIFF
--- a/ethers-contract/src/multicall/constants.rs
+++ b/ethers-contract/src/multicall/constants.rs
@@ -29,6 +29,7 @@ pub const MULTICALL_SUPPORTED_CHAIN_IDS: &[u64] = {
         ArbitrumNova as u64,             // Arbitrum Nova
         ArbitrumGoerli as u64,           // Arbitrum Görli
         ArbitrumTestnet as u64,          // Arbitrum Rinkeby
+        ArbitrumSepolia as u64,          // Arbitrum Sepolia
         Polygon as u64,                  // Polygon
         PolygonMumbai as u64,            // Polygon Mumbai
         Gnosis as u64,                   // Gnosis Chain


### PR DESCRIPTION
## Motivation

I couldn't use multicall with default constructor on Arbitrum Sepolia network due to this error: `Chain ID 421614 is currently not supported by Multicall. Provide an address instead.`.

Multicall is already deployed on Arbitrum Sepolia: https://sepolia.arbiscan.io/address/0xca11bde05977b3631167028862be2a173976ca11.

## Solution

Added chain ID to the list of supported chains.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
