### PR TITLE
Fix transaction_type comment

### DIFF
--- a/ethers-core/src/types/transaction/response.rs
+++ b/ethers-core/src/types/transaction/response.rs
@@ -101,8 +101,8 @@ pub struct Transaction {
     pub gateway_fee: Option<U256>,
 
     // EIP2718
-    /// Transaction type, Some(2) for EIP-1559 transaction,
-    /// Some(1) for AccessList transaction, None for Legacy
+    /// Transaction type, Some(3) for Blob transactions, Some(2) for EIP-1559 transaction,
+    /// Some(1) for AccessList transaction, Some(0) or None for Legacy
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
     pub transaction_type: Option<U64>,
 


### PR DESCRIPTION
Fixes the comment on `transaction_type`: 

- Blobs are reported as `Some(3)`
- Legacy transactions are reported as `Some(0)`