### PR TITLE
chore: bump jsonwebtoken version from 8 to 9

### DIFF
--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -32,7 +32,7 @@ http = "0.2"
 reqwest = { workspace = true, features = ["json"] }
 url.workspace = true
 base64 = "0.22"
-jsonwebtoken = "8"
+jsonwebtoken = "9"
 
 async-trait.workspace = true
 hex.workspace = true


### PR DESCRIPTION
It uses the latest Ring, which fixes an issue for compiling to wasm32-wasi

jsonwebtoken 8 uses ring v0.16.20 that has the issue

Issue: https://github.com/briansmith/ring/issues/1043

## Motivation

Compiling to wasm32-wasi was failing

## Solution

Bump jsonwebtoken to use latest Ring (v0.17.8 now)
