### PR TITLE
fix: fix ci with `Address` not found

### DIFF
--- a/ethers-contract/src/base.rs
+++ b/ethers-contract/src/base.rs
@@ -319,7 +319,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ethers_core::{abi::parse_abi, types::U256};
+    use ethers_core::{abi::parse_abi, types::U256, types::Address};
 
     #[test]
     fn can_parse_function_inputs() {


### PR DESCRIPTION
## Motivation

fix: fix ci with `Address` not found

## Solution
add `ethers_core::types::Address` to tests
