### PR TITLE
feat: Add support for cancun evm version

### DIFF
--- a/ethers-solc/src/compile/mod.rs
+++ b/ethers-solc/src/compile/mod.rs
@@ -52,6 +52,8 @@ pub const PARIS_SOLC: Version = Version::new(0, 8, 18);
 /// <https://blog.soliditylang.org/2023/05/10/solidity-0.8.20-release-announcement/>
 pub const SHANGHAI_SOLC: Version = Version::new(0, 8, 20);
 
+pub const CANCUN_SOLC: Version = Version::new(0, 8, 24);
+
 // `--base-path` was introduced in 0.6.9 <https://github.com/ethereum/solidity/releases/tag/v0.6.9>
 pub static SUPPORTS_BASE_PATH: Lazy<VersionReq> =
     Lazy::new(|| VersionReq::parse(">=0.6.9").unwrap());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

This PR adds a new "Cancun" evm version into the enum of supported evm versions.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Starting from v0.8.24 a new "Cancun" network upgrade has been added into solidity compilers. The corresponding `ethers-solc::EvmVersion` has not been updated though, which results in inability for clients to use "Cancun" evm version when compiling the contracts using default `ethers-solc::CompilerInput`.

"Shanghai" remains a default evm version as v0.8.24 release does not yet make "Cancun" its default target

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
