### PR TITLE
Docs: Fix typo in `events.md`

### DIFF
--- a/book/events/events.md
+++ b/book/events/events.md
@@ -16,7 +16,7 @@ Before diving into event handling, ensure you have ethers-rs added to your proje
 
 ```toml
 [dependencies]
-ethers = { version = "2.0.0.", features = ["full"] }
+ethers = { version = "2.0.0", features = ["full"] }
 ```
 
 Now, let's import the necessary components from the ethers-rs library:


### PR DESCRIPTION
Fix a typo in `events.md`.

This fixes that error thrown by cargo:
```
Caused by:
  failed to parse the version requirement `2.0.0.` for dependency `ethers`

Caused by:
  expected comma after patch version number, found '.'
```