### PR TITLE
feat: add Base Sepolia as a chain

### DIFF
--- a/ethers-contract/src/multicall/constants.rs
+++ b/ethers-contract/src/multicall/constants.rs
@@ -23,8 +23,10 @@ pub const MULTICALL_SUPPORTED_CHAIN_IDS: &[u64] = {
         Optimism as u64,                 // Optimism
         OptimismKovan as u64,            // Optimism Kovan
         OptimismGoerli as u64,           // Optimism Görli
+        OptimismSepolia as u64,          // Optimism Sepolia
         Base as u64,                     // Base
         BaseGoerli as u64,               // Base Görli
+        BaseSepolia as u64,              // Base Sepolia
         Arbitrum as u64,                 // Arbitrum
         ArbitrumNova as u64,             // Arbitrum Nova
         ArbitrumGoerli as u64,           // Arbitrum Görli

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -159,6 +159,7 @@ pub enum Chain {
 
     Base = 8453,
     BaseGoerli = 84531,
+    BaseSepolia = 84532,
 
     Linea = 59144,
     LineaTestnet = 59140,
@@ -317,10 +318,9 @@ impl Chain {
             // Explicitly exhaustive. See NB above.
             Morden | Ropsten | Rinkeby | Goerli | Kovan | Sepolia | Holesky | Moonbase |
             MoonbeamDev | OptimismKovan | Poa | Sokol | Rsk | EmeraldTestnet | Boba | Base |
-            BaseGoerli | ZkSync | ZkSyncTestnet | PolygonZkEvm | PolygonZkEvmTestnet | Metis |
-            Linea | LineaTestnet | Mantle | MantleTestnet | Zora | ZoraGoerli | ZoraSepolia => {
-                return None
-            }
+            BaseGoerli | BaseSepolia | ZkSync | ZkSyncTestnet | PolygonZkEvm |
+            PolygonZkEvmTestnet | Metis | Linea | LineaTestnet | Mantle | MantleTestnet |
+            Zora | ZoraGoerli | ZoraSepolia => return None,
         };
 
         Some(Duration::from_millis(ms))
@@ -372,6 +372,7 @@ impl Chain {
             Holesky |
             Base |
             BaseGoerli |
+            BaseSepolia |
             Optimism |
             OptimismGoerli |
             OptimismSepolia |
@@ -572,6 +573,7 @@ impl Chain {
             Base => ("https://api.basescan.org/api", "https://basescan.org"),
 
             BaseGoerli => ("https://api-goerli.basescan.org/api", "https://goerli.basescan.org"),
+            BaseSepolia => ("https://api-sepolia.basescan.org/api", "https://sepolia.basescan.org"),
 
             ZkSync => {
                 ("https://zksync2-mainnet-explorer.zksync.io/", "https://explorer.zksync.io/")
@@ -651,6 +653,7 @@ impl Chain {
             Mantle |
             MantleTestnet |
             BaseGoerli |
+            BaseSepolia |
             Gnosis |
             Scroll |
             ScrollSepolia => "ETHERSCAN_API_KEY",


### PR DESCRIPTION
## Motivation

There is no support for Base Sepolia as a chain.

## Solution

Adds Base Sepolia and associated constants to `Chain` , multi-call deployment list.

Also, this PR adds Optimism Sepolia to the supported multicall chains.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
