### PR TITLE
Fix handling of json rpc errors that use "details" instead of "message"

### DIFF
--- a/ethers-contract/src/multicall/constants.rs
+++ b/ethers-contract/src/multicall/constants.rs
@@ -32,6 +32,7 @@ pub const MULTICALL_SUPPORTED_CHAIN_IDS: &[u64] = {
         ArbitrumSepolia as u64,          // Arbitrum Sepolia
         Polygon as u64,                  // Polygon
         PolygonMumbai as u64,            // Polygon Mumbai
+        PolygonAmoy as u64,              // Polygon Amoy
         Gnosis as u64,                   // Gnosis Chain
         Avalanche as u64,                // Avalanche
         AvalancheFuji as u64,            // Avalanche Fuji

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -105,6 +105,9 @@ pub enum Chain {
     #[strum(to_string = "mumbai", serialize = "polygon-mumbai")]
     #[serde(alias = "mumbai")]
     PolygonMumbai = 80001,
+    #[strum(to_string = "amoy", serialize = "polygon-amoy")]
+    #[serde(alias = "amoy")]
+    PolygonAmoy = 80002,
     #[strum(serialize = "polygon-zkevm", serialize = "zkevm")]
     #[serde(alias = "zkevm", alias = "polygon_zkevm")]
     PolygonZkEvm = 1101,
@@ -299,7 +302,7 @@ impl Chain {
             Mainnet => 12_000,
             Arbitrum | ArbitrumTestnet | ArbitrumGoerli | ArbitrumSepolia | ArbitrumNova => 1_300,
             Optimism | OptimismGoerli | OptimismSepolia => 2_000,
-            Polygon | PolygonMumbai => 2_100,
+            Polygon | PolygonMumbai | PolygonAmoy => 2_100,
             Moonbeam | Moonriver => 12_500,
             BinanceSmartChain | BinanceSmartChainTestnet => 3_000,
             Avalanche | AvalancheFuji => 2_000,
@@ -377,6 +380,7 @@ impl Chain {
             OptimismSepolia |
             Polygon |
             PolygonMumbai |
+            PolygonAmoy |
             Avalanche |
             AvalancheFuji |
             Arbitrum |
@@ -448,6 +452,7 @@ impl Chain {
             PolygonMumbai => {
                 ("https://api-testnet.polygonscan.com/api", "https://mumbai.polygonscan.com")
             }
+            PolygonAmoy => ("https://rpc-amoy.polygon.technology", "https://www.oklink.com/amoy"),
 
             PolygonZkEvm => {
                 ("https://api-zkevm.polygonscan.com/api", "https://zkevm.polygonscan.com")
@@ -657,7 +662,9 @@ impl Chain {
 
             Avalanche | AvalancheFuji => "SNOWTRACE_API_KEY",
 
-            Polygon | PolygonMumbai | PolygonZkEvm | PolygonZkEvmTestnet => "POLYGONSCAN_API_KEY",
+            Polygon | PolygonMumbai | PolygonZkEvm | PolygonZkEvmTestnet | PolygonAmoy => {
+                "POLYGONSCAN_API_KEY"
+            }
 
             Fantom | FantomTestnet => "FTMSCAN_API_KEY",
 

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -347,8 +347,6 @@ impl Chain {
             OptimismKovan |
             Fantom |
             FantomTestnet |
-            BinanceSmartChain |
-            BinanceSmartChainTestnet |
             ArbitrumTestnet |
             Rsk |
             Oasis |
@@ -373,6 +371,8 @@ impl Chain {
             Goerli |
             Sepolia |
             Holesky |
+            BinanceSmartChain |
+            BinanceSmartChainTestnet |
             Base |
             BaseGoerli |
             Optimism |

--- a/ethers-middleware/src/gas_oracle/polygon.rs
+++ b/ethers-middleware/src/gas_oracle/polygon.rs
@@ -7,6 +7,7 @@ use url::Url;
 
 const MAINNET_URL: &str = "https://gasstation.polygon.technology/v2";
 const MUMBAI_URL: &str = "https://gasstation-testnet.polygon.technology/v2";
+const AMOY_URL: &str = "https://gasstation.polygon.technology/amoy";
 
 /// The [Polygon](https://docs.polygon.technology/docs/develop/tools/polygon-gas-station/) gas station API
 /// Queries over HTTP and implements the `GasOracle` trait.
@@ -112,6 +113,7 @@ impl Polygon {
         let url = match chain {
             Chain::Polygon => MAINNET_URL,
             Chain::PolygonMumbai => MUMBAI_URL,
+            Chain::PolygonAmoy => AMOY_URL,
             _ => return Err(GasOracleError::UnsupportedChain),
         };
         Ok(Self { client, url: Url::parse(url).unwrap(), gas_category: GasCategory::Standard })

--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -32,7 +32,7 @@ http = "0.2"
 reqwest = { workspace = true, features = ["json"] }
 url.workspace = true
 base64 = "0.21"
-jsonwebtoken = "8"
+jsonwebtoken = "9"
 
 async-trait.workspace = true
 hex.workspace = true

--- a/ethers-providers/src/rpc/transports/common.rs
+++ b/ethers-providers/src/rpc/transports/common.rs
@@ -20,6 +20,7 @@ pub struct JsonRpcError {
     /// The error code
     pub code: i64,
     /// The error message
+    #[serde(alias = "details")]
     pub message: String,
     /// Additional data
     pub data: Option<Value>,


### PR DESCRIPTION
## Motivation

I ran into an issue when using the `RetryClient` with a Polygon Mumbia RPC endpoint (`https://rpc-mumbai.maticvigil.com/`). The error it returns looks like this:
`{"error":{"details":"Bad parameters in JSONRPC request: eth_getLogs.","code":-32005},"jsonrpc":"2.0","id":19}`

Without this change the JsonRpcError fails to deserialize and the retry logic that is dependent on the JSON error code does not run.


## Solution

Make the deserialization a bit more flexible, and have it support both `"message"` and `"details"`.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes

Thank you!