### PR TITLE
chore: mark mantle and mantle sepolia chains as supporting eip 1559

### DIFF
--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -378,8 +378,6 @@ impl Chain {
             Boba |
             ZkSync |
             ZkSyncTestnet |
-            Mantle |
-            MantleTestnet |
             PolygonZkEvm |
             PolygonZkEvmTestnet |
             Metis |
@@ -414,6 +412,8 @@ impl Chain {
             Linea |
             LineaTestnet |
             FilecoinCalibrationTestnet |
+            Mantle |
+            MantleTestnet |
             Gnosis |
             Chiado |
             Mode |


### PR DESCRIPTION
## Motivation

Mantle and Mantle Sepolia support EIP 1559. As proof, we can see that by doing:

```
// for mantle
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", false],"id":1}' https://rpc.mantle.xyz

// for mantle sepolia
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", false],"id":1}' https://rpc.sepolia.mantle.xyz
```

the returned block object contains the `baseFeePerGas` attribute.

## Solution

I just updated the `is_legacy` function by moving `Mantle` and `MantleSepolia` to the `false` arm.

P.S.: I have a Rust program posting transactions to Mantle Sepolia and all of them are currently failing at the `fill_transaction` stage. Is there any workaround I can use while this is being reviewed and released?
