### PR TITLE
chore: bump `jsonwebtoken`

### DIFF
--- a/ethers-providers/Cargo.toml
+++ b/ethers-providers/Cargo.toml
@@ -32,7 +32,7 @@ http = "0.2"
 reqwest = { workspace = true, features = ["json"] }
 url.workspace = true
 base64 = "0.22"
-jsonwebtoken = "8"
+jsonwebtoken = "9"
 
 async-trait.workspace = true
 hex.workspace = true


### PR DESCRIPTION
Resolves the cross-compilation issue described in full at #2786 