### PR TITLE
fix: add selector collision check in abigen

### DIFF
--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -5,7 +5,7 @@ use crate::util;
 use ethers_core::{
     abi::{Function, FunctionExt, Param, ParamType},
     macros::{ethers_contract_crate, ethers_core_crate},
-    types::Selector,
+    types::Selector, utils::id,
 };
 use eyre::{Context as _, Result};
 use inflector::Inflector;
@@ -387,8 +387,27 @@ impl Context {
                 .push(function);
         }
 
+        
+        let mut all_signature_hashes = HashMap::new();
         // find all duplicates, where no aliases where provided
         for functions in all_functions.values() {
+            // this should not happen since functions with same
+            // signature hash are illegal
+            for function in functions {
+                let function_signature = function.signature();
+                let signature_hash = id(&function_signature);
+    
+                if let Some(prev_function_signature) = all_signature_hashes.get(&signature_hash) {
+                    eyre::ensure!(
+                        id(&prev_function_signature) != signature_hash,
+                        "Function with same signature hash defined twice: {} and {}",
+                        prev_function_signature,
+                        function_signature
+                    );
+                }
+                all_signature_hashes.insert(signature_hash.clone(), function_signature);
+            }
+
             if functions.iter().filter(|f| !aliases.contains_key(&f.abi_signature())).count() <= 1 {
                 // no overloads, hence no conflicts
                 continue

--- a/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
+++ b/ethers-contract/ethers-contract-abigen/src/contract/methods.rs
@@ -5,7 +5,8 @@ use crate::util;
 use ethers_core::{
     abi::{Function, FunctionExt, Param, ParamType},
     macros::{ethers_contract_crate, ethers_core_crate},
-    types::Selector, utils::id,
+    types::Selector,
+    utils::id,
 };
 use eyre::{Context as _, Result};
 use inflector::Inflector;
@@ -387,7 +388,6 @@ impl Context {
                 .push(function);
         }
 
-        
         let mut all_signature_hashes = HashMap::new();
         // find all duplicates, where no aliases where provided
         for functions in all_functions.values() {
@@ -396,7 +396,7 @@ impl Context {
             for function in functions {
                 let function_signature = function.signature();
                 let signature_hash = id(&function_signature);
-    
+
                 if let Some(prev_function_signature) = all_signature_hashes.get(&signature_hash) {
                     eyre::ensure!(
                         id(&prev_function_signature) != signature_hash,

--- a/ethers-contract/ethers-contract-derive/src/abigen.rs
+++ b/ethers-contract/ethers-contract-derive/src/abigen.rs
@@ -3,6 +3,7 @@
 
 use crate::spanned::Spanned;
 use ethers_contract_abigen::{multi::MultiExpansion, Abigen};
+use ethers_core::utils::id;
 use proc_macro2::TokenStream;
 use std::collections::HashSet;
 use syn::{
@@ -124,9 +125,13 @@ impl Parse for Parameter {
                 let parsed = content.parse_terminated(Spanned::<Method>::parse, Token![;])?;
 
                 let mut methods = Vec::with_capacity(parsed.len());
+                let mut signature_hashes = HashSet::new();
                 let mut signatures = HashSet::new();
                 let mut aliases = HashSet::new();
                 for method in parsed {
+                    if !signature_hashes.insert(id(String::from(method.signature.clone()))) {
+                        return Err(Error::new(method.span(), "duplicate method signature hash"))
+                    }
                     if !signatures.insert(method.signature.clone()) {
                         return Err(Error::new(method.span(), "duplicate method signature"))
                     }
@@ -420,6 +425,18 @@ mod tests {
                 false
             )
         );
+    }
+
+    #[test]
+    fn duplicate_method_signature_error() {
+        contract_args_err! {
+            TestContract,
+            "path/to/abi.json",
+            methods {
+                BlazingIt4490597615() as blazing_it_4490597615;
+                wycpnbqcyf() as wycpnbqcyf;
+            };
+        };
     }
 
     #[test]


### PR DESCRIPTION
## Motivation and Solution

This PR fixes issue #2808. It adds a check for duplicate function selector hashes when generating a contract's ABI.

## PR Checklist

-   [x] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
