### PR TITLE
Add optimize_gas param for create_access_list

### DIFF
--- a/ethers-middleware/src/signer.rs
+++ b/ethers-middleware/src/signer.rs
@@ -336,10 +336,11 @@ where
         &self,
         tx: &TypedTransaction,
         block: Option<BlockId>,
+        optimize_gas: Option<bool>,
     ) -> Result<AccessListWithGasUsed, Self::Error> {
         let tx = self.set_tx_from_if_none(tx);
         self.inner
-            .create_access_list(&tx, block)
+            .create_access_list(&tx, block, optimize_gas)
             .await
             .map_err(SignerMiddlewareError::MiddlewareError)
     }

--- a/ethers-providers/src/middleware.rs
+++ b/ethers-providers/src/middleware.rs
@@ -998,8 +998,12 @@ pub trait Middleware: Sync + Send + Debug {
         &self,
         tx: &TypedTransaction,
         block: Option<BlockId>,
+        optimize_gas: Option<bool>,
     ) -> Result<AccessListWithGasUsed, Self::Error> {
-        self.inner().create_access_list(tx, block).await.map_err(MiddlewareError::from_err)
+        self.inner()
+            .create_access_list(tx, block, optimize_gas)
+            .await
+            .map_err(MiddlewareError::from_err)
     }
 }
 

--- a/ethers-providers/src/rpc/provider.rs
+++ b/ethers-providers/src/rpc/provider.rs
@@ -554,10 +554,17 @@ impl<P: JsonRpcClient> Middleware for Provider<P> {
         &self,
         tx: &TypedTransaction,
         block: Option<BlockId>,
+        optimize_gas: Option<bool>
     ) -> Result<AccessListWithGasUsed, ProviderError> {
         let tx = utils::serialize(tx);
         let block = utils::serialize(&block.unwrap_or_else(|| BlockNumber::Latest.into()));
-        self.request("eth_createAccessList", [tx, block]).await
+        let optimize_gas = utils::serialize(&optimize_gas.unwrap_or_else(|| true));
+        let node_client = self.node_client().await?;
+        if let NodeClient::Erigon = node_client {
+            self.request("eth_createAccessList", [tx, block, optimize_gas]).await
+        } else {
+            self.request("eth_createAccessList", [tx, block]).await
+        }
     }
 
     async fn send_transaction<T: Into<TypedTransaction> + Send + Sync>(


### PR DESCRIPTION
## Motivation

To override balances when simulating transactions, we need to figure out the access list for the balanceOf of a token

On Erigon, the gas is optimized so the access list returned is empty (which is different than geth). To get it anyway, we need to pass in an additional `optimizeGas` boolean flag for the `eth_createAccessList` call. Since geth is unavailable on Gnosis chain, we need to add the functionality of the PR to achieve the desired outcome.

More information: https://github.com/ledgerwatch/erigon/issues/9444 

## Solution

This PR adds an optional `optimize_gas` (defaults to true) flag for the `create_access_list` method, that only gets applied if the node client is Erigon.

Please let me know if it's good or if I can improve anything!

## PR Checklist

-   [ ] Added Tests --> (this is erigon/gnosis specific, shall i add a test provider? it's not available on infura so lmk)
-   [ ] Added Documentation --> (didn't find any documentation for `create_access_list`, so didn't extend it)
-   [ ] Breaking changes
