### PR TITLE
feat: expose block timestamp in log

### DIFF
--- a/ethers-core/src/types/log.rs
+++ b/ethers-core/src/types/log.rs
@@ -28,6 +28,11 @@ pub struct Log {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_number: Option<U64>,
 
+    // Block timestamp
+    #[serde(rename = "blockTimestamp")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block_timestamp: Option<U64>,
+
     /// Transaction Hash
     #[serde(rename = "transactionHash")]
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Motivation

Tiny PR to expose an optional block timestamp on a log - I know ethers-rs is deprecated, but to migrate to alloy at the moment due to bandwidth is pretty hard to do, and having to fork ethers is a nightmare; this tiny field will unblock fetching this or having to write bespoke get_logs call.  

## Solution

Added block_timestamp to log struct

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
