### PR TITLE
Add aliases for Base, BaseSepolia and BaseGoerli

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -157,8 +157,14 @@ pub enum Chain {
 
     Boba = 288,
 
+    #[strum(to_string = "base")]
+    #[serde(alias = "base")]
     Base = 8453,
+    #[strum(to_string = "base-goerli")]
+    #[serde(alias = "base_goerli")]
     BaseGoerli = 84531,
+    #[strum(to_string = "base-sepolia")]
+    #[serde(alias = "base_sepolia")]
     BaseSepolia = 84532,
 
     Linea = 59144,

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -779,6 +779,9 @@ mod tests {
             (Mantle, &["mantle"]),
             (MantleTestnet, &["mantle-testnet"]),
             (Viction, &["viction"]),
+            (Base, &["base"]),
+            (BaseGoerli, &["base-goerli"]),
+            (BaseSepolia, &["base-sepolia"]),
         ];
 
         for &(chain, aliases) in ALIASES {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

## Motivation

There are no aliases set for Base Mainnet, Sepolia and Goerli.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add aliases for `Base`, `BaseGoerli` and `BaseSepolia` and related tests.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
